### PR TITLE
Use merge commits for merging

### DIFF
--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -181,15 +181,24 @@ module.exports = class GitSheets {
     return Promise.all(pendingDiffs)
   }
 
-  async merge (srcRef, dstRef) {
+  async merge (srcRef, dstRef, msg = null) {
     try {
       await this.git.mergeBase({'is-ancestor': true}, srcRef, dstRef)
     } catch (err) {
       throw new Error(`${srcRef} is not an ancestor of ${dstRef}`)
     }
+    const commitMsg = msg || `Merge ${dstRef}`
+    const dstTree = await this.repo.createTreeFromRef(dstRef)
+    const dstTreeHash = await dstTree.getHash()
+    const srcCommitHash = await this.git.revParse({verify: true}, srcRef)
+    const dstCommitHash = await this.git.revParse({verify: true}, dstRef)
+    const mergeCommitHash  = await this.git.commitTree(dstTreeHash, {
+      p: [srcCommitHash, dstCommitHash],
+      m: commitMsg
+    })
+
     const qualifiedSrcRef = await this.getQualifiedRef(srcRef)
-    const qualifiedDstRef = await this.getQualifiedRef(dstRef)
-    await this.git.updateRef(qualifiedSrcRef, qualifiedDstRef)
+    await this.git.updateRef(qualifiedSrcRef, mergeCommitHash)
     await this.git.branch({'D': true}, dstRef) // force delete in case srcRef is not checked out
   }
 

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -198,7 +198,7 @@ module.exports = class GitSheets {
     })
 
     const qualifiedSrcRef = await this.getQualifiedRef(srcRef)
-    await this.git.updateRef(qualifiedSrcRef, mergeCommitHash)
+    await this.git.updateRef(qualifiedSrcRef, mergeCommitHash, srcCommitHash)
     await this.git.branch({'D': true}, dstRef) // force delete in case srcRef is not checked out
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -160,12 +160,13 @@ async function createServer (gitSheets) {
 
   router.post('/compare/:srcRef([\\w-\\/]+)..:dstRef([\\w-\\/]+)', async (ctx) => {
     const { srcRef, dstRef } = ctx.params
+    const msg = ctx.query.msg
 
     ctx.assert(validRefPattern.test(srcRef), 400, 'invalid src ref')
     ctx.assert(validRefPattern.test(dstRef), 400, 'invalid dst ref')
 
     try {
-      await gitSheets.merge(srcRef, dstRef)
+      await gitSheets.merge(srcRef, dstRef, msg)
       ctx.status = 204
     } catch (err) {
       if (err.message.includes('not an ancestor of')) {

--- a/src/components/DataSheetLog.vue
+++ b/src/components/DataSheetLog.vue
@@ -9,7 +9,6 @@
 
       form(@submit.prevent="onSubmitCommit" data-test="commit-form")
         FieldLabeled.h-20(
-          v-show="false"
           fieldName="message",
           fieldType="textarea",
           placeholderText="What will this commit do to the database?"

--- a/src/components/forms/FieldLabeled.vue
+++ b/src/components/forms/FieldLabeled.vue
@@ -7,7 +7,8 @@
         :name="fieldName",
         :id="fieldName",
         :required="required"
-        :placeholder="placeholderText") {{ value }}
+        :placeholder="placeholderText"
+        @input="$emit('input', $event.target.value)") {{ value }}
 
     template(v-else)
       input.FieldLabeled__control(
@@ -15,8 +16,9 @@
         :id="fieldName",
         :type="fieldType",
         :required="required"
-        :placeholder="placeholderText",
-        :value="value")
+        :placeholder="placeholderText"
+        :value="value"
+        @input="$emit('input', $event.target.value)")
 </template>
 
 <script>

--- a/src/store.js
+++ b/src/store.js
@@ -37,8 +37,12 @@ export default new Vuex.Store({
       const response = await api.get(`/compare/${srcRef}..${dstRef}`);
       commit('SET_DIFFS', response.data);
     },
-    async merge (_context, { srcRef, dstRef }) {
-      await api.post(`/compare/${srcRef}..${dstRef}`);
+    async merge (_context, { srcRef, dstRef, commitMsg }) {
+      await api({
+        method: 'post',
+        url: `/compare/${srcRef}..${dstRef}`,
+        params: { msg: commitMsg },
+      });
     },
     async import (_context, { srcRef, file, branch }) {
       await api({

--- a/src/views/Sheet.vue
+++ b/src/views/Sheet.vue
@@ -106,12 +106,12 @@ export default {
         loader.hide();
       }
     },
-    async onCommit (msg) {
+    async onCommit (commitMsg) {
       const { srcRef, dstRef } = this;
       const loader = this.$loading.show();
 
       try {
-        await this.merge({ srcRef, dstRef });
+        await this.merge({ srcRef, dstRef, commitMsg });
         this.$router.push({ name: 'records', params: { srcRef } });
       } catch (err) {
         this.$awn.alert(`Failed to merge ${srcRef} onto ${dstRef}`);


### PR DESCRIPTION
Uses `commit-tree` with dstRef's tree hash and both srcRef and dstRef's commit hash as parents, then uses `update-ref` to move srcRef onto the newly created commit's hash.

There's still a check in place to make sure srcRef is an ancestor of dstRef, so it should only work with fast-forwardable merges. But if there's a command out there to test mergeability we should be able to add support for conflict-free merges.

Note: Merge `feat/export-csv` first to see the diff properly (it's very small).

Also note #27

Closes #18 