### PR TITLE
Support nested branch names

### DIFF
--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -183,7 +183,7 @@ module.exports = class GitSheets {
     const qualifiedSrcRef = await this.getQualifiedRef(srcRef)
     const qualifiedDstRef = await this.getQualifiedRef(dstRef)
     await this.git.updateRef(qualifiedSrcRef, qualifiedDstRef)
-    await this.git.branch({'d': true}, dstRef)
+    await this.git.branch({'D': true}, dstRef) // force delete in case srcRef is not checked out
   }
 
   async getParsedDiffOutput (srcRef, dstRef) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,7 +4,7 @@ const git = require('git-client')
 const bodyParser = require('koa-bodyparser')
 const GitSheets = require('./lib')
 
-const validRefPattern = /^[\w-]+$/
+const validRefPattern = /^[\w-\/]+$/
 const validPathTemplatePattern = /^[{}\w- \/]+$/
 
 module.exports = createServer
@@ -25,7 +25,7 @@ async function createServer (gitSheets) {
     throw new Error(`invalid repo ${gitSheets.repo.gitDir}`)
   }
 
-  router.get('/:ref', async (ctx) => {
+  router.get('/config/:ref+', async (ctx) => {
     const ref = ctx.params.ref
     ctx.assert(validRefPattern.test(ref), 400, 'invalid ref')
 
@@ -41,7 +41,7 @@ async function createServer (gitSheets) {
     }
   })
 
-  router.put('/:ref', bodyParser(), async (ctx) => {
+  router.put('/config/:ref+', bodyParser(), async (ctx) => {
     const ref = ctx.params.ref
     const path = ctx.request.body.config && ctx.request.body.config.path
 
@@ -61,7 +61,7 @@ async function createServer (gitSheets) {
     }
   })
 
-  router.get('/:ref/records', async (ctx) => {
+  router.get('/records/:ref+', async (ctx) => {
     const ref = ctx.params.ref
     ctx.assert(validRefPattern.test(ref), 400, 'invalid ref')
 
@@ -77,7 +77,7 @@ async function createServer (gitSheets) {
     }
   })
 
-  router.post('/:ref/import', async (ctx) => {
+  router.post('/import/:ref+', async (ctx) => {
     const ref = ctx.params.ref
     const readStream = ctx.req
     const branch = ctx.request.query.branch || ref
@@ -130,7 +130,7 @@ async function createServer (gitSheets) {
     }
   })
 
-  router.get('/:srcRef/compare/:dstRef', async (ctx) => {
+  router.get('/compare/:srcRef([\\w-\\/]+)..:dstRef([\\w-\\/]+)', async (ctx) => {
     const { srcRef, dstRef } = ctx.params
 
     ctx.assert(validRefPattern.test(srcRef), 400, 'invalid src ref')
@@ -140,7 +140,7 @@ async function createServer (gitSheets) {
     ctx.body = diffs
   })
 
-  router.post('/:srcRef/compare/:dstRef', async (ctx) => {
+  router.post('/compare/:srcRef([\\w-\\/]+)..:dstRef([\\w-\\/]+)', async (ctx) => {
     const { srcRef, dstRef } = ctx.params
 
     ctx.assert(validRefPattern.test(srcRef), 400, 'invalid src ref')

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -53,19 +53,19 @@ describe('server', () => {
 
       expect(response.body).toHaveProperty('config')
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{id}}')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
     })
 
     test('updates config', async () => {
       await request(server.callback())
         .put('/master')
-        .send({ config: { path: '{{id}}-updated'} })
+        .send({ config: { path: '{{last_name}}/{{first_name}}-updated'} })
         .expect(204)
 
       const response = await request(server.callback())
         .get('/master')
       
-      expect(response.body.config.path).toBe('{{id}}-updated')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}-updated')
     })
   })
 
@@ -73,7 +73,7 @@ describe('server', () => {
     test('lists rows with _id field in each row', async () => {
       await loadData(gitSheets, {
         data: sampleData, 
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'master'
       })
@@ -145,7 +145,7 @@ describe('server', () => {
         .get('/master')
       
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{id}}')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
     })
 
     test('truncates and loads', async () => {
@@ -226,13 +226,13 @@ describe('server', () => {
     beforeEach(async () => {
       await loadData(gitSheets, {
         data: sampleData,
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'master'
       })
       await loadData(gitSheets, {
         data: sampleDataChanged,
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'proposal'
       })
@@ -253,7 +253,7 @@ describe('server', () => {
 
       const modifiedDiff = response.body.find((diff) => diff.status === 'modified')
 
-      expect(modifiedDiff).toBeTruthy()
+      expect(modifiedDiff).toBeDefined()
       expect(modifiedDiff.patch.length).toBe(1)
 
       const expectedPatch = {
@@ -303,7 +303,7 @@ describe('server', () => {
       `
       await loadData(gitSheets, {
         data: conflictingData,
-        pathTemplate: '{{id}}',
+        pathTemplate: '{{last_name}}/{{first_name}}',
         ref: 'master',
         branch: 'master'
       })

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -53,24 +53,46 @@ describe('server', () => {
 
       expect(response.body).toHaveProperty('config')
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
+      expect(response.body.config.path).toBe('{{id}}')
     })
 
     test('updates config', async () => {
       await request(server.callback())
         .put('/master')
-        .send({ config: { path: '{{last_name}}/{{first_name}}-updated'} })
+        .send({ config: { path: '{{last_name}}/{{first_name}}'} })
         .expect(204)
 
       const response = await request(server.callback())
         .get('/master')
       
-      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}-updated')
+      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
     })
   })
 
   describe('list records', () => {
     test('lists rows with _id field in each row', async () => {
+      await loadData(gitSheets, {
+        data: sampleData, 
+        pathTemplate: '{{id}}',
+        ref: 'master',
+        branch: 'master'
+      })
+
+      const response = await request(server.callback())
+        .get('/master/records')
+        .expect(200)
+
+      expect(Array.isArray(response.body)).toBe(true)
+      expect(response.body.length).toBe(getCsvRowCount(sampleData))
+      expect(response.body[0]).toHaveProperty('_id')
+    })
+
+    test('lists rows with nested paths', async () => {
+      await request(server.callback())
+        .put('/master')
+        .send({ config: { path: '{{last_name}}/{{first_name}}'} })
+        .expect(204)
+
       await loadData(gitSheets, {
         data: sampleData, 
         pathTemplate: '{{last_name}}/{{first_name}}',
@@ -85,6 +107,7 @@ describe('server', () => {
       expect(Array.isArray(response.body)).toBe(true)
       expect(response.body.length).toBe(getCsvRowCount(sampleData))
       expect(response.body[0]).toHaveProperty('_id')
+      expect(response.body[0]._id).toContain('/')
     })
 
     test('returns empty array if no data', async () => {
@@ -145,7 +168,7 @@ describe('server', () => {
         .get('/master')
       
       expect(response.body.config).toHaveProperty('path')
-      expect(response.body.config.path).toBe('{{last_name}}/{{first_name}}')
+      expect(response.body.config.path).toBe('{{id}}')
     })
 
     test('truncates and loads', async () => {
@@ -223,94 +246,122 @@ describe('server', () => {
   })
 
   describe('compare', () => {
-    beforeEach(async () => {
-      await loadData(gitSheets, {
-        data: sampleData,
-        pathTemplate: '{{last_name}}/{{first_name}}',
-        ref: 'master',
-        branch: 'master'
-      })
-      await loadData(gitSheets, {
-        data: sampleDataChanged,
-        pathTemplate: '{{last_name}}/{{first_name}}',
-        ref: 'master',
-        branch: 'proposal'
-      })
-    })
-
-    test('returns expected number of diffs', async () => {
-      const response = await request(server.callback())
-        .get('/master/compare/proposal')
-        .expect(200)
-      
-      expect(Array.isArray(response.body)).toBe(true)
-      expect(response.body.length).toBe(SAMPLE_DATA_CHANGES_COUNT)
-    })
-
-    test('computes expected json patch for modified row', async () => {
-      const response = await request(server.callback())
-        .get('/master/compare/proposal')
-
-      const modifiedDiff = response.body.find((diff) => diff.status === 'modified')
-
-      expect(modifiedDiff).toBeDefined()
-      expect(modifiedDiff.patch.length).toBe(1)
-
-      const expectedPatch = {
-        op: 'replace',
-        path: '/last_name',
-        from: 'Hansford',
-        value: 'Footsford'
-      }
-      expect(modifiedDiff.patch[0]).toMatchObject(expectedPatch)
-    })
-
-    test('comparing identical refs returns empty array', async () => {
-      const response = await request(server.callback())
-        .get('/master/compare/master')
-
-      expect(response.body.length).toBe(0)
-    })
-
-    test('merging merges branches', async () => {
-      await request(server.callback())
-        .post('/master/compare/proposal')
-        .expect(204)
-
-      const response = await request(server.callback())
-        .get('/master/records')
-
-      const changedRowId = '3'
-      const changedRow = response.body.find((row) => row.id === changedRowId)
-      expect(changedRow).toBeDefined()
-      expect(changedRow.last_name).toBe('Footsford')
-    })
-
-    test('merging deletes merged branch', async () => {
-      await request(server.callback())
-        .post('/master/compare/proposal')
-        .expect(204)
-
-      await request(server.callback())
-        .get('/proposal/records')
-        .expect(404)
-    })
-
-    test('merging on non-ancestor throws error', async () => {
-      const conflictingData = stripIndent`
-        id,first_name,last_name,email,dob
-        1,empty,empty,empty,empty
-      `
-      await loadData(gitSheets, {
-        data: conflictingData,
-        pathTemplate: '{{last_name}}/{{first_name}}',
-        ref: 'master',
-        branch: 'master'
+    describe('top-level paths', () => {
+      beforeEach(async () => {
+        await loadData(gitSheets, {
+          data: sampleData,
+          pathTemplate: '{{id}}',
+          ref: 'master',
+          branch: 'master'
+        })
+        await loadData(gitSheets, {
+          data: sampleDataChanged,
+          pathTemplate: '{{id}}',
+          ref: 'master',
+          branch: 'proposal'
+        })
       })
 
-      await request(server.callback())
-        .post('/master/compare/proposal')
-        .expect(409)
+      test('returns expected number of diffs', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/proposal')
+          .expect(200)
+        
+        expect(Array.isArray(response.body)).toBe(true)
+        expect(response.body.length).toBe(SAMPLE_DATA_CHANGES_COUNT)
+      })
+
+      test('computes expected json patch for modified row', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/proposal')
+
+        const modifiedDiff = response.body.find((diff) => diff.status === 'modified')
+
+        expect(modifiedDiff).toBeDefined()
+        expect(modifiedDiff.patch.length).toBe(1)
+
+        const expectedPatch = {
+          op: 'replace',
+          path: '/last_name',
+          from: 'Hansford',
+          value: 'Footsford'
+        }
+        expect(modifiedDiff.patch[0]).toMatchObject(expectedPatch)
+      })
+
+      test('comparing identical refs returns empty array', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/master')
+
+        expect(response.body.length).toBe(0)
+      })
+
+      test('merging merges branches', async () => {
+        await request(server.callback())
+          .post('/master/compare/proposal')
+          .expect(204)
+
+        const response = await request(server.callback())
+          .get('/master/records')
+
+        const changedRowId = '3'
+        const changedRow = response.body.find((row) => row.id === changedRowId)
+        expect(changedRow).toBeDefined()
+        expect(changedRow.last_name).toBe('Footsford')
+      })
+
+      test('merging deletes merged branch', async () => {
+        await request(server.callback())
+          .post('/master/compare/proposal')
+          .expect(204)
+
+        await request(server.callback())
+          .get('/proposal/records')
+          .expect(404)
+      })
+
+      test('merging on non-ancestor throws error', async () => {
+        const conflictingData = stripIndent`
+          id,first_name,last_name,email,dob
+          1,empty,empty,empty,empty
+        `
+        await loadData(gitSheets, {
+          data: conflictingData,
+          pathTemplate: '{{last_name}}/{{first_name}}',
+          ref: 'master',
+          branch: 'master'
+        })
+
+        await request(server.callback())
+          .post('/master/compare/proposal')
+          .expect(409)
+      })
+    })
+
+    describe('nested paths', () => {
+      beforeEach(async () => {
+        await loadData(gitSheets, {
+          data: sampleData,
+          pathTemplate: '{{last_name}}/{{first_name}}',
+          ref: 'master',
+          branch: 'master'
+        })
+        await loadData(gitSheets, {
+          data: sampleDataChanged,
+          pathTemplate: '{{last_name}}/{{first_name}}',
+          ref: 'master',
+          branch: 'proposal'
+        })
+      })
+
+      test('returns expected number of diffs', async () => {
+        const response = await request(server.callback())
+          .get('/master/compare/proposal')
+          .expect(200)
+        
+        expect(Array.isArray(response.body)).toBe(true)
+        expect(response.body.length).toBe(SAMPLE_DATA_CHANGES_COUNT)
+      })
     })
   })
 })

--- a/backend/test/util/index.js
+++ b/backend/test/util/index.js
@@ -20,7 +20,7 @@ async function setupRepo (gitSheets) {
     'allow-empty-message': true,
     m: 'initial commit'
   })
-  await gitSheets.saveConfig({ path: '{{id}}' }, 'master')
+  await gitSheets.saveConfig({ path: '{{last_name}}/{{first_name}}' }, 'master')
 }
 
 async function teardownRepo (gitSheets) {

--- a/backend/test/util/index.js
+++ b/backend/test/util/index.js
@@ -20,7 +20,7 @@ async function setupRepo (gitSheets) {
     'allow-empty-message': true,
     m: 'initial commit'
   })
-  await gitSheets.saveConfig({ path: '{{last_name}}/{{first_name}}' }, 'master')
+  await gitSheets.saveConfig({ path: '{{id}}' }, 'master')
 }
 
 async function teardownRepo (gitSheets) {

--- a/src/components/DataSheetLog.vue
+++ b/src/components/DataSheetLog.vue
@@ -23,7 +23,7 @@
 
       form(@submit.prevent="onSubmitUpload" data-test="upload-form")
         input(type="file" name="file" accept=".csv" required ref="file" data-test="upload-file")
-        SubmitButton.mt-3.w-full Select file
+        SubmitButton.mt-3.w-full Upload file
 </template>
 
 <script>

--- a/src/router.js
+++ b/src/router.js
@@ -8,13 +8,14 @@ export default new Router({
   mode: 'history',
   routes: [
     {
-      path: '/:srcRef?',
+      path: '/records/:srcRef([\\w-\\/]+)?',
+      alias: '/',
       name: 'sheet',
       component: Sheet,
       props: true,
     },
     {
-      path: '/:srcRef/compare/:dstRef',
+      path: '/compare/:srcRef([\\w-\\/]+)..:dstRef([\\w-\\/]+)',
       name: 'compare',
       component: Sheet,
       props: true,

--- a/src/store.js
+++ b/src/store.js
@@ -25,20 +25,20 @@ export default new Vuex.Store({
   },
   actions: {
     async getRecords ({ commit }, srcRef) {
-      const response = await api.get(`/${srcRef}/records`);
+      const response = await api.get(`/records/${srcRef}`);
       commit('SET_RECORDS', response.data);
     },
     async getDiffs ({ commit }, { srcRef, dstRef }) {
-      const response = await api.get(`/${srcRef}/compare/${dstRef}`);
+      const response = await api.get(`/compare/${srcRef}..${dstRef}`);
       commit('SET_DIFFS', response.data);
     },
     async merge (_context, { srcRef, dstRef }) {
-      await api.post(`/${srcRef}/compare/${dstRef}`);
+      await api.post(`/compare/${srcRef}..${dstRef}`);
     },
     async import (_context, { srcRef, file, branch }) {
       await api({
         method: 'post',
-        url: `/${srcRef}/import?branch=${branch}`,
+        url: `/import/${srcRef}?branch=${branch}`,
         data: file,
         headers: {'content-type': 'text/csv'},
       });

--- a/src/views/Sheet.vue
+++ b/src/views/Sheet.vue
@@ -95,7 +95,7 @@ export default {
 
       try {
         await this.merge({ srcRef, dstRef });
-        this.$router.push(`/${srcRef}`);
+        this.$router.push(`/records/${srcRef}`);
       } catch (err) {
         console.error(err.message);
       }
@@ -106,7 +106,7 @@ export default {
 
       try {
         await this.import({ srcRef, file, branch });
-        this.$router.push(`/${srcRef}/compare/${branch}`);
+        this.$router.push(`/compare/${srcRef}..${branch}`);
       } catch (err) {
         console.error(err.message);
       }


### PR DESCRIPTION
Branches off of `hotfix/renames` so review that one first.

This PR changes the URL structure on the API and frontend so the action is always first `/records`, `/config`, `/compare`, `/import`, followed by the branch name(s). This way we can support nested branch names like `proposal/alpha`, e.g. `/compare/proposal/alpha..proposal/beta`. It also adds frontend and backend tests for this support.