### PR TITLE
Support renames and tests for nested paths

### DIFF
--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -53,19 +53,19 @@ describe('server', () => {
 
       expect(response.body).toHaveProperty('config')
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{id}}')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
     })
 
     test('updates config', async () => {
       await request(server.callback())
         .put('/master')
-        .send({ config: { path: '{{id}}-updated'} })
+        .send({ config: { path: '{{last_name}}/{{first_name}}-updated'} })
         .expect(204)
 
       const response = await request(server.callback())
         .get('/master')
       
-      expect(response.body.config.path).toBe('{{id}}-updated')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}-updated')
     })
   })
 
@@ -73,7 +73,7 @@ describe('server', () => {
     test('lists rows with _id field in each row', async () => {
       await loadData(gitSheets, {
         data: sampleData, 
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'master'
       })
@@ -145,7 +145,7 @@ describe('server', () => {
         .get('/master')
       
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{id}}')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
     })
 
     test('truncates and loads', async () => {
@@ -226,13 +226,13 @@ describe('server', () => {
     beforeEach(async () => {
       await loadData(gitSheets, {
         data: sampleData,
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'master'
       })
       await loadData(gitSheets, {
         data: sampleDataChanged,
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'proposal'
       })
@@ -253,7 +253,7 @@ describe('server', () => {
 
       const modifiedDiff = response.body.find((diff) => diff.status === 'modified')
 
-      expect(modifiedDiff).toBeTruthy()
+      expect(modifiedDiff).toBeDefined()
       expect(modifiedDiff.patch.length).toBe(1)
 
       const expectedPatch = {
@@ -303,7 +303,7 @@ describe('server', () => {
       `
       await loadData(gitSheets, {
         data: conflictingData,
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'master'
       })

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -53,24 +53,46 @@ describe('server', () => {
 
       expect(response.body).toHaveProperty('config')
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
+      expect(response.body.config.path).toBe('{{id}}')
     })
 
     test('updates config', async () => {
       await request(server.callback())
         .put('/master')
-        .send({ config: { path: '{{last_name}}/{{first_name}}-updated'} })
+        .send({ config: { path: '{{last_name}}/{{first_name}}'} })
         .expect(204)
 
       const response = await request(server.callback())
         .get('/master')
       
-      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}-updated')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
     })
   })
 
   describe('list records', () => {
     test('lists rows with _id field in each row', async () => {
+      await loadData(gitSheets, {
+        data: sampleData, 
+        pathTemplate: '{{id}}',
+        ref: 'master',
+        branch: 'master'
+      })
+
+      const response = await request(server.callback())
+        .get('/master/records')
+        .expect(200)
+
+      expect(Array.isArray(response.body)).toBe(true)
+      expect(response.body.length).toBe(getCsvRowCount(sampleData))
+      expect(response.body[0]).toHaveProperty('_id')
+    })
+
+    test('lists rows with nested paths', async () => {
+      await request(server.callback())
+        .put('/master')
+        .send({ config: { path: '{{last_name}}/{{first_name}}'} })
+        .expect(204)
+
       await loadData(gitSheets, {
         data: sampleData, 
         pathTemplate: '{{last_name}}/{{first_name}}',
@@ -85,6 +107,7 @@ describe('server', () => {
       expect(Array.isArray(response.body)).toBe(true)
       expect(response.body.length).toBe(getCsvRowCount(sampleData))
       expect(response.body[0]).toHaveProperty('_id')
+      expect(response.body[0]._id).toContain('/')
     })
 
     test('returns empty array if no data', async () => {
@@ -145,7 +168,7 @@ describe('server', () => {
         .get('/master')
       
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
+      expect(response.body.config.path).toBe('{{id}}')
     })
 
     test('truncates and loads', async () => {
@@ -223,94 +246,122 @@ describe('server', () => {
   })
 
   describe('compare', () => {
-    beforeEach(async () => {
-      await loadData(gitSheets, {
-        data: sampleData,
-        pathTemplate: '{{last_name}}/{{first_name}}',
-        ref: 'master',
-        branch: 'master'
-      })
-      await loadData(gitSheets, {
-        data: sampleDataChanged,
-        pathTemplate: '{{last_name}}/{{first_name}}',
-        ref: 'master',
-        branch: 'proposal'
-      })
-    })
-
-    test('returns expected number of diffs', async () => {
-      const response = await request(server.callback())
-        .get('/master/compare/proposal')
-        .expect(200)
-      
-      expect(Array.isArray(response.body)).toBe(true)
-      expect(response.body.length).toBe(SAMPLE_DATA_CHANGES_COUNT)
-    })
-
-    test('computes expected json patch for modified row', async () => {
-      const response = await request(server.callback())
-        .get('/master/compare/proposal')
-
-      const modifiedDiff = response.body.find((diff) => diff.status === 'modified')
-
-      expect(modifiedDiff).toBeDefined()
-      expect(modifiedDiff.patch.length).toBe(1)
-
-      const expectedPatch = {
-        op: 'replace',
-        path: '/last_name',
-        from: 'Hansford',
-        value: 'Footsford'
-      }
-      expect(modifiedDiff.patch[0]).toMatchObject(expectedPatch)
-    })
-
-    test('comparing identical refs returns empty array', async () => {
-      const response = await request(server.callback())
-        .get('/master/compare/master')
-
-      expect(response.body.length).toBe(0)
-    })
-
-    test('merging merges branches', async () => {
-      await request(server.callback())
-        .post('/master/compare/proposal')
-        .expect(204)
-
-      const response = await request(server.callback())
-        .get('/master/records')
-
-      const changedRowId = '3'
-      const changedRow = response.body.find((row) => row.id === changedRowId)
-      expect(changedRow).toBeDefined()
-      expect(changedRow.last_name).toBe('Footsford')
-    })
-
-    test('merging deletes merged branch', async () => {
-      await request(server.callback())
-        .post('/master/compare/proposal')
-        .expect(204)
-
-      await request(server.callback())
-        .get('/proposal/records')
-        .expect(404)
-    })
-
-    test('merging on non-ancestor throws error', async () => {
-      const conflictingData = stripIndent`
-        id,first_name,last_name,email,dob
-        1,empty,empty,empty,empty
-      `
-      await loadData(gitSheets, {
-        data: conflictingData,
-        pathTemplate: '{{last_name}}/{{first_name}}',
-        ref: 'master',
-        branch: 'master'
+    describe('top-level paths', () => {
+      beforeEach(async () => {
+        await loadData(gitSheets, {
+          data: sampleData,
+          pathTemplate: '{{id}}',
+          ref: 'master',
+          branch: 'master'
+        })
+        await loadData(gitSheets, {
+          data: sampleDataChanged,
+          pathTemplate: '{{id}}',
+          ref: 'master',
+          branch: 'proposal'
+        })
       })
 
-      await request(server.callback())
-        .post('/master/compare/proposal')
-        .expect(409)
+      test('returns expected number of diffs', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/proposal')
+          .expect(200)
+        
+        expect(Array.isArray(response.body)).toBe(true)
+        expect(response.body.length).toBe(SAMPLE_DATA_CHANGES_COUNT)
+      })
+
+      test('computes expected json patch for modified row', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/proposal')
+
+        const modifiedDiff = response.body.find((diff) => diff.status === 'modified')
+
+        expect(modifiedDiff).toBeDefined()
+        expect(modifiedDiff.patch.length).toBe(1)
+
+        const expectedPatch = {
+          op: 'replace',
+          path: '/last_name',
+          from: 'Hansford',
+          value: 'Footsford'
+        }
+        expect(modifiedDiff.patch[0]).toMatchObject(expectedPatch)
+      })
+
+      test('comparing identical refs returns empty array', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/master')
+
+        expect(response.body.length).toBe(0)
+      })
+
+      test('merging merges branches', async () => {
+        await request(server.callback())
+          .post('/master/compare/proposal')
+          .expect(204)
+
+        const response = await request(server.callback())
+          .get('/master/records')
+
+        const changedRowId = '3'
+        const changedRow = response.body.find((row) => row.id === changedRowId)
+        expect(changedRow).toBeDefined()
+        expect(changedRow.last_name).toBe('Footsford')
+      })
+
+      test('merging deletes merged branch', async () => {
+        await request(server.callback())
+          .post('/master/compare/proposal')
+          .expect(204)
+
+        await request(server.callback())
+          .get('/proposal/records')
+          .expect(404)
+      })
+
+      test('merging on non-ancestor throws error', async () => {
+        const conflictingData = stripIndent`
+          id,first_name,last_name,email,dob
+          1,empty,empty,empty,empty
+        `
+        await loadData(gitSheets, {
+          data: conflictingData,
+          pathTemplate: '{{last_name}}/{{first_name}}',
+          ref: 'master',
+          branch: 'master'
+        })
+
+        await request(server.callback())
+          .post('/master/compare/proposal')
+          .expect(409)
+      })
+    })
+
+    describe('nested paths', () => {
+      beforeEach(async () => {
+        await loadData(gitSheets, {
+          data: sampleData,
+          pathTemplate: '{{last_name}}/{{first_name}}',
+          ref: 'master',
+          branch: 'master'
+        })
+        await loadData(gitSheets, {
+          data: sampleDataChanged,
+          pathTemplate: '{{last_name}}/{{first_name}}',
+          ref: 'master',
+          branch: 'proposal'
+        })
+      })
+
+      test('returns expected number of diffs', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/proposal')
+          .expect(200)
+        
+        expect(Array.isArray(response.body)).toBe(true)
+        expect(response.body.length).toBe(SAMPLE_DATA_CHANGES_COUNT)
+      })
     })
   })
 })

--- a/backend/test/util/index.js
+++ b/backend/test/util/index.js
@@ -20,7 +20,7 @@ async function setupRepo (gitSheets) {
     'allow-empty-message': true,
     m: 'initial commit'
   })
-  await gitSheets.saveConfig({ path: '{{id}}' }, 'master')
+  await gitSheets.saveConfig({ path: '{{last_name}}/{{first_name}}' }, 'master')
 }
 
 async function teardownRepo (gitSheets) {

--- a/backend/test/util/index.js
+++ b/backend/test/util/index.js
@@ -20,7 +20,7 @@ async function setupRepo (gitSheets) {
     'allow-empty-message': true,
     m: 'initial commit'
   })
-  await gitSheets.saveConfig({ path: '{{last_name}}/{{first_name}}' }, 'master')
+  await gitSheets.saveConfig({ path: '{{id}}' }, 'master')
 }
 
 async function teardownRepo (gitSheets) {


### PR DESCRIPTION
Treats renames as modifications as described in #13. Also adds tests to make sure nested paths are supported.

Fixes #13.