### PR TITLE
Export csv

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2039,15 +2039,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3087,15 +3078,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "into-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.0.tgz",
-      "integrity": "sha512-cbDhb8qlxKMxPBk/QxTtYg1DQ4CwXmadu7quG3B7nrJsgSncEreF2kwWKZFdnjc/lSNNIkFPsjI7SM0Cx/QXPw==",
-      "requires": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^2.0.0"
-      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -5921,6 +5903,15 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "streaming-json-stringify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/streaming-json-stringify/-/streaming-json-stringify-3.1.0.tgz",
+      "integrity": "sha1-gCAEN6mTzDnE/gAmO3s7kDrIevU=",
+      "requires": {
+        "json-stringify-safe": "5",
+        "readable-stream": "2"
+      }
     },
     "string-length": {
       "version": "2.0.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -485,6 +485,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.138",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
+      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -494,8 +499,7 @@
     "@types/node": {
       "version": "12.6.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
-      "dev": true
+      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1822,6 +1826,16 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "fast-csv": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-3.4.0.tgz",
+      "integrity": "sha512-/vPTDJc/l6VLOLIqcrMjuhyi8ZVTipTNl2GkVvaYiHlyh16oQMYPUkUVfREurT3MYE9j3mLQDk2Q8kPq30qQCg==",
+      "requires": {
+        "@types/lodash": "^4.14.132",
+        "@types/node": "^12.0.2",
+        "lodash": "^4.17.13"
+      }
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -2024,6 +2038,15 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -3064,6 +3087,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "into-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.0.tgz",
+      "integrity": "sha512-cbDhb8qlxKMxPBk/QxTtYg1DQ4CwXmadu7quG3B7nrJsgSncEreF2kwWKZFdnjc/lSNNIkFPsjI7SM0Cx/QXPw==",
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^2.0.0"
+      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -4432,8 +4464,7 @@
     "lodash": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,11 +23,11 @@
     "fast-json-patch": "^2.2.1",
     "hologit": "^0.21.0",
     "http-assert": "^1.4.1",
-    "into-stream": "^5.1.0",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-router": "^7.4.0",
     "maxstache": "^1.0.7",
+    "streaming-json-stringify": "^3.1.0",
     "to-readable-stream": "^2.1.0",
     "winston": "^2.4.3",
     "yargs": "^13.2.4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,9 +19,11 @@
   "dependencies": {
     "@iarna/toml": "^2.2.3",
     "csv-parser": "^2.3.0",
+    "fast-csv": "^3.4.0",
     "fast-json-patch": "^2.2.1",
     "hologit": "^0.21.0",
     "http-assert": "^1.4.1",
+    "into-stream": "^5.1.0",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-router": "^7.4.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -65,6 +65,7 @@ async function createServer (gitSheets) {
 
   router.get('/records/:ref+', async (ctx) => {
     const ref = ctx.params.ref
+    const format = ctx.query.format
     ctx.assert(validRefPattern.test(ref), 400, 'invalid ref')
 
     let rows
@@ -78,7 +79,7 @@ async function createServer (gitSheets) {
       }
     }
 
-    switch (ctx.accepts('json', 'csv')) {
+    switch (format || ctx.accepts('json', 'csv')) {
       case 'csv':
         ctx.type = 'text/csv'
         ctx.set('Content-Disposition', `attachment; filename=${ref}.csv`)

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -131,6 +131,24 @@ describe('server', () => {
         .expect(404)
     })
 
+    test('lists rows as csv if requested', async () => {
+      await loadData(gitSheets, {
+        data: sampleData, 
+        pathTemplate: '{{id}}',
+        ref: 'master',
+        branch: 'master'
+      })
+
+      const response = await request(server.callback())
+        .get('/records/master')
+        .accept('text/csv')
+        .expect(200)
+
+      expect(getCsvRowCount(response.text)).toBe(getCsvRowCount(sampleData))
+      expect(response.type).toBe('text/csv')
+      expect(response.headers).toHaveProperty('content-disposition')
+    })
+
     test.skip('requesting a non-gitsheet-style branch returns empty array with count in header', async () => {
       // commit a csv file (non exploded) and request the branch
       const response = await request(server.callback())

--- a/src/components/DataSheetLog.vue
+++ b/src/components/DataSheetLog.vue
@@ -24,6 +24,13 @@
       form(@submit.prevent="onSubmitUpload" data-test="upload-form")
         input(type="file" name="file" accept=".csv" required ref="file" data-test="upload-file")
         SubmitButton.mt-3.w-full Upload file
+
+    .b-indigo-100.p-5.-m-5.border-b(v-if="records.length > 0")
+      h3 Download
+
+      p Get a copy of this sheet for editing in a spreadsheet application.
+
+      a.BaseButton.-primary.DownloadButton.mt-3.w-full(:href="exportUrl" download) Download CSV
 </template>
 
 <script>
@@ -48,6 +55,10 @@ export default {
     records: {
       type: Array,
       required: true,
+    },
+    exportUrl: {
+      type: String,
+      default: null,
     },
   },
 
@@ -168,5 +179,10 @@ li {
 
 .-status-modified {
   @apply text-blue-700;
+}
+
+.DownloadButton {
+  display: inline-block;
+  text-align: center;
 }
 </style>

--- a/src/components/DataSheetLog.vue
+++ b/src/components/DataSheetLog.vue
@@ -131,8 +131,9 @@ export default {
     onSubmitCommit () {
       this.$emit('commit', this.commitMessage);
     },
-    onSubmitUpload () {
+    onSubmitUpload (event) {
       this.$emit('upload', this.$refs.file.files[0]);
+      event.target.reset();
     },
   },
 }

--- a/src/store.js
+++ b/src/store.js
@@ -11,6 +11,11 @@ export default new Vuex.Store({
     records: [],
     diffs: [],
   },
+  getters: {
+    constructExportUrl (state) {
+      return (ref) => `/api/records/${ref}?format=csv`;
+    },
+  },
   mutations: {
     SET_RECORDS (state, records) {
       state.records = records;

--- a/src/views/Sheet.vue
+++ b/src/views/Sheet.vue
@@ -1,11 +1,16 @@
 <template lang="pug">
   .DataSheet-ct
     DataSheet(:records="mergedRecords")
-    DataSheetLog(:records="mergedRecords" @commit="onCommit" @upload="onUpload")
+    DataSheetLog(
+      :records="mergedRecords"
+      :export-url="constructExportUrl(dstRef || srcRef)"
+      @commit="onCommit"
+      @upload="onUpload"
+    )
 </template>
 
 <script>
-import { mapState, mapActions, mapMutations } from 'vuex';
+import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
 import { uniqueNamesGenerator } from 'unique-names-generator';
 
 import DataSheet from '@/components/DataSheet.vue';
@@ -28,6 +33,7 @@ export default {
   },
   computed: {
     ...mapState(['records', 'diffs']),
+    ...mapGetters(['constructExportUrl']),
     keyedDiffs () {
       return this.diffs.reduce((accum, item) => {
         accum[item._id] = item;


### PR DESCRIPTION
Adds "Download CSV" button to UI (may want to improve layout or markup).

Behind the scenes, the `/records` endpoint will now always return a stream—whether CSV or JSON—and will return CSV if the request uses the `Accept: text/csv` header or the `?format=csv` query parameter.

Closes #25