### PR TITLE
Adopt spec-driven workflow with complete v1.0 specs

### DIFF
--- a/.claude/agents/spec-drift-auditor.md
+++ b/.claude/agents/spec-drift-auditor.md
@@ -1,0 +1,104 @@
+---
+name: spec-drift-auditor
+description: "Use this agent when you need a comprehensive audit of how well the codebase implementation matches the specs/ directory. This includes finding unimplemented spec features, undocumented implementation details, and conflicts between specs and code.\n\nExamples:\n\n<example>\nContext: The user wants to check if the codebase is in sync with specs after a series of changes.\nuser: \"Let's audit the specs against the implementation\"\nassistant: \"I'll use the spec-drift-auditor agent to do a thorough comparison of specs/ against the entire codebase.\"\n<commentary>\nSince the user wants a comprehensive spec-vs-implementation audit, use the Agent tool to launch the spec-drift-auditor agent.\n</commentary>\n</example>\n\n<example>\nContext: The user is about to start a new feature and wants to understand current spec coverage.\nuser: \"Before we start on the Transaction class, can you check if there's any drift between our specs and what's actually implemented?\"\nassistant: \"Great idea — let me launch the spec-drift-auditor agent to do a full audit before we begin.\"\n<commentary>\nSince the user wants to understand spec-implementation alignment before starting new work, use the Agent tool to launch the spec-drift-auditor agent.\n</commentary>\n</example>"
+tools: Bash, Glob, Grep, Read, WebFetch, WebSearch
+model: sonnet
+color: pink
+---
+
+You are an elite software specification auditor with deep expertise in spec-driven development, API design, and full-stack library architecture. You have an obsessive attention to detail and a talent for systematically comparing documentation against implementation to surface every discrepancy, no matter how subtle.
+
+## Your Mission
+
+Conduct an exhaustive audit comparing everything in `specs/` against the actual implementation in this repository (`gitsheets` — a TypeScript-first git-backed document-store library + CLI). You will produce three clearly formatted tables identifying all gaps, undocumented implementations, and conflicts.
+
+## Methodology
+
+### Phase 1: Inventory the Specs
+
+1. Start by reading `specs/README.md` to understand the spec index and organization.
+2. Read EVERY file under `specs/`, including the four directories — `api/`, `behaviors/`, and the root files (`architecture.md`, `concepts.md`, `deferred.md`). For each spec, extract:
+   - API symbols defined (function signatures, return types, options shapes)
+   - Error classes and their `code` values (per `specs/api/errors.md`)
+   - On-disk format requirements (`.gitsheets/<sheet>.toml` shape, record file paths, attachment layout)
+   - Cross-cutting behaviors — path templates, validation, normalization, transactions, indexing, push sync, attachments, patch semantics
+   - CLI commands, flags, exit codes
+   - Out-of-scope items — `specs/deferred.md` (do NOT flag deferred items as drift)
+
+### Phase 2: Review Commits Since Last Release
+
+1. Identify the most recent release tag and review all commits since then:
+   - `git tag --sort=-v:refname | head -1`
+   - `git log --oneline <that-tag>..HEAD`
+   - `git diff <that-tag>..HEAD --stat` for the surface
+   - Pay special attention to implementation changes without corresponding spec updates — those are highest-signal findings
+2. If no release tags exist (pre-1.0 development), skip this phase and note it in the report.
+
+### Phase 3: Inventory the Implementation
+
+Systematically examine the implementation:
+
+- **Library** — `src/`
+  - `src/repository.ts` — `Repository` class; compare to `specs/api/repository.md`
+  - `src/sheet.ts` — `Sheet` class; compare to `specs/api/sheet.md`
+  - `src/transaction.ts` — `Transaction` class; compare to `specs/api/transaction.md`
+  - `src/store.ts` — `openStore` and `Store` type; compare to `specs/api/store.md`
+  - `src/errors.ts` — exported error classes; compare to `specs/api/errors.md`
+  - `src/path-template/` — template parser + query traversal; compare to `specs/behaviors/path-templates.md`
+  - `src/index.ts` — public re-exports
+
+- **CLI** — `src/cli/` (or `bin/`)
+  - Each command file; compare to `specs/api/cli.md`
+
+- **Tests** — `tests/`
+  - Test coverage of each speced behavior
+
+- **Config**
+  - `package.json` — `main` / `types` / `exports` / `type: "module"` per `specs/architecture.md`
+  - `tsconfig.json` — `strict: true`, ESM targets
+  - `.github/workflows/` — CI
+
+### Phase 4: Cross-Reference and Analyze
+
+1. For every item defined in specs, check if it exists in implementation and whether it matches.
+2. For every significant implementation detail, check if it's covered in specs.
+3. Identify conflicts where both exist but disagree.
+4. **Skip** items explicitly listed in `specs/deferred.md` — these are intentional gaps, not drift.
+
+## Output Format
+
+Produce your report with a summary line at the top followed by three tables:
+
+### Summary
+
+> X items specified but not implemented, Y items implemented but not specified, Z conflicts found.
+
+### Table 1: Specified but Not Implemented
+
+| Spec File | Item | Description | Proposed Resolution |
+|-----------|------|-------------|---------------------|
+
+For each row, clearly identify what the spec says should exist, where it should be, and recommend either implementing it or updating the spec to remove it (with reasoning).
+
+### Table 2: Implemented but Not Specified
+
+| Implementation File | Item | Description | Proposed Resolution |
+|---------------------|------|-------------|---------------------|
+
+For each row, identify the undocumented implementation, what it does, and recommend either adding it to the appropriate spec or removing/deprecating it (with reasoning).
+
+### Table 3: Spec-Implementation Conflicts
+
+| Spec File | Implementation File | Item | Spec Says | Implementation Does | Proposed Resolution |
+|-----------|---------------------|------|-----------|---------------------|---------------------|
+
+For each row, clearly describe the discrepancy and recommend which side should be updated (with reasoning).
+
+## Important Guidelines
+
+- **Be exhaustive.** Check every API method, every error code, every config option. Do not sample — audit everything.
+- **Be precise.** Reference specific file paths and line numbers where possible. Quote spec text and code when describing conflicts.
+- **Be practical.** Your proposed resolutions should consider what seems intentional vs accidental. If implementation has evolved beyond the spec, usually the spec needs updating. If a spec feature was clearly planned but not built, flag it for implementation.
+- **Distinguish severity.** Note when a gap is trivial (e.g., slightly different parameter name) vs significant (e.g., entire method missing).
+- **Group logically.** Within each table, group items by module / spec file for readability.
+- **Respect `deferred.md`.** Items there are intentional gaps, not drift. Don't flag them.

--- a/.claude/commands/audit-spec-drift.md
+++ b/.claude/commands/audit-spec-drift.md
@@ -1,0 +1,1 @@
+Use the spec-drift-auditor agent to do a comprehensive audit of how well the codebase implementation matches the specs/ directory. Report unimplemented spec features, undocumented implementation details, and conflicts between specs and code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# gitsheets
+
+A git-backed document store for low-volume, high-touch, human-scale data. Library + CLI.
+
+## Spec-driven
+
+**`specs/` is the source of truth.** Before writing or changing code, read the relevant spec; if the spec doesn't cover what you're about to do, update the spec first.
+
+Workflow:
+
+1. Spec change → propose what should be true
+2. Reviewer agrees on desired state
+3. Implement to match the spec
+4. Verify running software matches the spec
+
+Start at [specs/README.md](specs/README.md). The index of what's where:
+
+- [specs/architecture.md](specs/architecture.md) — stack, packaging, foundational decisions
+- [specs/concepts.md](specs/concepts.md) — vocabulary: Repository, Sheet, Record, Transaction, Store, Index
+- [specs/deferred.md](specs/deferred.md) — features intentionally out of scope for v1.0 (do NOT silently implement these)
+- [specs/api/](specs/api/) — per-symbol API contracts (Repository, Sheet, Transaction, Store, Errors, CLI)
+- [specs/behaviors/](specs/behaviors/) — cross-cutting rules (path templates, validation, normalization, transactions, indexing, push sync, attachments, patch semantics)
+
+## Spec drift auditing
+
+Run `/audit-spec-drift` to launch a comprehensive audit comparing `specs/` against the implementation. Use it before starting major work, after large refactors, and as part of the release checklist.
+
+## v1.0 milestone
+
+The active work scope is [the 1.0.0 milestone](https://github.com/JarvusInnovations/gitsheets/milestone/1) — see issues #128 through #141 (excluding the few backlog ones). The [holo-tree (Rust) migration](https://github.com/JarvusInnovations/gitsheets/issues/127) is v1.1; v1.0 stays on the JS hologit substrate.
+
+## Stack
+
+- **Language** — TypeScript (strict). ESM-only.
+- **Runtime** — Node.js ≥ 20 or Bun ≥ 1.
+- **Tree primitives** — hologit (JS) for v1.0; holo-tree (Rust via napi-rs) for v1.1.
+- **TOML** — `@iarna/toml` (preserves Date types).
+- **JSON Schema validation** — `ajv`.
+- **Runtime consumer-validator interface** — [Standard Schema](https://standardschema.dev) (any compliant validator: Zod, Valibot, ArkType, Effect Schema).
+- **JSON Merge Patch** — RFC 7396 via `json-merge-patch`.
+- **Tests** — Vitest (or `node --test`; chosen during #137).
+
+See [specs/architecture.md](specs/architecture.md) for the full stack rationale.
+
+## Authorship conventions
+
+- TypeScript everywhere. `strict: true`. No `.js` in `src/`.
+- Field naming: `camelCase` in code, in TOML records, and on `Sheet.<field>` config — no casing translation.
+- IDs: consumer's choice (gitsheets doesn't impose UUID/string/numeric). Path templates render whatever the field holds.
+- Timestamps: TOML datetime types preserved by `@iarna/toml`; consumers can also use ISO 8601 strings.
+- Use the typed error classes from [specs/api/errors.md](specs/api/errors.md) — never throw plain `Error` from public surfaces.
+- Mutations go through `repo.transact` or via the permissive Sheet methods documented in [specs/behaviors/transactions.md](specs/behaviors/transactions.md).
+
+## Source control
+
+- **Conventional commits** — `type(scope): description` (e.g., `feat(sheet): add patch method`, `fix(path-template): handle multi-variable segments`, `docs(specs): clarify trailer conventions`).
+- **Logical sets per commit** — group related changes together; commit often. When multiple uncommitted change-sets exist, commit them separately in a logical order.
+- **Always `git status` before staging.** Stage specific files or directories — never `git add -A` or `git add .`.
+- **Generated changes commit first.** When a command modifies files (`npm install`, codegen), commit those in a dedicated commit with the exact command in the body. Then make manual edits in a separate commit.
+- **Don't commit suspected secrets** — `.env`, anything in `*.local.*`, credentials, private keys.
+
+## Tooling
+
+- **`gh-axi`** (or `gh`) for all GitHub operations.
+- **GitHub Actions** — when authoring or modifying a workflow, run `gh-axi repo view <owner>/<repo>` on each action's repo to confirm the latest recommended version.
+- **`jq`** for processing JSON in any shell pipeline. No inline Python/Node to filter JSON.
+- **`npm`** for packages. Never hand-edit `package.json` or `package-lock.json` — use `npm install <pkg>`, `npm uninstall <pkg>`, etc. Commit `package-lock.json`.
+- **`asdf`** for tool versions when available. Never edit `.tool-versions` directly.
+
+## Commands (post-1.0)
+
+```bash
+npm install
+npm run build         # tsc → dist/
+npm test              # vitest (or node --test)
+npm run type-check
+npm run lint
+```
+
+CLI usage:
+
+```bash
+git sheet upsert <sheet> [file]
+git sheet query <sheet> [--filter.<field>=<value>]
+git sheet read <sheet> <path>
+git sheet edit <sheet> <path>
+git sheet normalize <sheet>
+git sheet infer <sheet>
+git sheet migrate-config <sheet>
+```
+
+See [specs/api/cli.md](specs/api/cli.md).
+
+## When in doubt
+
+Pick the spec that mentions what you're working on. If multiple specs apply (e.g., `Sheet.patch` involves [api/sheet.md](specs/api/sheet.md), [behaviors/patch-semantics.md](specs/behaviors/patch-semantics.md), [behaviors/validation.md](specs/behaviors/validation.md)), read each. If you can't find a spec, the answer is to write one — not to make up behavior.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,140 @@
+# Specs
+
+This directory is the source of truth for what `gitsheets` *should be*. The implementation under `src/` is brought into conformance with these specs — not the other way around.
+
+If you're about to write code, you're in the wrong place. Start here, read the relevant spec, then go write code that matches it.
+
+## Workflow
+
+```text
+1. Spec change  →  propose what should be true
+2. Accept       →  reviewer agrees on desired state
+3. Implement    →  bring code into conformance
+4. Verify       →  compare running software to spec
+```
+
+Concretely:
+
+- **Starting a feature** — write or update the spec first. Open the PR with the spec changes. Once reviewers agree, implement.
+- **Fixing a bug** — if the spec covers the behavior, the spec is right and the code is wrong; fix the code. If the spec is silent, decide whether the spec should be amended.
+- **Reviewing code** — compare the diff against the spec. The spec is the acceptance criteria.
+- **Spec is ambiguous** — propose a spec amendment in the same PR; don't guess and code.
+
+PRs that change runtime behavior should include a spec change. If they don't, that's a smell.
+
+## Directory layout
+
+```text
+specs/
+├── README.md             # This file — workflow + layout
+├── architecture.md       # Tech stack, packaging, foundational decisions
+├── concepts.md           # Vocabulary: Repository, Sheet, Record, Transaction, Store, Index
+├── deferred.md           # Features intentionally not in scope for v1.0
+├── api/                  # Per-symbol API contracts
+│   ├── conventions.md
+│   ├── repository.md
+│   ├── sheet.md
+│   ├── transaction.md
+│   ├── store.md
+│   ├── errors.md
+│   └── cli.md
+└── behaviors/            # Cross-cutting rules referenced from multiple APIs
+    ├── path-templates.md
+    ├── validation.md
+    ├── normalization.md
+    ├── transactions.md
+    ├── indexing.md
+    ├── push-sync.md
+    ├── attachments.md
+    └── patch-semantics.md
+```
+
+### Why no `data-model.md`?
+
+Most spec-driven projects describe a domain (Person, Project, Order…). Gitsheets is a **library**, not a domain app. The closest equivalent — the vocabulary of types we expose to consumers — lives in [`concepts.md`](concepts.md). API surface lives under [`api/`](api/).
+
+### Why no `screens/`?
+
+Gitsheets has no UI. The pre-v1.0 Vue frontend is being removed (see [GitHub #128](https://github.com/JarvusInnovations/gitsheets/issues/128)). The only user-facing surfaces are the JS/TS API and the CLI — both speced in [`api/`](api/).
+
+## What specs cover
+
+- **API contracts** — function signatures, semantics, errors thrown
+- **On-disk formats** — `.gitsheets/<name>.toml` config, record TOML files, attachment paths
+- **Cross-cutting rules** — path templates, validation, normalization, transactions, indexing
+- **CLI commands** — flags, defaults, behavior
+
+## What specs do NOT cover
+
+- **Implementation details** — internal class hierarchies, helper-function naming, file organization within `src/`
+- **Performance microbenches** — covered in PR descriptions and the [holo-tree migration](https://github.com/JarvusInnovations/gitsheets/issues/127), not here
+- **Test cases** — tests derive from specs but aren't the spec
+- **Repository housekeeping** — branch naming, release procedure, CI workflow specifics
+
+## The right level of detail
+
+Specs declare *what* must be true, not *how* to implement it.
+
+**Good** — declarative, testable:
+> "`Sheet.patch(query, partial)` reads the matched record via `queryFirst`, applies RFC 7396 JSON Merge Patch semantics to combine the patch with the existing record, validates the result against the sheet's JSON Schema and any consumer-supplied Standard Schema validator, then upserts the new record within the current transaction."
+
+**Too vague** — implementer still has to guess:
+> "Patch updates a record by merging in changes."
+
+**Too detailed** — duplicates the code:
+> "Open the record blob, parse with `iarna/toml`, deepclone the object, walk the patch tree with a recursive merge function, then…"
+
+## Spec drift auditing
+
+Run `/audit-spec-drift` (the Claude Code command at `.claude/commands/audit-spec-drift.md`) to launch a comprehensive audit comparing this directory against the implementation. It produces three tables: specified-but-not-implemented, implemented-but-not-specified, and conflicts. Use it before starting major work and as part of the release checklist.
+
+## Versioning relative to specs
+
+These specs describe **v1.0** of gitsheets. Items intentionally deferred to later releases (e.g., the [holo-tree migration in v1.1](https://github.com/JarvusInnovations/gitsheets/issues/127), watch mode, attachments iterator) live in [`deferred.md`](deferred.md).
+
+When v1.1 begins, deferred items get promoted into the active specs; the spec authoring rules above apply.
+
+## Authoring guidance
+
+- Use the templates below. Sections may be empty during early drafts; mark them `_TBD_` rather than deleting them so readers know what's missing.
+- Link liberally between specs. Specs form a graph.
+- Prefer enumerations and tables over prose for anything with discrete cases.
+
+### API template
+
+```markdown
+# API: <Symbol>
+
+## Summary
+One paragraph on what this is.
+
+## Signature
+TypeScript signature(s).
+
+## Semantics
+Per-method behavior. Rules for return values, side effects, errors.
+
+## Errors
+Which exception classes get thrown, under what conditions.
+
+## Examples
+Compact code snippets showing typical use.
+
+## Coordinates with
+Links to related specs.
+```
+
+### Behavior template
+
+```markdown
+# Behavior: <Name>
+
+## Rule
+The invariant or rule, stated declaratively.
+
+## Applies To
+Which APIs / concepts this behavior governs.
+
+## Details
+Edge cases, calculations, timing, error handling.
+```

--- a/specs/api/cli.md
+++ b/specs/api/cli.md
@@ -1,0 +1,167 @@
+# API: CLI
+
+`git sheet <command>` — the command-line interface. Installs as both `gitsheets` and `git-sheet`.
+
+## Summary
+
+The CLI is a thin wrapper around the JS API. Every command resolves to an operation on a `Repository` (or `Sheet`/`Transaction`); the CLI handles arg parsing, I/O encoding, and output formatting.
+
+## Global flags
+
+These apply to every command unless noted otherwise:
+
+| Flag | Default | Source |
+|---|---|---|
+| `--git-dir <path>` | discovered | `GIT_DIR` env var |
+| `--root <path>` | `/` | `GITSHEETS_ROOT` env var |
+| `--prefix <path>` | none | `GITSHEETS_PREFIX` env var |
+| `--ref <ref>` | `HEAD` | `GITSHEETS_REF` env var |
+| `--commit-to <ref>` | derived from `--ref` (if ref is a branch) | none |
+| `--working` | false | none |
+
+`--ref` selects which commit/branch to read from or transact against. `--commit-to` overrides which branch a write-transaction advances. `--working` reads/writes the working tree state (not a committed tree).
+
+These options unify what [#106](https://github.com/JarvusInnovations/gitsheets/issues/106) asked for. Every mutating command implicitly uses `repo.transact` and accepts `--message`, `--author-name`, `--author-email`, `--trailer.<Key>=<value>`.
+
+## Commands
+
+### `git sheet upsert <sheet> [file]`
+
+Insert or update one or more records.
+
+```bash
+git sheet upsert users users.json
+git sheet upsert users - < records.csv --format=csv
+git sheet upsert users '{"slug":"jane","email":"jane@x.org"}'
+```
+
+Flags:
+
+- `--format <json|toml|csv>` — input format (default: inferred from extension, fallback `json`)
+- `--encoding <enc>` — default `utf8`
+- `--patch` — apply RFC 7396 patch semantics to existing records (replaces pre-v1.0 `--patch-existing` deepmerge behavior; see [behaviors/patch-semantics.md](../behaviors/patch-semantics.md))
+- `--delete-missing` — full-replace mode: records in the sheet but not in the input are deleted
+- `--attachments.<path>=<spec>` — attach a file alongside the record (format `[ext]:<source-path>`)
+- `--message <msg>`, `--author-name`, `--author-email`, `--trailer.<Key>=<value>` — transaction metadata
+
+Output (per record, to stdout):
+
+```text
+<blob-hash> <rendered-path>
+```
+
+### `git sheet query <sheet>`
+
+Read records.
+
+```bash
+git sheet query users
+git sheet query users --filter.email=jane@x.org
+git sheet query users --filter status=active --filter project_id=p1
+git sheet query users --format=csv --headers
+```
+
+Flags:
+
+- `--filter.<field>=<value>` — equality filter
+- `--fields <name>...` — output column subset / reorder
+- `--fields.<from>=<to>` — output column rename
+- `--limit <n>`
+- `--format <json|csv|tsv|toml>` (default: `json`)
+- `--headers` (CSV/TSV only; default: true)
+
+### `git sheet read <sheet> <path>`
+
+Read a single record by exact path.
+
+```bash
+git sheet read users users/janedoe
+```
+
+Output: TOML or JSON to stdout (per `--format`).
+
+### `git sheet edit <sheet> <path>`
+
+Open a record in `$EDITOR`. On save, validate and upsert.
+
+```bash
+git sheet edit users users/janedoe
+```
+
+Honors the same transaction flags as `upsert`.
+
+### `git sheet normalize <sheet>`
+
+Re-write every record in the sheet through the canonical-normalization pipeline. Commits a single transaction containing all changed records.
+
+```bash
+git sheet normalize users
+```
+
+Use case: after upgrading the sheet's `sort` config, or after a manual edit that didn't preserve sort order, recanonicalize all records.
+
+### `git sheet infer <sheet>`
+
+Scan existing records and write a starter `[gitsheet.schema]` to `.gitsheets/<sheet>.toml`.
+
+```bash
+git sheet infer users
+```
+
+Output is conservative — observed types only, no inferred regex/format constraints. The result is a starting point the user edits.
+
+See [#130](https://github.com/JarvusInnovations/gitsheets/issues/130).
+
+### `git sheet migrate-config <sheet>`
+
+Convert a pre-v1.0 `[gitsheet.fields]` config to a v1.0 `[gitsheet.schema]` config. Lossless for `type`/`enum`/`default`; surfaces `trueValues`/`falseValues` as a warning suggesting the CSV-ingest helper.
+
+```bash
+git sheet migrate-config users
+```
+
+See [#130](https://github.com/JarvusInnovations/gitsheets/issues/130).
+
+### `git sheet init <sheet>` _(deferred to post-1.0)_
+
+Scaffold `.gitsheets/<sheet>.toml`. See [#139](https://github.com/JarvusInnovations/gitsheets/issues/139).
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Generic error (unhandled exception) |
+| 2 | Argument-parsing error |
+| 22 | `ValidationError` |
+| 64 | `ConfigError` |
+| 65 | `RefError` (not-found) |
+| 66 | `NotFoundError` |
+| 69 | `TransactionError` |
+| 70 | `IndexError` |
+
+Following loose [`sysexits.h`](https://man.openbsd.org/sysexits.3) precedent where useful, otherwise improvised. Stable from v1.0.
+
+## Streaming behavior
+
+`upsert` and `query` stream records when possible. Large CSV inputs / outputs do not need to fit in memory.
+
+## Error output
+
+Errors print to stderr in this shape:
+
+```text
+gitsheets: <error-class>: <message>
+  code:   <code>
+  cause:  <optional cause>
+```
+
+Plus a non-zero exit code per the table above.
+
+## Coordinates with
+
+- [api/repository.md](repository.md)
+- [api/sheet.md](sheet.md)
+- [api/transaction.md](transaction.md)
+- [api/errors.md](errors.md)
+- All [behaviors/](../behaviors/) specs — the CLI surfaces them through flags

--- a/specs/api/conventions.md
+++ b/specs/api/conventions.md
@@ -1,0 +1,97 @@
+# API: Conventions
+
+Cross-cutting rules every API spec under this directory inherits.
+
+## Module surface
+
+All public symbols are imported from the package root:
+
+```typescript
+import {
+  openRepo, openStore,
+  Repository, Sheet, Transaction,
+  GitsheetsError, ConfigError, ValidationError, TransactionError,
+  IndexError, RefError, PathTemplateError, NotFoundError,
+} from 'gitsheets';
+```
+
+No deep imports (`gitsheets/lib/Sheet`) — the implementation can rearrange `src/` freely.
+
+## TypeScript posture
+
+- `strict: true` in shipped types.
+- Public functions have explicit return types — no `Promise<any>`.
+- Generics flow from sheet configs through to consumer call sites (`Sheet<T>`, `Store<Schemas>`).
+
+## Async patterns
+
+- Read-many results: `async function*` iterators. Consumers `for await` them.
+- Read-one: `Promise<T | undefined>`.
+- Writes: `Promise<{ blob, path }>` (single-record) or `Promise<TransactionResult>` (transaction commit).
+
+## Options-object pattern
+
+Functions with more than two parameters take an options object:
+
+```typescript
+// good
+await sheet.defineIndex('byEmail', { unique: true, eager: false }, fn);
+
+// not the convention
+await sheet.defineIndex('byEmail', true, false, fn);
+```
+
+Optional fields have documented defaults. Missing `undefined` is treated as "use default."
+
+## Errors
+
+Every error thrown by gitsheets extends `GitsheetsError` and carries a stable `code` string. Consumers should switch on `instanceof` or on `err.code` — never on `err.message`. See [api/errors.md](errors.md).
+
+## Cancellation
+
+Long-running iterations (`Sheet.query`) honor `AbortSignal` when one is passed in via the options. Without a signal, they run to completion.
+
+```typescript
+const controller = new AbortController();
+for await (const record of sheet.query({}, { signal: controller.signal })) {
+  // ...
+  if (someCondition) controller.abort();
+}
+```
+
+`AbortError` is thrown after the next yield point. (Defer if implementation cost is high for v1.0; documented here as the convention for any iterator that adds cancellation later.)
+
+## Async iteration over trees
+
+The library exposes async iterators throughout. They are **single-pass** — re-iterating requires calling the producing method again. Internal caching may make re-iteration fast, but the iterators are not stateless.
+
+## Naming
+
+- **Methods that don't commit:** `upsert`, `delete`, `patch`, `setAttachment` — they stage tree writes. Commits happen on transaction boundary.
+- **Methods that do commit (implicit transaction):** none by name. Permissive mode commits at the end of any standalone mutation, but the *method* doesn't carry "commit" in its name.
+- **Methods that always commit explicitly:** `Repository.transact` and `Store.transact`.
+
+## Versioning
+
+The public API is the API surface speced under `specs/api/`. Anything not speced there is implementation detail and may change without notice. Breaking changes to speced surface require a major version bump.
+
+## Default branches and refs
+
+When a ref isn't specified:
+
+- Read operations default to the repository's `HEAD`.
+- Write operations (transactions) default `parent` to `HEAD`.
+- The CLI honors `GITSHEETS_REF` for an override.
+
+## Default paths
+
+When a root isn't specified:
+
+- `Repository.openSheet(name)` defaults `root` to `/` (repo root) — `.gitsheets/<name>.toml` is read from there.
+- The CLI honors `GITSHEETS_ROOT` and `GITSHEETS_PREFIX` for overrides (matching the pre-v1.0 behavior).
+
+## I/O
+
+- All file paths inside the data repo are POSIX-style (`/` separators) regardless of host OS.
+- TOML reads use `@iarna/toml` to preserve Date types.
+- TOML writes serialize sorted keys (deep) for byte-stable normalization.

--- a/specs/api/errors.md
+++ b/specs/api/errors.md
@@ -1,0 +1,97 @@
+# API: Errors
+
+Typed exception classes with stable codes. Consumers switch on `instanceof` or `err.code` — never on `err.message`.
+
+## Hierarchy
+
+```typescript
+export class GitsheetsError extends Error {
+  readonly code: string;
+  readonly status: number;        // HTTP-style hint for consumers building APIs
+  readonly cause?: unknown;
+}
+
+export class ConfigError extends GitsheetsError {}
+export class ValidationError extends GitsheetsError {
+  readonly issues: ValidationIssue[];
+}
+export class TransactionError extends GitsheetsError {}
+export class IndexError extends GitsheetsError {
+  readonly conflictingPaths?: string[];
+}
+export class RefError extends GitsheetsError {}
+export class PathTemplateError extends GitsheetsError {}
+export class NotFoundError extends GitsheetsError {}
+```
+
+Every gitsheets exception extends `GitsheetsError`. Consumer catch blocks can typically use:
+
+```typescript
+try {
+  await sheet.upsert(record);
+} catch (err) {
+  if (err instanceof ValidationError) {
+    // err.issues
+  } else if (err instanceof GitsheetsError) {
+    // err.code
+    // err.status
+  } else {
+    throw err;
+  }
+}
+```
+
+## Code table
+
+| Class | Code | `status` | Meaning |
+|---|---|---:|---|
+| `ConfigError` | `config_missing` | 500 | `.gitsheets/<name>.toml` not found |
+| `ConfigError` | `config_invalid` | 500 | Sheet config TOML malformed or schema unparseable |
+| `ValidationError` | `validation_failed` | 422 | Record failed JSON Schema or Standard Schema validation |
+| `TransactionError` | `transaction_in_progress` | 409 | Concurrent `repo.transact` attempt |
+| `TransactionError` | `transaction_required` | 409 | Mutation outside a transaction in strict mode |
+| `TransactionError` | `parent_moved` | 409 | Optimistic-concurrency conflict at commit |
+| `TransactionError` | `commit_failed` | 500 | `git commit-tree` / `update-ref` non-zero |
+| `IndexError` | `index_unique_conflict` | 409 | Unique index would be violated |
+| `IndexError` | `index_not_defined` | 500 | `findByIndex` for an undeclared index |
+| `RefError` | `ref_not_found` | 404 | Resolution of a ref / commit-hash failed |
+| `RefError` | `not_an_ancestor` | 409 | Merge-like operation where src is not an ancestor of dst |
+| `PathTemplateError` | `path_render_failed` | 422 | Template can't render against the record (missing fields, etc.) |
+| `PathTemplateError` | `path_invalid_chars` | 422 | Rendered path contains characters disallowed by the filesystem (Windows, etc.) |
+| `NotFoundError` | `record_not_found` | 404 | `delete` / `patch` / etc. against a path that doesn't exist |
+
+The `code` strings are stable. New scenarios get new codes; existing codes never change meaning.
+
+## ValidationIssue
+
+```typescript
+interface ValidationIssue {
+  path: string[];          // e.g., ['email']
+  message: string;         // human-readable
+  source: 'json-schema' | 'standard-schema';
+  schemaPath?: string;     // JSON Schema pointer when source === 'json-schema'
+  code?: string;           // schema-keyword name (e.g., 'required', 'pattern')
+}
+```
+
+Combined from both validation layers. The `source` field identifies which layer raised the issue.
+
+## Why typed errors
+
+The pre-v1.0 `errors.js` defined a few classes but consumer code (and even `backend/server.js`) routinely string-matched error messages (`err.message.startsWith('invalid tree ref')`). That couples consumers to error text and breaks on phrasing changes. v1.0 eliminates string-matching: every throwsite uses a typed class with a stable `code`.
+
+## Migrating from pre-v1.0 names
+
+| Pre-v1.0 | v1.0 |
+|---|---|
+| `SerializationError` | `ValidationError` (`validation_failed`) for record-validation cases; `ConfigError` (`config_invalid`) for sheet-config parse cases |
+| `ConfigError` | `ConfigError` (with stable `code`) |
+| `InvalidRefError` | `RefError` (`ref_not_found`) |
+| `MergeError` | `RefError` (`not_an_ancestor`) |
+
+The pre-v1.0 `errors.js` module is removed during the [#128 purge](https://github.com/JarvusInnovations/gitsheets/issues/128).
+
+## Coordinates with
+
+- All API specs throw from this taxonomy.
+- [GitHub #136](https://github.com/JarvusInnovations/gitsheets/issues/136) tracks the implementation.

--- a/specs/api/repository.md
+++ b/specs/api/repository.md
@@ -1,0 +1,164 @@
+# API: Repository
+
+The entry point. A `Repository` represents a git repository that contains gitsheets data.
+
+## Summary
+
+`Repository` opens a git directory, exposes per-sheet handles, and orchestrates transactions. It's the primary object every consumer holds.
+
+## Construction
+
+```typescript
+import { openRepo } from 'gitsheets';
+
+const repo = await openRepo({
+  gitDir?: string,           // path to a .git directory; default: discovered from cwd
+  workingTree?: boolean,     // default false; true to also resolve working-tree state
+});
+```
+
+Backed by hologit's repo discovery. If `gitDir` is omitted, the library probes `cwd` upward for a `.git`.
+
+A fresh-but-initialized repository (no commits yet) is supported — see [#19](https://github.com/JarvusInnovations/gitsheets/issues/19).
+
+## Methods
+
+### `repo.openSheet(name, opts?)`
+
+Returns a `Sheet` handle bound to this repository's current state.
+
+```typescript
+const users = await repo.openSheet('users', {
+  root?: string,             // default: '/'
+  prefix?: string,           // optional sub-prefix under root; default: none
+  validator?: StandardSchema, // optional Standard Schema validator
+});
+```
+
+Throws `ConfigError` if `.gitsheets/<name>.toml` doesn't exist under the resolved root.
+
+### `repo.openSheets(opts?)`
+
+Returns `{ [sheetName]: Sheet }` covering every sheet declared in `.gitsheets/`.
+
+```typescript
+const sheets = await repo.openSheets({ root?: string, prefix?: string });
+```
+
+Used by `openStore` (see [api/store.md](store.md)).
+
+### `repo.transact(opts, handler)`
+
+Run a handler inside a transaction. Returns `Promise<TransactionResult<T>>` where `T` is the handler's return type.
+
+```typescript
+const result = await repo.transact(
+  {
+    parent?: string,                 // ref or commit hash; default: current HEAD
+    author?: { name: string, email: string }, // default: git config
+    committer?: { name: string, email: string }, // default: author
+    message: string,                 // commit subject + body
+    trailers?: Record<string, string>, // appended per `git interpret-trailers` rules
+    branch?: string,                  // ref to update on success; default: the parent ref if it was a branch
+  },
+  async (tx: Transaction) => {
+    // mutations via tx.sheet(name).upsert / delete / patch
+    return someValue;
+  }
+);
+// result: { value, commitHash, treeHash, ref, parentCommitHash }
+```
+
+See [behaviors/transactions.md](../behaviors/transactions.md) for semantics (mutex, commit-on-success, trailer formatting).
+
+### `repo.requireExplicitTransactions()`
+
+Opt into strict mode. After this is called on a `Repository`, calling `Sheet.upsert` / `delete` / `patch` outside a transaction throws `TransactionError` with `code: 'transaction_required'`.
+
+Default mode is permissive (mutations outside a transaction auto-open one).
+
+### `repo.startPushDaemon(opts)`
+
+Returns a `PushDaemon` handle. Configures async background push-to-remote with retry/backoff. See [behaviors/push-sync.md](../behaviors/push-sync.md).
+
+```typescript
+const daemon = repo.startPushDaemon({
+  remote: 'origin',
+  branch?: string,           // default: HEAD's branch
+  backoff?: 'exponential' | { base: number, cap: number, multiplier: number },
+  maxRetries?: number,       // default: Infinity
+});
+
+daemon.on('push', ({ commit, durationMs }) => {});
+daemon.on('error', ({ commit, err, attempt }) => {});
+daemon.on('retry', ({ commit, attempt, nextDelayMs }) => {});
+
+daemon.status();             // { lastPushAt, lastError, pendingCommits, currentBackoffMs }
+await daemon.stop();         // graceful drain
+```
+
+### `repo.resolveRef(ref)`
+
+Returns the commit hash a ref points to, or `null` if the ref doesn't exist.
+
+```typescript
+const hash = await repo.resolveRef('main');         // → '01ab...'
+const missing = await repo.resolveRef('nope');      // → null
+```
+
+## TransactionResult
+
+```typescript
+interface TransactionResult<T> {
+  value: T;                  // whatever the handler returned
+  commitHash: string;        // the new commit
+  treeHash: string;          // the tree that commit points at
+  ref: string | null;        // the ref that was updated, if any
+  parentCommitHash: string | null;
+}
+```
+
+`commitHash` and `treeHash` are populated even if the handler made no mutations (an empty tree-equivalent commit is still produced when explicitly transacted) — but in permissive mode, a no-op handler does *not* commit.
+
+## Errors
+
+| Class | Code | When |
+|---|---|---|
+| `RefError` | `ref_not_found` | `parent` ref doesn't exist |
+| `TransactionError` | `transaction_in_progress` | Another transaction is open on this repo |
+| `TransactionError` | `commit_failed` | The underlying `git commit-tree` or `update-ref` failed |
+| `TransactionError` | `parent_moved` | Optimistic concurrency: parent ref moved between transaction start and commit |
+| `ConfigError` | `config_missing` | `.gitsheets/<name>.toml` not found in `openSheet` |
+| `ConfigError` | `config_invalid` | Sheet config TOML is malformed |
+
+## Examples
+
+### Open + transact
+
+```typescript
+const repo = await openRepo({ gitDir: '/path/to/repo' });
+
+await repo.transact(
+  { message: 'janedoe: POST /api/users', author: { name: 'Jane', email: 'jane@x.org' } },
+  async (tx) => {
+    await tx.sheet('users').upsert({ slug: 'janedoe', email: 'jane@x.org' });
+  }
+);
+```
+
+### Push daemon
+
+```typescript
+const daemon = repo.startPushDaemon({ remote: 'origin' });
+// ... mutations happen, daemon pushes async ...
+await daemon.stop();
+```
+
+## Coordinates with
+
+- [api/sheet.md](sheet.md)
+- [api/transaction.md](transaction.md)
+- [api/store.md](store.md)
+- [api/errors.md](errors.md)
+- [behaviors/transactions.md](../behaviors/transactions.md)
+- [behaviors/push-sync.md](../behaviors/push-sync.md)

--- a/specs/api/sheet.md
+++ b/specs/api/sheet.md
@@ -1,0 +1,190 @@
+# API: Sheet
+
+A typed handle to a single sheet within a repository. The most-touched object in consumer code.
+
+## Summary
+
+A `Sheet<T>` represents one declared sheet in `.gitsheets/<name>.toml`. It owns the path template, the JSON Schema, the canonical-normalization rules, and the secondary in-memory indices. All record-level mutations and queries go through it.
+
+## Type parameter
+
+`T` is the record shape inferred from the sheet's JSON Schema, optionally narrowed by a consumer-supplied Standard Schema validator. Without a validator, `T = Record<string, unknown>`.
+
+## Reading
+
+### `sheet.query(filter?, opts?)`
+
+Async iterator yielding records matching `filter`.
+
+```typescript
+for await (const user of sheet.query({ accountLevel: 'staff' })) {
+  // ...
+}
+```
+
+- `filter` is a plain object. Each key on the filter is matched against the record's field by equality. Function-valued filter entries are called as `(recordValue, record) => boolean`. Nested objects descend recursively.
+- If the filter includes fields from the path template, gitsheets prunes the tree traversal to only matching subtrees (see [behaviors/path-templates.md](../behaviors/path-templates.md)).
+- Order of results: filesystem order within each tree level. Not guaranteed stable across implementation changes — sort in consumer code if order matters.
+- `opts.signal?: AbortSignal` — see [api/conventions.md](conventions.md#cancellation).
+
+### `sheet.queryFirst(filter?)`
+
+Returns `Promise<T | undefined>`. The first match, or `undefined`.
+
+### `sheet.queryAll(filter?)`
+
+Returns `Promise<T[]>`. All matches collected into an array. Convenience over `for await ... push`.
+
+### `sheet.pathForRecord(record)`
+
+Returns `Promise<string>` — the path the sheet's template would render this record to. Does not write.
+
+### `sheet.normalizeRecord(record)`
+
+Returns `Promise<T>` — the record with canonical normalization applied (sorted keys deep, array-field sorts per [behaviors/normalization.md](../behaviors/normalization.md)). Does not write, does not validate.
+
+## Writing
+
+All write methods stage to the current transaction's tree (or, in permissive mode, auto-open and commit a single-mutation transaction). See [behaviors/transactions.md](../behaviors/transactions.md).
+
+### `sheet.upsert(record)`
+
+```typescript
+const { blob, path } = await sheet.upsert({
+  slug: 'janedoe',
+  email: 'jane@x.org',
+  fullName: 'Jane Doe',
+});
+```
+
+- Validates the record (JSON Schema + optional Standard Schema; see [behaviors/validation.md](../behaviors/validation.md))
+- Applies canonical normalization
+- Renders the record's path from the template
+- If the record was loaded from disk (has the `Symbol.for('gitsheets-path')` annotation) and the new rendered path differs, the old path's file is deleted (rename semantics)
+- Writes the TOML blob to the tree
+- Returns the staged blob + its path
+
+Throws `ValidationError` on invalid input. Throws `PathTemplateError` if the template can't render against the record.
+
+### `sheet.delete(recordOrPath)`
+
+```typescript
+await sheet.delete({ slug: 'janedoe' });   // delete by record
+await sheet.delete('users/janedoe');       // delete by path
+```
+
+If passed a record, renders its path via the template first. Returns void.
+
+Throws `NotFoundError` if the path doesn't exist in the current tree.
+
+### `sheet.patch(query, partial)`
+
+Applies an RFC 7396 JSON Merge Patch to an existing record.
+
+```typescript
+await sheet.patch(
+  { slug: 'janedoe' },
+  { fullName: 'Jane O. Doe', bio: null }
+);
+```
+
+Steps:
+
+1. `queryFirst(query)` → existing record. Throws `NotFoundError` if no match.
+2. Apply RFC 7396 semantics — see [behaviors/patch-semantics.md](../behaviors/patch-semantics.md). (`null` deletes, arrays replace, objects merge.)
+3. Validate the merged record (same pipeline as `upsert`).
+4. `upsert` the result.
+
+Returns `Promise<{ blob, path }>` matching `upsert`.
+
+### `sheet.clear()`
+
+Removes every record from the sheet's tree. Used during full-replace imports.
+
+### `sheet.clone()`
+
+Returns a deep clone of the `Sheet` instance with a cloned data tree. Used to stage a tentative state for diffing / proposing without mutating the original.
+
+## Indexing
+
+### `sheet.defineIndex(name, opts?, keyFn)`
+
+Declare a secondary in-memory index.
+
+```typescript
+sheet.defineIndex(
+  'byEmail',
+  { unique: true, eager: false },
+  (record) => record.email.toLowerCase()
+);
+
+sheet.defineIndex(
+  'byProjectAndStatus',
+  (record) => `${record.projectId}:${record.status}`
+);
+```
+
+- `opts.unique?: boolean` — default `false`
+- `opts.eager?: boolean` — default `false` (lazy)
+- `keyFn(record): string | undefined` — return `undefined` to exclude a record from the index
+
+See [behaviors/indexing.md](../behaviors/indexing.md) for build, invalidation, and conflict semantics.
+
+### `sheet.findByIndex(name, key)`
+
+- Unique index: returns `Promise<T | undefined>`
+- Non-unique index: returns `Promise<T[]>`
+
+Throws `IndexError` (`index_not_defined`) if `name` isn't declared on this sheet.
+Throws `IndexError` (`index_unique_conflict`) during a lazy build if uniqueness is violated.
+
+## Attachments
+
+Binary blobs colocated with a record.
+
+```typescript
+await sheet.setAttachment(record, 'avatar.jpg', blob);
+await sheet.setAttachments(record, { 'avatar.jpg': blob1, 'avatar-128.jpg': blob2 });
+
+const attachments = await sheet.getAttachments(record); // current low-level surface
+const avatar = await sheet.getAttachment(record, 'avatar.jpg');
+```
+
+The iterator API (`for await (const { name, mimeType, blob } of sheet.attachments(record))`) is deferred to a post-1.0 release. See [#140](https://github.com/JarvusInnovations/gitsheets/issues/140).
+
+## Diff
+
+### `sheet.diffFrom(srcCommitHash?, opts?)`
+
+Async iterator of changes between `srcCommitHash` and the current tree, scoped to this sheet's root.
+
+```typescript
+for await (const change of sheet.diffFrom('HEAD~1', { records: true, patches: true })) {
+  // change.status: 'added' | 'modified' | 'deleted' | 'renamed'
+  // change.path
+  // change.src / change.dst  (when records: true)
+  // change.patch             (when patches: true)
+}
+```
+
+- `srcCommitHash` defaults to the empty tree (all current records are "added").
+- `opts.blobs?: boolean` — include raw blob handles
+- `opts.records?: boolean` — include parsed src/dst records
+- `opts.patches?: boolean` — include RFC 6902 (JSON Patch) patches between src and dst
+
+## Errors
+
+See [api/errors.md](errors.md). Common: `ValidationError`, `NotFoundError`, `PathTemplateError`, `IndexError`.
+
+## Coordinates with
+
+- [api/conventions.md](conventions.md)
+- [api/transaction.md](transaction.md)
+- [api/errors.md](errors.md)
+- [behaviors/path-templates.md](../behaviors/path-templates.md)
+- [behaviors/validation.md](../behaviors/validation.md)
+- [behaviors/normalization.md](../behaviors/normalization.md)
+- [behaviors/transactions.md](../behaviors/transactions.md)
+- [behaviors/indexing.md](../behaviors/indexing.md)
+- [behaviors/patch-semantics.md](../behaviors/patch-semantics.md)
+- [behaviors/attachments.md](../behaviors/attachments.md)

--- a/specs/api/store.md
+++ b/specs/api/store.md
@@ -1,0 +1,108 @@
+# API: Store
+
+A top-level typed wrapper that auto-discovers sheets in a repository and binds them to consumer validators.
+
+## Summary
+
+`openStore(repo, opts)` is the recommended entry point for TypeScript consumers. It:
+
+1. Discovers every sheet declared in `.gitsheets/*.toml`
+2. Optionally binds each to a consumer-supplied [Standard Schema](https://standardschema.dev) validator
+3. Returns a typed object whose properties are the sheets, with full TS inference
+
+## Construction
+
+```typescript
+import { openStore, openRepo } from 'gitsheets';
+import { z } from 'zod';
+
+const UserSchema = z.object({
+  slug: z.string(),
+  email: z.string().email(),
+  fullName: z.string(),
+});
+
+const ProjectSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  stage: z.enum(['idea', 'active', 'maintaining', 'dormant']),
+});
+
+const repo = await openRepo();
+const store = await openStore(repo, {
+  validators: {
+    users: UserSchema,
+    projects: ProjectSchema,
+    // sheets without entries here still work, typed as Sheet<Record<string, unknown>>
+  },
+});
+
+// fully typed against UserSchema
+const jane = await store.users.queryFirst({ slug: 'janedoe' });
+// jane is z.infer<typeof UserSchema> | undefined
+
+// store.transact bundles writes across sheets atomically
+await store.transact({ message: '...' }, async (tx) => {
+  await tx.users.upsert({ slug: 'jane', email: 'jane@x.org', fullName: 'Jane' });
+  await tx.projects.upsert({ slug: 'p1', title: 'P1', stage: 'idea' });
+});
+```
+
+## Type inference
+
+When a sheet has an entry in `validators`, its type flows through:
+
+- `store.<sheet>` is `Sheet<z.infer<typeof SchemaForThatSheet>>`
+- `tx.<sheet>` inside `store.transact` is the same Sheet type, scoped to the transaction's tree
+
+When a sheet does not have an entry in `validators`:
+
+- `store.<sheet>` is `Sheet<Record<string, unknown>>`
+- The JSON Schema in `.gitsheets/<sheet>.toml` still runs on every write — only the *TS-level* shape is `unknown`
+
+## Sheet discovery
+
+Sheets are discovered by enumerating `.gitsheets/*.toml`. The discovery happens once at `openStore` time. Sheets added after `openStore` are not auto-detected — call `openStore` again or use `repo.openSheet(name)` for one-offs.
+
+A sheet present in `validators` but missing from `.gitsheets/` throws `ConfigError` (`config_missing`) at `openStore` time.
+
+A sheet present in `.gitsheets/` but missing from `validators` is included as `Sheet<Record<string, unknown>>` — not an error.
+
+## Transactions
+
+`store.transact(opts, handler)` is a thin wrapper over `repo.transact` that passes a `tx` object exposing `tx.<sheet>` aliases:
+
+```typescript
+await store.transact({ message: '...' }, async (tx) => {
+  // tx.users: Sheet<User>      (transaction-scoped)
+  // tx.projects: Sheet<Project> (transaction-scoped)
+  // ... one tx.<sheet> per declared sheet
+});
+```
+
+The transaction's commit message, trailers, author, parent, etc. follow the same options as `repo.transact` (see [api/transaction.md](transaction.md)).
+
+## Why `Store` and not just `Repository`?
+
+`Repository.openSheets()` returns `{ [name]: Sheet<unknown> }` — a flat dictionary with no type-level connection between sheet names and shapes. `Store` adds:
+
+- Generic type inference from the `validators` map
+- Validator wiring (consumer's Zod/Valibot/etc. is automatically attached to each Sheet)
+- `transact` shorthand with `tx.<sheet>` aliases
+
+Both APIs are public. Use `Repository` for one-off scripts and dynamic discovery; use `Store` for typed applications.
+
+## Errors
+
+| Class | Code | When |
+|---|---|---|
+| `ConfigError` | `config_missing` | A sheet in `validators` doesn't have a `.gitsheets/<name>.toml` |
+| `ConfigError` | `config_invalid` | A sheet's config TOML is malformed |
+| (errors from `Sheet`) | (various) | Per-sheet operations propagate normally |
+
+## Coordinates with
+
+- [api/repository.md](repository.md)
+- [api/sheet.md](sheet.md)
+- [api/transaction.md](transaction.md)
+- [behaviors/validation.md](../behaviors/validation.md)

--- a/specs/api/transaction.md
+++ b/specs/api/transaction.md
@@ -1,0 +1,162 @@
+# API: Transaction
+
+A scope bundling one or more sheet mutations into a single commit.
+
+## Summary
+
+A `Transaction` is the unit of atomicity. Inside a transaction, mutations stage to a private tree built from the parent ref; on success the tree commits and the configured branch advances. On throw, the tree is discarded — no commit, no ref movement.
+
+Transactions are created by `Repository.transact(opts, handler)` and (in typed Store usage) by `Store.transact(opts, handler)`. They are not directly constructible by consumers.
+
+## Lifecycle
+
+```text
+1. parent ref resolves      → parentCommitHash
+2. private tree built       → copy of parent's tree
+3. handler runs             → mutations stage to the private tree
+4. handler resolves         → finalize: validate, write tree, commit, update ref
+   handler throws           → discard tree, no commit, no ref movement
+5. transaction closed       → mutex released
+```
+
+## Inside the handler
+
+The handler receives a `tx` object. The Sheet handles obtained from `tx.sheet(name)` are scoped to the transaction's tree — their writes do not become visible to other readers until the transaction commits.
+
+```typescript
+await repo.transact({ message: '...' }, async (tx) => {
+  const users = tx.sheet('users');
+  await users.upsert({ slug: 'jane', email: 'jane@x.org' });
+
+  const audit = tx.sheet('audits');
+  await audit.upsert({ action: 'user.create', subject: 'jane' });
+
+  return { created: 'jane' };
+});
+```
+
+`tx.sheet(name)` returns a `Sheet` with the same API as the outer `Repository.openSheet(name)` — except all writes route through the transaction's private tree.
+
+## Read isolation
+
+Reads through `tx.sheet(name)` see the transaction's in-flight mutations. Reads outside the transaction (e.g., a concurrent `repo.openSheet(name).queryFirst(...)`) see the *committed* state — the pre-transaction tree — until the transaction commits.
+
+## Commit message + trailers
+
+The commit's message is structured:
+
+```text
+<subject>
+
+<optional body>
+
+Trailer-Key: trailer-value
+Another-Trailer: another-value
+```
+
+- **Subject** = the `message` option (first line).
+- **Body** = anything after the first line of `message`.
+- **Trailers** = appended per `git interpret-trailers` rules. See [behaviors/transactions.md](../behaviors/transactions.md) for the format.
+
+Trailer keys use HTTP-header style: first letter capitalized, multi-word hyphenated, rest lowercase (`Subject-Id`, `User-Agent`, `Action`).
+
+## Author and committer
+
+- **Author** = `opts.author` or git config `user.name` / `user.email`.
+- **Committer** = `opts.committer` or `opts.author`.
+- Both can be omitted entirely if git config is set.
+
+## Concurrency
+
+One open transaction per `Repository` at a time. A concurrent `repo.transact(...)` call while another is open throws `TransactionError` (`transaction_in_progress`).
+
+Mutations made *outside* any open transaction (permissive mode) implicitly open and commit a single-mutation transaction; they too contend for the mutex.
+
+In **strict mode** (`repo.requireExplicitTransactions()`), mutations outside `repo.transact(...)` throw `TransactionError` (`transaction_required`).
+
+## Parent ref handling
+
+- If `opts.parent` is a branch name (e.g., `main`), the transaction's parent commit is `main`'s tip at transaction open; on commit, `main` advances to the new commit.
+- If `opts.parent` is a commit hash, the transaction commits onto that hash; if `opts.branch` is also set, that branch is updated.
+- If neither is set, defaults to `HEAD`'s ref.
+
+If the parent ref moves between transaction open and commit (a separate process committed), the transaction throws `TransactionError` (`parent_moved`). The handler's tree changes are discarded.
+
+## Permissive mode
+
+Standalone mutations (mutations called without an enclosing `repo.transact`) auto-open a transaction with a generated message:
+
+```text
+<sheet> upsert <path>
+```
+
+or `<sheet> delete <path>`, etc. The author defaults to git config. The branch defaults to `HEAD`'s ref.
+
+This makes simple scripts ergonomic. For request-bound workflows, consumers should call `repo.transact` explicitly to control the message/author/trailers.
+
+## Hooks
+
+None in v1.0. Pre-commit and post-commit hook points are deliberately not exposed — the API can grow them later without breaking existing callers.
+
+## Examples
+
+### Single-sheet write
+
+```typescript
+const { value, commitHash } = await repo.transact(
+  {
+    parent: 'main',
+    author: { name: 'Jane Doe', email: 'jane@x.org' },
+    message: 'janedoe: POST /api/users\n\nCreated by sign-up flow',
+    trailers: { Action: 'user.create', 'Subject-Slug': 'janedoe' },
+  },
+  async (tx) => {
+    return tx.sheet('users').upsert({ slug: 'janedoe', email: 'jane@x.org' });
+  }
+);
+```
+
+### Multi-sheet atomic write
+
+```typescript
+await repo.transact(
+  { message: 'admin: project.delete squadquest' },
+  async (tx) => {
+    await tx.sheet('projects').delete({ slug: 'squadquest' });
+    for await (const m of tx.sheet('memberships').query({ projectSlug: 'squadquest' })) {
+      await tx.sheet('memberships').delete(m);
+    }
+  }
+);
+```
+
+### Strict mode
+
+```typescript
+repo.requireExplicitTransactions();
+
+await sheet.upsert({ ... });          // throws TransactionError: transaction_required
+
+await repo.transact({ message: '...' }, async (tx) => {
+  await tx.sheet('users').upsert({ ... });  // ok
+});
+```
+
+## Errors
+
+| Class | Code | When |
+|---|---|---|
+| `TransactionError` | `transaction_in_progress` | Concurrent `repo.transact` attempt |
+| `TransactionError` | `transaction_required` | Mutation outside a transaction in strict mode |
+| `TransactionError` | `parent_moved` | Optimistic-concurrency conflict at commit |
+| `TransactionError` | `commit_failed` | `git commit-tree` or `update-ref` returned non-zero |
+| `RefError` | `ref_not_found` | `opts.parent` is a branch name that doesn't exist |
+| (any) | (any) | Errors thrown by the handler propagate out after tree discard |
+
+## Coordinates with
+
+- [api/repository.md](repository.md)
+- [api/sheet.md](sheet.md)
+- [api/store.md](store.md)
+- [api/errors.md](errors.md)
+- [behaviors/transactions.md](../behaviors/transactions.md)

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,0 +1,90 @@
+# Architecture
+
+Foundational tech decisions for gitsheets v1.0.
+
+## Goal
+
+A git-backed document store for low-volume, high-touch, human-scale data — readable through the JavaScript/TypeScript API and the `git sheet` CLI. The substrate is git itself: each record is a TOML file at a templated path; each mutation is a commit.
+
+Concrete v1.0 ship list lives across [GitHub issues #128–#141 in the 1.0.0 milestone](https://github.com/JarvusInnovations/gitsheets/milestone/1).
+
+## Stack
+
+| Layer | Choice | Why |
+|-------|--------|-----|
+| Language | **TypeScript** (strict) | Discoverability for consumers; type-flow from `.gitsheets/<sheet>.toml` JSON Schema through to typed `Store.<sheet>.upsert(...)` |
+| Module format | **ESM-only** | Modern Node + Bun + edge runtimes all handle ESM. Dual CJS/ESM build deferred until a concrete consumer needs it. |
+| Runtime | **Node.js ≥ 20**, **Bun ≥ 1** | Both have native ESM, both can host the CLI. No Deno target in v1.0. |
+| Tree primitives | **hologit (JS)** | Provides `TreeObject`, `BlobObject`, repo discovery, in-memory mutable trees, packfile access via the `git` CLI. v1.0 stays on the JS substrate. |
+| TOML | **`@iarna/toml`** | Preserves date types; canonical-sorted keys for byte-stable normalization. |
+| JSON Schema validation | **`ajv`** | Industry-standard, well-maintained, fast. Used for the persisted shape contract per [behaviors/validation.md](behaviors/validation.md). |
+| Runtime validator (consumer-supplied) | Any **[Standard Schema](https://standardschema.dev)** implementation | Consumer chooses Zod / Valibot / ArkType / Effect Schema. Gitsheets calls `~standard.validate`. |
+| JSON Merge Patch | **`json-merge-patch`** (or equivalent) | RFC 7396 semantics — see [behaviors/patch-semantics.md](behaviors/patch-semantics.md). |
+| Tests | **Vitest** (or `node --test` — pick at start of #137) | TS-native, ESM-native. Replaces Jest + Cypress. |
+| CLI argument parsing | **`yargs`** (current dep) or equivalent | Whatever gives clean TS types for command modules. |
+
+### What we deliberately don't use
+
+- **A custom query language.** Records are TOML files; queries are async iterators with in-memory equality predicates. Consumers needing richer filtering iterate and filter in their own code.
+- **A built-in HTTP server.** The pre-v1.0 `backend/server.js` is removed. Consumers building APIs around gitsheets build their own HTTP layer.
+- **Built-in full-text search.** Out of scope — consumers can build SQLite FTS / Meilisearch / etc. on top.
+- **Migration framework.** Schema migrations are one-off scripts that commit to the data repo. Don't generalize.
+- **An ORM-style models layer.** `Sheet<T>` is generic over the consumer's record type — no class-based ActiveRecord layer.
+
+## Packaging
+
+- **Single npm package: `gitsheets`** — library + CLI in one. Single `package.json`, single set of dependencies. Splitting into `@gitsheets/core` + `@gitsheets/cli` is deferred until there's a reason.
+- **Entry points:**
+  - `import { ... } from 'gitsheets'` → public library exports
+  - `bin/gitsheets` (also installed as `git-sheet` for the `git sheet <cmd>` invocation)
+- **Published artifacts:** built `dist/`, type definitions, source maps. No source TypeScript in the published package.
+
+## Repository layout
+
+```text
+gitsheets/
+├── src/                      # TypeScript library
+│   ├── cli/                  # CLI entry + command modules
+│   ├── path-template/        # path template parser + query traversal
+│   ├── errors.ts             # exported error classes
+│   ├── repository.ts         # Repository class
+│   ├── sheet.ts              # Sheet class
+│   ├── transaction.ts        # Transaction class
+│   ├── store.ts              # openStore + Store type
+│   └── index.ts              # public re-exports
+├── tests/                    # Vitest (or node --test) suite
+├── docs/                     # User-facing documentation (see #141)
+├── specs/                    # ← source of truth, this directory
+├── .claude/
+│   ├── agents/               # spec-drift-auditor
+│   └── commands/             # /audit-spec-drift
+├── .github/workflows/        # CI
+├── CLAUDE.md
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+The pre-v1.0 layout (`backend/lib/`, `backend/commands/`, `src/` Vue frontend, `cypress.json`, `vue.config.js`, etc.) is removed during the purge ([issue #128](https://github.com/JarvusInnovations/gitsheets/issues/128)).
+
+## What stays cross-cutting in the library
+
+These belong to the library and are not consumer concerns:
+
+- **TOML serialization** — sorted-key normalization, custom Date handling. Bytes on disk are deterministic for byte-stable git diffs.
+- **Path template rendering** — `${{ field }}` and `${{ expression }}` syntax, recursive `${{ field/** }}`, multi-variable per-segment.
+- **Tree mutation under the hood** — `tree.writeChild`, `tree.deleteChild`, `tree.getBlobMap` — surfaced via `Sheet` + `Transaction`.
+- **Git operations** — commit creation, ref updates, push. Surfaced via `Transaction` + the optional push daemon.
+- **Validation orchestration** — JSON Schema → optional Standard Schema → upsert. Errors bubble up as typed exceptions.
+
+## Distribution
+
+- **npm:** `gitsheets` (current owner: themightychris).
+- **Versioning:** semver. v1.0.0 is the cut after all `[1.0]`-tagged issues in the [1.0.0 milestone](https://github.com/JarvusInnovations/gitsheets/milestone/1) close. Patch releases inside 1.x preserve the documented API.
+- **Breaking changes** — only at major boundaries. The library's pre-1.0 API does not constrain v1.0 (the legacy `GitSheets` class is purged outright; no migration shim).
+
+## Holo-tree migration (v1.1)
+
+[Issue #127](https://github.com/JarvusInnovations/gitsheets/issues/127) tracks the swap to a Rust `holo-tree` crate via `napi-rs`. **This is a 1.1 internal-engine change with no public-API impact** — consumers should not see any difference, only ~100x faster tree operations.
+
+v1.0 ships on the current JS hologit substrate. The holo-tree migration begins after 1.0 closes.

--- a/specs/behaviors/attachments.md
+++ b/specs/behaviors/attachments.md
@@ -1,0 +1,148 @@
+# Behavior: Attachments
+
+## Rule
+
+A record may have any number of **attachments** — binary blobs colocated with the record in the data tree. Attachments are first-class: they participate in commits, diffs, and merges the same way records do.
+
+## Applies To
+
+- [api/sheet.md](../api/sheet.md) — `getAttachment`, `getAttachments`, `setAttachment`, `setAttachments`
+- [behaviors/path-templates.md](path-templates.md) — query traversal skips attachment subtrees
+
+## Storage layout
+
+For a record at `<sheetRoot>/<recordPath>.toml`, attachments live in a sibling directory at `<sheetRoot>/<recordPath>/`:
+
+```text
+users/janedoe.toml              # the record
+users/janedoe/avatar.jpg        # attachment 1
+users/janedoe/avatar-128.jpg    # attachment 2
+users/janedoe/cover.png         # attachment 3
+```
+
+The record's own file (`<recordPath>.toml`) and the attachment directory (`<recordPath>/`) coexist as siblings in the tree. Git handles this without conflict.
+
+## Naming
+
+Attachment names are simple filenames — no slashes. Nested subdirectories under an attachment directory are reserved for future use; v1.0 attachments are flat per record.
+
+The attachment name typically encodes the type via extension (`.jpg`, `.pdf`, `.zip`). The library does not enforce extension correctness or content-type validation — that's the consumer's responsibility.
+
+## API
+
+### `sheet.setAttachment(record, name, blob)`
+
+Stage a single attachment.
+
+```typescript
+const blob = await repo.writeBlobFromFile('/path/to/avatar.jpg');
+await sheet.setAttachment(record, 'avatar.jpg', blob);
+```
+
+`blob` is a hologit `BlobObject` (or whatever the new substrate provides — see the implementation note below). Helper methods exist for creating blobs from files, buffers, or streams.
+
+### `sheet.setAttachments(record, map)`
+
+Stage multiple attachments at once.
+
+```typescript
+await sheet.setAttachments(record, {
+  'avatar.jpg': avatarBlob,
+  'avatar-128.jpg': thumbnailBlob,
+});
+```
+
+### `sheet.getAttachments(record)`
+
+Returns a blob map keyed by attachment name. Used for browsing.
+
+```typescript
+const attachments = await sheet.getAttachments(record);
+// → { 'avatar.jpg': BlobObject, 'avatar-128.jpg': BlobObject }
+```
+
+Returns `null` if the record has no attachment directory.
+
+### `sheet.getAttachment(record, name)`
+
+Returns the named attachment's blob, or `null` if absent.
+
+```typescript
+const blob = await sheet.getAttachment(record, 'avatar.jpg');
+if (blob) {
+  const buf = await blob.read();   // Buffer
+}
+```
+
+### `sheet.deleteAttachment(record, name)` _(new in v1.0)_
+
+Remove a single attachment.
+
+```typescript
+await sheet.deleteAttachment(record, 'avatar.jpg');
+```
+
+The pre-v1.0 API didn't expose a delete; consumers had to manipulate the tree directly. v1.0 adds this for symmetry.
+
+### `sheet.deleteAttachments(record)` _(new in v1.0)_
+
+Remove all attachments for a record.
+
+## Iterator API (deferred)
+
+A higher-level iterator surface is filed as [#140](https://github.com/JarvusInnovations/gitsheets/issues/140):
+
+```typescript
+for await (const { name, mimeType, blob } of sheet.attachments(record)) { ... }
+```
+
+Sugar over `getAttachments`. Not in v1.0; the existing methods cover the use case.
+
+## Atomicity
+
+Attachment changes are part of the transaction's tree. They stage and commit atomically with record changes:
+
+```typescript
+await repo.transact({ message: 'Update avatar' }, async (tx) => {
+  await tx.sheet('users').upsert(updatedUser);                // record change
+  await tx.sheet('users').setAttachment(updatedUser, 'avatar.jpg', blob);  // attachment change
+  // Both land in the same commit
+});
+```
+
+If the handler throws, both changes are discarded.
+
+## Cascade on record delete
+
+When a record is deleted via `Sheet.delete(record)`, **its attachment directory is also deleted in the same operation.** The pre-v1.0 behavior left attachments orphaned in the tree; v1.0 fixes this.
+
+For "preserve attachments across record deletion" use cases (rare), the consumer can move the attachment subtree to a different location before deleting the record.
+
+## Query interaction
+
+The `query` traversal recognizes that a directory named `<recordName>/` next to a file `<recordName>.toml` is an attachment container, not a nested record. It descends into the directory only for `getAttachments` calls — never for query iteration. See [behaviors/path-templates.md](path-templates.md).
+
+This means a sheet with `path = "${{ slug }}"` and records at `users/janedoe.toml` + attachments at `users/janedoe/avatar.jpg` works correctly — `query({})` yields only `janedoe`, not also the avatar.
+
+## Binary diffs
+
+Git handles binary blob diffs by recording before/after blob hashes. Gitsheets' `Sheet.diffFrom` includes attachment changes when scanning the record's path — but parses them as blob-diff records (no `records: true` payload, since attachments aren't TOML).
+
+For diffing the attachment content itself (image diffs, PDF text extraction), consumers run their own tools against the blob hashes.
+
+## Size limits
+
+Gitsheets imposes no inherent size limit. Practical limits come from git itself:
+
+- Single blob: git happily stores multi-GB blobs but performance degrades
+- Repo total: git LFS is the conventional answer for large binary repos
+- For attachments larger than ~10 MB, consider whether the data belongs in the gitsheets repo at all or in object storage referenced by URL from the record
+
+The library does not invoke git LFS automatically. Consumers wanting LFS configure it via `.gitattributes` in the data repo themselves.
+
+## Coordinates with
+
+- [api/sheet.md](../api/sheet.md)
+- [behaviors/path-templates.md](path-templates.md)
+- [behaviors/transactions.md](transactions.md)
+- [GitHub #140](https://github.com/JarvusInnovations/gitsheets/issues/140) — iterator API (deferred)

--- a/specs/behaviors/indexing.md
+++ b/specs/behaviors/indexing.md
@@ -1,0 +1,140 @@
+# Behavior: Secondary Indexing
+
+## Rule
+
+A `Sheet` may declare one or more **secondary indices** for fast lookup by a derived key — typically a field that isn't in the path template. Indices are built and kept in process memory; they are not persisted to the data repo.
+
+Indices supplement the path template (the *primary* index, which determines record locations on disk). The path template handles the dominant access pattern; secondary indices handle the others.
+
+## Applies To
+
+- [api/sheet.md](../api/sheet.md) — `defineIndex`, `findByIndex`
+- [api/repository.md](../api/repository.md) — Sheet instances obtained via `repo.openSheet` and `repo.openSheets`
+- [api/store.md](../api/store.md) — Store-wrapped sheets get indices defined the same way
+
+## Declaration
+
+```typescript
+sheet.defineIndex(
+  name: string,
+  opts?: { unique?: boolean; eager?: boolean },
+  keyFn: (record: T) => string | undefined,
+): void;
+```
+
+- `name` — identifier used by `findByIndex`. Unique within the sheet.
+- `opts.unique` — default `false`. If `true`, each key maps to at most one record.
+- `opts.eager` — default `false`. If `true`, the index is built at sheet-open time.
+- `keyFn` — called per record. Returns the index key (string) or `undefined` to exclude the record from the index.
+
+Composite keys: concatenate inside `keyFn` (`record.projectId + ':' + record.status`).
+
+```typescript
+sheet.defineIndex('byEmail', { unique: true }, (r) => r.email.toLowerCase());
+sheet.defineIndex('byProjectAndStatus', (r) => `${r.projectId}:${r.status}`);
+```
+
+## Lookup
+
+```typescript
+sheet.findByIndex(name: string, key: string): Promise<T | undefined>;       // unique
+sheet.findByIndex(name: string, key: string): Promise<T[]>;                  // non-unique
+```
+
+The return type depends on whether the index was declared unique. TS overloads disambiguate.
+
+Throws `IndexError` (`index_not_defined`) if `name` isn't declared on this sheet.
+
+## Build timing
+
+### Lazy (default)
+
+The index is empty until the first `findByIndex(name, ...)` call for that name. On first call:
+
+1. Iterate every record in the sheet
+2. Call `keyFn(record)` for each
+3. Populate the in-memory index
+4. Serve the lookup
+5. Subsequent lookups hit the populated index
+
+### Eager (`opts.eager: true`)
+
+The index is built at `sheet.defineIndex` time (synchronously enough — see below).
+
+```typescript
+sheet.defineIndex('byLegacyId', { unique: true, eager: true }, (r) => r.legacyId);
+// → returns after the iteration completes; index ready
+```
+
+`defineIndex` with `eager: true` returns a `Promise<void>` that resolves when the build completes. The lazy variant returns `void` synchronously.
+
+## Invalidation
+
+### On `Sheet.upsert(record)` / `Sheet.delete(record)` (same instance)
+
+Indices update synchronously after the mutation succeeds. The record's old keys (computed from the *previous* on-disk state, when available) are removed from each index; the new keys are added.
+
+Without a pre-mutation read (e.g., a brand-new upsert), there's no old key to remove — straightforward addition.
+
+For updates where the record changed identity-fields (the key from `keyFn` differs from before), the old key is removed and the new key is added in one synchronous step.
+
+### On out-of-band ref movement
+
+If the sheet's underlying ref moves due to a change made outside this `Sheet` instance — another process committed, the data repo was re-clone, etc. — every index on the sheet is marked dirty.
+
+Next `findByIndex(name, ...)` call:
+
+1. Detects the dirty state (by comparing the current ref's commit hash against the hash captured at last build)
+2. Discards the existing index for that name
+3. Re-runs the build pipeline
+4. Serves the lookup
+
+Other indices on the same sheet don't rebuild until accessed.
+
+### Across multiple `Sheet` instances
+
+Two `Sheet` instances opened against the same repo (e.g., a `Sheet` from `repo.openSheet('users')` and another from `store.users`) maintain *independent* indices. Mutations against one don't update the other.
+
+This is a deliberate simplification — coordinating indices across instances would require an event bus the library otherwise doesn't need. Consumers building applications typically hold one `Sheet` (or one `Store`) per repo per process; the multi-instance scenario is unusual.
+
+## Unique conflicts
+
+When `opts.unique: true`:
+
+- **Lazy build:** the conflict throws on first `findByIndex` call (or any `upsert`/`delete` that triggers a build). `IndexError` (`index_unique_conflict`) names both conflicting paths.
+- **Eager build:** the conflict throws from the `defineIndex` Promise.
+- **Mutation that would create a conflict:** `Sheet.upsert(record)` throws `IndexError` (`index_unique_conflict`) before writing to the tree. The mutation is aborted; the tree is unchanged. (This is the *only* index-related validation that affects writes — non-unique indices never block a write.)
+
+## Memory + performance
+
+- Each index entry costs roughly `key.length + 24` bytes plus a reference to the record (which is held by the sheet's in-memory record cache, not duplicated).
+- A 10,000-record sheet with a single unique index on a 32-char key: ~600 KB.
+- Build time for 10,000 records on commodity hardware: well under a second.
+
+Memory limits are the consumer's concern. The library doesn't bound index size; consumers running on memory-constrained hosts should be deliberate about which indices to declare.
+
+## Persisted indices?
+
+Out of scope for v1.0. The reasoning:
+
+- Most use cases at gitsheets' "civic scale" target rebuild in <1s
+- Persistence requires choosing an on-disk format, deciding when to rebuild on schema change, and handling crash-during-write — substantial design + test surface
+- If a consumer's corpus grows past the threshold, that's the time to design persisted indices with real requirements in hand
+
+See [deferred.md](../deferred.md#persisted-indexes).
+
+## Lookups vs. queries
+
+`findByIndex` is an in-memory hash lookup — O(1). `Sheet.query` is a tree walk + filter — O(records) in the worst case (path template helps when applicable). They're complementary:
+
+- Use `findByIndex` when you have a derived key and need fast point lookups
+- Use `query` when you need to enumerate or filter on path-template fields
+
+There's no `findManyByIndex` for non-unique indices because `findByIndex` already returns an array when the index is non-unique.
+
+## Coordinates with
+
+- [api/sheet.md](../api/sheet.md)
+- [api/errors.md](../api/errors.md)
+- [behaviors/path-templates.md](path-templates.md)
+- [GitHub #134](https://github.com/JarvusInnovations/gitsheets/issues/134) — implementation issue

--- a/specs/behaviors/normalization.md
+++ b/specs/behaviors/normalization.md
@@ -1,0 +1,150 @@
+# Behavior: Canonical Normalization
+
+## Rule
+
+Records are written to disk in a **canonical form** so that logically-equal records produce byte-identical TOML. This makes git diffs meaningful (changes show real changes, not key reorderings) and makes byte-level merging viable for propose-review flows.
+
+Normalization is separate from validation:
+
+- **Validation** (see [validation.md](validation.md)) decides *whether* a record is acceptable.
+- **Normalization** decides *how* that record's bytes are written.
+
+Both run on every write.
+
+## Applies To
+
+- [api/sheet.md](../api/sheet.md) — `upsert`, `patch`, `normalizeRecord`
+- [`.gitsheets/<sheet>.toml`](../concepts.md#sheet) — `[gitsheet.fields.<name>]` config
+
+## Rules
+
+### Object keys
+
+All object keys are alphabetically sorted, **deep**. A record like:
+
+```javascript
+{ slug: 'jane', email: 'jane@x.org', fullName: 'Jane' }
+```
+
+writes as TOML with keys in alphabetical order:
+
+```toml
+email = 'jane@x.org'
+fullName = 'Jane'
+slug = 'jane'
+```
+
+This applies recursively to nested objects (TOML tables).
+
+### Array element order
+
+By default, **arrays preserve insertion order**. This is the right default — many arrays are intrinsically ordered (a list of steps, a timeline).
+
+For arrays whose order is *not* significant, a sheet declares a sort rule:
+
+```toml
+[gitsheet.fields.tags.sort]
+# ...spec below
+```
+
+When a sort rule is declared, the array is sorted before write.
+
+### Sort rule formats
+
+Three equivalent forms:
+
+**Array of field names** (most concise):
+
+```toml
+[gitsheet.fields.tags]
+sort = ['namespace', 'slug']
+```
+
+Sorts an array of objects by `namespace` then `slug`, ascending.
+
+**Table of field → direction:**
+
+```toml
+[gitsheet.fields.tags.sort]
+namespace = 'ASC'
+slug = 'ASC'
+```
+
+Same as above, but lets you declare descending order per field:
+
+```toml
+[gitsheet.fields.audit.sort]
+timestamp = 'DESC'
+```
+
+**Inline JS expression** (most flexible):
+
+```toml
+[gitsheet.fields.relationships]
+sort = '''
+  if (a.priority !== b.priority) return b.priority - a.priority;
+  return a.label.localeCompare(b.label);
+'''
+```
+
+The string is the *body* of a sort comparator — `(a, b) => { <body> }`. Used when the comparison is non-trivial.
+
+**Bare boolean** (sort scalars):
+
+```toml
+[gitsheet.fields.aliases]
+sort = true
+```
+
+Sorts an array of strings using locale-aware comparison (`localeCompare` with `sensitivity: 'base'`, `numeric: true`, `ignorePunctuation: true`).
+
+### TOML serialization details
+
+- The library uses `@iarna/toml` for serialization. Dates, datetimes, and date-times round-trip correctly (a Date in the record becomes the matching TOML date type).
+- Multi-line strings use TOML's triple-quoted form when the string contains newlines or exceeds a length threshold; otherwise inline.
+- Null values are *omitted* from the output. TOML can't represent `null`; absent fields read back as `undefined` and are treated as null by validation.
+- Empty arrays and empty objects are preserved (they have semantic meaning distinct from absent).
+
+### File bytes
+
+After all of the above:
+
+1. Apply array sort rules (if declared)
+2. Sort object keys (deep)
+3. Serialize via `@iarna/toml`
+4. The resulting bytes are what's written to the blob
+
+The same record always produces the same bytes, regardless of the order fields were set on the input object.
+
+## Validation order vs. normalization order
+
+Per [validation.md](validation.md):
+
+1. JSON Schema validation
+2. Standard Schema validation (may transform the record)
+3. **Normalization** (key sort, array sort)
+4. TOML serialize
+5. Write to tree
+
+Normalization runs after the Standard Schema transform — so if a Zod schema transforms `tag: 'TYPESCRIPT'` to `tag: 'typescript'`, the normalized output reflects the transform.
+
+## Hash determinism
+
+Because the on-disk bytes are deterministic, the git blob hash is deterministic per logical-record state. Two writes of the same record from different code paths produce the same blob hash — meaning git sees no change to commit.
+
+This is load-bearing for:
+
+- Reproducible imports (`upsert` of identical input is idempotent in the commit graph)
+- Reliable propose-review flows (a "proposal" branch that re-writes the same records doesn't show as different)
+- Hash-based caching (e.g., the parsed-record cache in #138)
+
+## Limits
+
+- **Float precision** — `@iarna/toml` preserves IEEE-754 doubles. For decimal arithmetic, consumers should use string representation or a decimal library; the canonical form is still byte-stable for any given input.
+- **Custom classes** — only TOML-representable types round-trip. Anything else (functions, symbols, class instances beyond Date) should be omitted from records or stringified by the consumer's Standard Schema layer.
+
+## Coordinates with
+
+- [api/sheet.md](../api/sheet.md)
+- [behaviors/validation.md](validation.md)
+- The Canonical Sorting doc in [docs/canonical-sorting.md](../../docs/canonical-sorting.md) (pre-v1.0; will be incorporated into the v1.0 docs in [#141](https://github.com/JarvusInnovations/gitsheets/issues/141))

--- a/specs/behaviors/patch-semantics.md
+++ b/specs/behaviors/patch-semantics.md
@@ -1,0 +1,147 @@
+# Behavior: Patch Semantics (RFC 7396)
+
+## Rule
+
+`Sheet.patch(query, partial)` and the CLI's `--patch` flag use **[RFC 7396 JSON Merge Patch](https://www.rfc-editor.org/rfc/rfc7396)** to combine the partial document with the existing record.
+
+A standards-based merge with predictable rules — replacing the pre-v1.0 `deepmerge` behavior, which had multiple non-obvious edge cases.
+
+## Applies To
+
+- [api/sheet.md](../api/sheet.md) — `patch(query, partial)`
+- [api/cli.md](../api/cli.md) — `git sheet upsert --patch`
+
+## RFC 7396 in one paragraph
+
+Apply each key of the patch to the target:
+
+- If the patch value is `null`, **delete** that key from the target
+- If the patch value is an object, **recursively merge** with the target's value at that key (which must also be an object or absent)
+- If the patch value is anything else (scalar, array), **replace** the target's value at that key
+
+That's the entire spec. Arrays replace as atomic values — element-level merging is *not* part of RFC 7396 and is intentionally not supported.
+
+## Pipeline
+
+When `sheet.patch(query, partial)` is called:
+
+1. `queryFirst(query)` → existing record. If no match, throw `NotFoundError` (`record_not_found`).
+2. Apply RFC 7396 to combine `partial` with the existing record → new record.
+3. Validate the new record (JSON Schema + optional Standard Schema, per [validation.md](validation.md)). On failure, throw `ValidationError`.
+4. Apply canonical normalization (per [normalization.md](normalization.md)).
+5. Render path, write to tree (within the current transaction).
+
+Returns `Promise<{ blob, path }>` — the same shape as `upsert`.
+
+## Worked examples
+
+### Update a field
+
+```javascript
+existing = { slug: 'jane', email: 'jane@old.org', fullName: 'Jane' }
+patch    = { email: 'jane@new.org' }
+result   = { slug: 'jane', email: 'jane@new.org', fullName: 'Jane' }
+```
+
+### Delete a field
+
+```javascript
+existing = { slug: 'jane', email: 'jane@x.org', bio: 'Hello!' }
+patch    = { bio: null }
+result   = { slug: 'jane', email: 'jane@x.org' }       // bio removed
+```
+
+### Replace an array
+
+```javascript
+existing = { slug: 'jane', tags: ['foo', 'bar'] }
+patch    = { tags: ['baz'] }
+result   = { slug: 'jane', tags: ['baz'] }              // replaced, not concatenated
+```
+
+This is the surprising case for consumers expecting deep-merge behavior. The CLI help text and `docs/` explicitly call it out.
+
+### Merge nested objects
+
+```javascript
+existing = { slug: 'jane', address: { city: 'Philly', zip: '19103' } }
+patch    = { address: { zip: '19104' } }
+result   = { slug: 'jane', address: { city: 'Philly', zip: '19104' } }    // recursive merge
+```
+
+### Delete a nested field
+
+```javascript
+existing = { slug: 'jane', address: { city: 'Philly', zip: '19103' } }
+patch    = { address: { zip: null } }
+result   = { slug: 'jane', address: { city: 'Philly' } }
+```
+
+### Replace a nested object wholesale
+
+```javascript
+existing = { slug: 'jane', address: { city: 'Philly', zip: '19103' } }
+patch    = { address: { city: 'Pittsburgh' } }
+result   = { slug: 'jane', address: { city: 'Pittsburgh' } }   // zip is deleted? NO!
+```
+
+Wait — actually:
+
+```javascript
+result   = { slug: 'jane', address: { city: 'Pittsburgh', zip: '19103' } }
+```
+
+Because the patch value `{ city: 'Pittsburgh' }` is an object, RFC 7396 recursively merges. To *replace* the address object wholesale, the patch would need to first delete all of address's keys, or set `address: null` and then `upsert` (not patch) the new shape.
+
+In practice, "replace this whole subtree" is `upsert`, not `patch`. If a consumer wants atomic replace-then-set behavior, they use `upsert` with the full record.
+
+## Vs. `upsert`
+
+| | `upsert(newRecord)` | `patch(query, partial)` |
+|---|---|---|
+| Read existing first | No (write only) | Yes (`queryFirst(query)`) |
+| Required input | full record | partial — only changed fields |
+| Missing-record behavior | Creates a new one | `NotFoundError` |
+| Replace whole field | Pass new value | Pass new value (non-object) |
+| Delete field | Omit from record (creates a full replacement that doesn't have the field) | Pass `null` |
+
+Use `upsert` when you have the whole record. Use `patch` when you have just the changes.
+
+## Vs. pre-v1.0 `deepmerge` behavior
+
+The pre-v1.0 `commands/upsert.js` `--patch-existing` flag used the `deepmerge` package, which has different rules:
+
+| Operation | deepmerge | RFC 7396 |
+|---|---|---|
+| Arrays | **Concat** by default (configurable) | **Replace** |
+| `null` values | Treat as a value (set to `null`) | **Delete** the key |
+| Nested objects | Merge recursively | Merge recursively (same) |
+| Scalars | Replace | Replace (same) |
+
+The shift to RFC 7396 is a **breaking change** for any consumer relying on the pre-v1.0 array-concat behavior. The CLI's `--patch` flag uses RFC 7396; there is no compatibility mode.
+
+Consumers who *do* want array-concat semantics can do it themselves:
+
+```typescript
+// before patch
+const existing = await sheet.queryFirst({ slug: 'jane' });
+const merged = { ...existing, tags: [...existing.tags, ...newTags] };
+await sheet.upsert(merged);
+```
+
+## Implementation note
+
+The library uses the [`json-merge-patch`](https://www.npmjs.com/package/json-merge-patch) package (or equivalent) for the merge operation. The `deepmerge` package is removed from `package.json` during the [#128 purge](https://github.com/JarvusInnovations/gitsheets/issues/128).
+
+## Conformance
+
+The RFC 7396 specification provides an [appendix of test cases](https://www.rfc-editor.org/rfc/rfc7396#appendix-A). All of them are part of the v1.0 test suite.
+
+## Coordinates with
+
+- [api/sheet.md](../api/sheet.md)
+- [api/cli.md](../api/cli.md)
+- [behaviors/validation.md](validation.md)
+- [behaviors/normalization.md](normalization.md)
+- [behaviors/transactions.md](transactions.md)
+- [GitHub #133](https://github.com/JarvusInnovations/gitsheets/issues/133) — implementation issue

--- a/specs/behaviors/path-templates.md
+++ b/specs/behaviors/path-templates.md
@@ -1,0 +1,132 @@
+# Behavior: Path Templates
+
+## Rule
+
+Every sheet declares a **path template** that determines where each record's TOML file lives in the data tree. The template serves two purposes — *where to write* a record, and *how to prune the search* when querying.
+
+## Applies To
+
+- [api/sheet.md](../api/sheet.md) — `upsert`, `delete`, `query`, `queryFirst`, `queryAll`, `pathForRecord`
+- [`.gitsheets/<sheet>.toml`](../concepts.md#sheet) — `[gitsheet].path` config
+
+## Syntax
+
+The template is a slash-separated string of components. Each component is either literal text, a field reference, or a JS expression.
+
+| Form | Example | Meaning |
+|---|---|---|
+| Literal | `users/by-domain/` | Static path text |
+| Field reference | `${{ slug }}` | The value of `record.slug`, rendered to string |
+| Expression | `${{ slug.toLowerCase() }}` | Arbitrary JS expression with record fields in scope |
+| Recursive | `${{ path/** }}` | The value of the field, which may itself contain `/` — used for nested-path fields |
+| Prefix/suffix | `user-${{ id }}.draft` | Literal prefix/suffix attached to an expression |
+
+A template is parsed once per sheet and cached.
+
+### Examples
+
+```toml
+# Simple unique-field key
+path = "${{ slug }}"
+
+# Composite key (two-level directory)
+path = "${{ domain }}/${{ username }}"
+
+# Sharded by date
+path = "${{ publishedAt.getFullYear() }}/${{ publishedAt.getMonth() }}/${{ slug }}"
+
+# Multi-variable per segment (#105 fix)
+path = "${{ year }}/${{ status }}--${{ id }}"
+
+# Nested path field (the field's value contains slashes)
+path = "${{ contentPath/** }}"
+```
+
+## Rendering
+
+`Template.render(record)` walks each component, calls `render(record)` on the component, and joins the results with `/`. Adds `.toml` as the final extension when writing.
+
+If any component returns `null` or `undefined`, the render fails with `PathTemplateError` (`path_render_failed`). The error names which component couldn't render.
+
+### Expression rendering
+
+Expressions are evaluated in a sandbox (`vm.runInNewContext`) with the record's fields bound as identifiers via `with(record) { return (<expression>) }`. Undefined-identifier errors are treated as "this component is un-renderable" (returns `undefined`) rather than thrown, since they're typically expected at *query* time (see below).
+
+This mirrors the pre-v1.0 behavior; documented here so the v1.0 TS rewrite preserves it.
+
+### Multi-variable per segment
+
+Components can contain multiple expressions and literal text:
+
+```text
+path = "${{ year }}/${{ status }}--${{ id }}"
+```
+
+Renders as `2026/active--12345`. The pre-v1.0 implementation had a bug where multiple expressions per segment failed to render — [#105](https://github.com/JarvusInnovations/gitsheets/issues/105). The v1.0 rewrite fixes this with a regression test.
+
+### Invalid characters
+
+The rendered path is validated against filesystem constraints. Windows is the strictest target — the characters `< > : " | ? *` and control codes are rejected.
+
+`PathTemplateError` (`path_invalid_chars`) is thrown with the offending component named. Strategy options (omit / slugify / throw) are not implementation choices — throw is the v1.0 behavior. Consumers wanting slugification do it themselves in a `${{ slugify(name) }}` expression.
+
+This addresses [#14](https://github.com/JarvusInnovations/gitsheets/issues/14).
+
+## Query traversal
+
+When a query specifies fields that the path template uses, gitsheets prunes the tree walk to only matching subtrees instead of reading every record.
+
+### Algorithm
+
+```text
+For each component of the path template, in order:
+  - If the component is a literal: walk into that named subtree.
+  - If the component is a field reference and the query has a value for that field:
+      - Compute the rendered value.
+      - Walk into that named subtree (if it exists; else: no results).
+  - If the component is a field reference and the query has NO value for that field:
+      - Walk into ALL children of the current subtree.
+      - Recurse the algorithm with the next component, against each child.
+  - If the component is the last and is a field reference WITH a value:
+      - Open `<rendered>.toml` directly. Apply the in-memory equality filter from queryMatches(query, record). Yield if it matches.
+  - If the component is the last and is a field reference WITHOUT a value:
+      - List all `*.toml` children. For each, parse and apply queryMatches. Yield if it matches.
+  - If the component is recursive (`${{ field/** }}`):
+      - Walk the subtree as a flat blob map (recursive); apply queryMatches.
+```
+
+### Practical implication
+
+A sheet with `path = "${{ domain }}/${{ username }}"` and a query `{ domain: 'af.mil' }` reads only the `af.mil/` subtree. A query with no `domain` reads all subtrees but is still O(records). A query `{ domain: 'af.mil', username: 'GrandmaCOBOL' }` reads exactly one file.
+
+### Function-valued filter entries
+
+`query({ slug: (value) => value.startsWith('jane') })` cannot prune by the path template (the function is opaque). The traversal falls back to listing all subtrees. Equality predicates are preferred for fields used in path templates.
+
+## Recursive components (`field/**`)
+
+A `${{ field/** }}` component handles fields whose value contains `/`. Example: a CMS where `path = "${{ contentPath/** }}"` and `contentPath = "docs/guides/intro"` writes to `docs/guides/intro.toml`.
+
+Query against a recursive component reads the full subtree as a blob map; it doesn't prune.
+
+Only one recursive component per template (the final one). Multiple recursive components would create ambiguous paths.
+
+## Attachments and the path template
+
+Attachments live at `<recordPath>/<attachmentName>`. The query traversal skips them because:
+
+- Path-template traversal only follows `.toml` files at record positions
+- Sub-tree directories named `<record-without-.toml>` are treated as attachment containers, not as nested records
+
+See [behaviors/attachments.md](attachments.md).
+
+## Caching
+
+Templates are parsed once per template string (process-wide cache by string). Re-parsing on every render would be wasteful and is avoided.
+
+## Coordinates with
+
+- [api/sheet.md](../api/sheet.md)
+- [behaviors/attachments.md](attachments.md)
+- [GitHub #105](https://github.com/JarvusInnovations/gitsheets/issues/105) — multi-variable component bug
+- [GitHub #14](https://github.com/JarvusInnovations/gitsheets/issues/14) — invalid character handling

--- a/specs/behaviors/push-sync.md
+++ b/specs/behaviors/push-sync.md
@@ -1,0 +1,153 @@
+# Behavior: Push Sync
+
+## Rule
+
+A `Repository` can run an optional **push daemon** that asynchronously pushes new commits to a configured git remote, with retry and exponential backoff. Push-only — the daemon never pulls.
+
+## Applies To
+
+- [api/repository.md](../api/repository.md) — `repo.startPushDaemon(opts)`
+- [api/transaction.md](../api/transaction.md) — commits produced by `repo.transact` are what the daemon pushes
+
+## Why push-only
+
+A consumer process that writes to gitsheets is the *single writer* (see [behaviors/transactions.md](transactions.md)). Pulling from the remote at runtime would risk overwriting in-memory state and unstaged tree changes — neither is recoverable cleanly.
+
+If a consumer needs to incorporate changes from elsewhere (a manual edit, a separate process), the canonical path is: stop the consumer, pull, restart. The library does not automate this.
+
+## Lifecycle
+
+```text
+1. Consumer calls repo.startPushDaemon(opts) → PushDaemon handle
+2. Daemon registers a listener for ref-update events (or polls; impl detail)
+3. On each new commit produced by `repo.transact`:
+     - Add to push queue
+     - Attempt push immediately
+     - On success: emit 'push' event
+     - On failure: schedule retry with backoff; emit 'error' / 'retry' events
+4. Consumer optionally inspects daemon.status() at any time
+5. Consumer calls daemon.stop() at shutdown:
+     - Stop accepting new commits to the queue
+     - Drain in-flight retries (with a configurable timeout)
+     - Resolve daemon.stop()'s Promise
+```
+
+## Push command
+
+The underlying operation is `git push <remote> <branch>` with no `--force`. **Regular fast-forward only.**
+
+If the remote rejects the push (non-fast-forward, "remote contains work that you do not have"), the daemon does not retry — it emits an `error` event and surfaces a hard error in `daemon.status()`. The consumer needs to intervene; a never-force-push policy is non-negotiable.
+
+The daemon does *not* attempt to merge or rebase. The local commit history is the source of truth.
+
+## Backoff
+
+Default: exponential, base 1 second, multiplier 2, cap 1 hour.
+
+| Attempt | Delay |
+|---|---|
+| 1 | 1s |
+| 2 | 2s |
+| 3 | 4s |
+| 4 | 8s |
+| 5 | 16s |
+| ... | ... |
+| Stable max | 3600s |
+
+Configurable:
+
+```typescript
+repo.startPushDaemon({
+  remote: 'origin',
+  backoff: { base: 5000, multiplier: 1.5, cap: 1800_000 },  // 5s base, 30min cap
+  maxRetries: 100,
+});
+```
+
+Or accept the default with `backoff: 'exponential'`.
+
+`maxRetries` defaults to `Infinity` — the daemon keeps retrying until success, or until `daemon.stop()` is called.
+
+## Events
+
+```typescript
+daemon.on('push',  ({ commit, durationMs }) => { ... });
+daemon.on('retry', ({ commit, attempt, nextDelayMs }) => { ... });
+daemon.on('error', ({ commit, err, attempt }) => { ... });
+daemon.on('stopped', () => { ... });
+```
+
+- `push` — successful push. `durationMs` is wall-clock for the push attempt.
+- `retry` — a failed attempt has been scheduled for retry. Fires *before* the delay.
+- `error` — a failure occurred. May or may not be retried; if retried, a `retry` event follows.
+- `stopped` — emitted after `daemon.stop()` completes draining.
+
+Consumers building observability surfaces typically attach to `push`, `retry`, `error` for Prometheus / structured-logging fan-out.
+
+## Status
+
+```typescript
+daemon.status();
+// → {
+//   running: boolean,
+//   lastPushAt: ISO 8601 | null,
+//   lastError: { message: string, at: ISO 8601, attempt: number } | null,
+//   pendingCommits: number,
+//   currentBackoffMs: number | null,        // current delay, if a retry is scheduled
+//   currentAttempt: number | null,           // which attempt we're on for the next commit
+// }
+```
+
+Cheap to call — no I/O, just in-memory snapshot.
+
+## Stopping
+
+```typescript
+await daemon.stop({ timeoutMs?: 30_000 });
+```
+
+- Stops accepting new commits
+- Waits for the currently-in-flight push (if any) to complete or fail
+- Drains the retry queue up to `timeoutMs` (default 30s)
+- After the timeout, abandons remaining queued commits — they remain in the local repo and can be retried by restarting the daemon
+- Resolves once the daemon is fully idle
+
+`daemon.stop()` is the only correct way to end the daemon. Letting the process exit while the daemon is running may leave commits unpushed.
+
+## Authentication
+
+**Out of scope for the daemon.** The daemon runs `git push` and inherits the process's git auth configuration:
+
+- SSH: `GIT_SSH_COMMAND`, ssh-agent, `~/.ssh/config`
+- HTTPS: git credential helper, env-injected token in the remote URL
+- GitHub App: token via credential helper (`gh auth setup-git` or equivalent)
+
+The library doesn't know what credentials are in play. If a `git push` fails authentication, the daemon emits an `error` event with the underlying git stderr — the consumer decides whether that's recoverable.
+
+For container deployments, common patterns:
+
+- **Deploy key (SSH):** mount the private key, configure `GIT_SSH_COMMAND='ssh -i /run/secrets/deploy-key -o StrictHostKeyChecking=accept-new'`
+- **GitHub App:** an init container or sidecar refreshes a short-lived token and writes a `.git-credentials` file
+- **HTTPS PAT:** simplest; embed in the remote URL (avoid logging) or use a credential helper
+
+## Idempotency
+
+Pushing a commit that's already on the remote is a no-op (`Everything up-to-date`). Push attempts are safe to retry.
+
+If the daemon restarts and finds commits in the local repo that aren't on the remote, it pushes them. The daemon doesn't track a "pending" state across restarts — it diffs local vs. remote on startup and queues anything ahead.
+
+## Push frequency
+
+The daemon pushes once per commit by default. For high-frequency commit workloads, this can be wasteful — a `debounceMs` option may be added later to coalesce multiple commits into a single push (still all individual commits, just a single network round-trip). Out of scope for v1.0.
+
+## Multiple daemons
+
+A `Repository` can host at most one push daemon at a time. `repo.startPushDaemon(...)` while one is already running throws `TransactionError` (`push_daemon_running`). Stop the existing one first.
+
+A daemon is bound to a single `(remote, branch)` pair. To push the same commits to two remotes, run two daemons in two `Repository` instances (or feature-request a multi-remote daemon if a consumer needs it).
+
+## Coordinates with
+
+- [api/repository.md](../api/repository.md)
+- [api/transaction.md](../api/transaction.md)
+- [GitHub #132](https://github.com/JarvusInnovations/gitsheets/issues/132) — implementation issue

--- a/specs/behaviors/transactions.md
+++ b/specs/behaviors/transactions.md
@@ -1,0 +1,195 @@
+# Behavior: Transactions
+
+## Rule
+
+A **transaction** scopes a set of mutations to one commit. The mutations stage into a private tree built from a parent ref. On success the tree is finalized into a commit and the configured branch advances. On failure (handler throws) the tree is discarded — no commit, no ref movement.
+
+## Applies To
+
+- [api/transaction.md](../api/transaction.md) — the `Transaction` class itself
+- [api/repository.md](../api/repository.md) — `repo.transact(opts, handler)`
+- [api/store.md](../api/store.md) — `store.transact(opts, handler)`
+- [api/sheet.md](../api/sheet.md) — `Sheet.upsert` / `delete` / `patch` (in permissive mode, auto-opens a transaction)
+
+## Single-writer model
+
+One open transaction per `Repository` at a time, serialized by an in-process mutex.
+
+| Scenario | Behavior |
+|---|---|
+| Two concurrent `repo.transact` calls | Second waits on the mutex; runs after the first commits or releases. |
+| Concurrent `repo.transact` *and* a permissive-mode `Sheet.upsert` outside a transaction | The permissive `upsert` opens its own transaction, contends for the same mutex. |
+| Same-process concurrent reads | Reads don't take the mutex. They see the *committed* state (pre-transaction tree). |
+
+Multi-process / multi-host writers are explicitly out of scope. If another process commits to the same ref while a transaction is open, the transaction throws `TransactionError` (`parent_moved`) when it tries to commit. Detection is via comparing the parent ref's commit hash at transaction open vs. at commit.
+
+## Commit-on-success-only
+
+```text
+handler resolves successfully + tree has at least one staged change
+  → finalize: validate the staged tree, commit, update ref
+  → resolve { value, commitHash, treeHash, ref, parentCommitHash }
+
+handler resolves successfully but no mutations occurred
+  → permissive mode: no commit, resolves with { value, commitHash: null, ... }
+  → explicit `repo.transact`: same — empty transactions don't commit
+
+handler throws
+  → tree discarded, no commit, no ref movement
+  → throw propagates out of `repo.transact`
+  → mutex released
+```
+
+This differs from the [pre-v1.0 PR #38 prototype](https://github.com/JarvusInnovations/gitsheets/pull/38), which committed unconditionally when `save()` was called. The commit-on-success-only rule is a hard requirement for production use — a half-applied mutation in the log is worse than no log entry.
+
+## Commit message format
+
+```text
+<subject line>
+
+<optional body, separated by blank line>
+
+<trailers, separated by blank line>
+```
+
+- **Subject** = first line of the `message` option. ≤ 72 chars is convention but not enforced.
+- **Body** = anything after the first blank line of `message`, up to the trailers.
+- **Trailers** = key/value lines appended per `git interpret-trailers`. Format and conventions below.
+
+## Trailer convention
+
+Trailers are appended at the end of the commit message, parseable by `git interpret-trailers --parse`.
+
+### Format
+
+```text
+Subject-Type: project
+Subject-Id: 01ab-...
+Subject-Slug: squadquest
+Action: project.soft-delete
+Actor-Slug: chris
+Reason: spam policy violation
+```
+
+### Naming
+
+HTTP-header style:
+
+- First letter capitalized
+- Multi-word keys hyphenated
+- Rest lowercase
+
+Examples: `Subject-Type`, `User-Agent`, `Response-Code`. Single-word keys: `Action`, `Reason`, `Host`.
+
+### Semantic vs. request trailers
+
+Trailers serve two purposes — the API doesn't distinguish, but consumers typically use both:
+
+**Semantic** (describes the action):
+
+- `Action` — dotted action name (`project.soft-delete`, `tag.merge`, `account-level.change`)
+- `Subject-Type` — entity type affected
+- `Subject-Id` — UUID
+- `Subject-Slug` — slug
+- `Actor-Slug` — actor's slug
+- `Actor-Account-Level` — actor's role
+- `Reason` — free-form rationale
+
+**Request context** (describes the HTTP request that triggered the commit):
+
+- `Host`
+- `Content-Type`
+- `User-Agent`
+- `User-Ip`
+- `Response-Code`
+
+Consumers building request-bound commit lifecycles (one commit per HTTP request) populate both sets. Programmatic / batch consumers typically populate only semantic trailers.
+
+## Author and committer
+
+```typescript
+{
+  author?: { name: string, email: string },
+  committer?: { name: string, email: string }
+}
+```
+
+Resolution:
+
+1. `opts.author` if provided
+2. `opts.committer` falls back to `opts.author` if not provided separately
+3. If `opts.author` is omitted, falls back to git config (`user.name`, `user.email`)
+4. If git config is also missing, falls back to `Anonymous <anonymous@gitsheets.local>` and logs a warning
+
+## Parent ref handling
+
+- `opts.parent`: ref name, short hash, or full commit hash. Default: current `HEAD`.
+- `opts.branch`: ref to update on commit. Default:
+  - If `opts.parent` is a branch (e.g., `main`): that same branch
+  - If `opts.parent` is a commit hash: `null` (no ref updated — the commit is "detached")
+
+To "commit onto a feature branch": `opts.parent: 'feature-x'`. To "commit onto a specific commit but not advance any branch": `opts.parent: '01ab2c...'`.
+
+## Optimistic concurrency
+
+At transaction open: capture `parentCommitHash = resolveRef(opts.parent)`.
+
+At commit time: re-resolve `opts.parent`. If it has moved:
+
+- The transaction is closed
+- `TransactionError` (`parent_moved`) is thrown with both hashes (`expected`, `actual`)
+- Tree is discarded
+- Consumer can retry by re-opening a transaction (it'll pick up the new parent)
+
+This catches concurrent commits from outside the API instance — direct git commits, separate gitsheets processes, etc. — at minimal cost.
+
+## Permissive mode (default)
+
+`Sheet.upsert(record)` called outside any explicit `repo.transact`:
+
+1. Opens a transaction with auto-generated `message`: `"<sheet> upsert <renderedPath>"`
+2. Renders the record via the template, stages the write
+3. Commits with the auto-generated message and git-config author
+4. Returns the `{ blob, path }` shape that `upsert` documents
+
+Equivalent for `delete` (`"<sheet> delete <path>"`) and `patch` (`"<sheet> patch <path>"`).
+
+This makes simple scripts ergonomic. For production request-bound flows, consumers should call `repo.transact` explicitly to control author/message/trailers — see [architecture.md](../architecture.md) recommendations.
+
+## Strict mode
+
+After `repo.requireExplicitTransactions()`:
+
+- Standalone `Sheet.upsert` / `delete` / `patch` throws `TransactionError` (`transaction_required`)
+- All writes must be inside an explicit `repo.transact` block
+
+Strict mode is per-`Repository` and one-way (no `releaseStrictMode`) — set once at boot.
+
+## Hooks
+
+None in v1.0. Pre-commit and post-commit hook points are deliberately not exposed. The internal commit pipeline is structured so hooks can be added in a future minor release without breaking existing callers — but the *contract* doesn't include them.
+
+If a consumer needs hook-like behavior in v1.0:
+
+- Pre-commit equivalent: run any side-effects in the handler before the last `tx.sheet(...)` call
+- Post-commit equivalent: chain `await repo.transact(...).then(...)` — the resolved `TransactionResult` includes the commit hash for downstream effects
+
+## Historical note: PR #38
+
+The transaction concept has existed in design form since 2020 — see [PR #38 (Feature/transactions)](https://github.com/JarvusInnovations/gitsheets/pull/38), a draft prototype that added `gitSheets.createTransaction(parentRef)` to the legacy `GitSheets` class. The prototype:
+
+- Returned `{ upsert(data), save(branch?) }`
+- Staged writes into an in-memory `TreeObject`
+- Committed unconditionally on `save()`
+- Had no message/author/trailers/mutex/commit-on-success
+
+The v1.0 design (this spec + [#129](https://github.com/JarvusInnovations/gitsheets/issues/129)) preserves the kernel idea (tree-builder + commit) and adds the production-grade pieces. PR #38 should be closed as superseded.
+
+## Coordinates with
+
+- [api/transaction.md](../api/transaction.md)
+- [api/repository.md](../api/repository.md)
+- [api/store.md](../api/store.md)
+- [api/errors.md](../api/errors.md)
+- [GitHub #129](https://github.com/JarvusInnovations/gitsheets/issues/129) — implementation issue
+- [GitHub PR #38](https://github.com/JarvusInnovations/gitsheets/pull/38) — historical prototype

--- a/specs/behaviors/validation.md
+++ b/specs/behaviors/validation.md
@@ -1,0 +1,152 @@
+# Behavior: Validation
+
+## Rule
+
+Records are validated on every write through two stacked layers, in order:
+
+1. **JSON Schema** — declared in `.gitsheets/<sheet>.toml`, **persisted with the data**. Framework-agnostic. The shape contract the repo carries.
+2. **Standard Schema** _(optional, consumer-supplied)_ — runs after JSON Schema, **lives in consumer code**. Adds branded types, refinements, transforms.
+
+A failure at either layer throws `ValidationError`. Validation runs synchronously inside `Sheet.upsert` / `Sheet.patch`, before any tree mutation.
+
+## Applies To
+
+- [`.gitsheets/<sheet>.toml`](../concepts.md#sheet) — `[gitsheet.schema]` block
+- [api/sheet.md](../api/sheet.md) — `upsert`, `patch`
+- [api/repository.md](../api/repository.md) — `openSheet(name, { validator? })`
+- [api/store.md](../api/store.md) — `openStore(repo, { validators? })`
+
+## Why two layers
+
+What gets persisted with the data vs. what lives in consumer code:
+
+- **Persisted** — the _shape_ of records. A consumer cloning the repo without consumer code should be able to introspect what records look like.
+- **Consumer-side** — _which framework_ validates them. Zod, Valibot, ArkType — application choices.
+
+JSON Schema is the standard for "describe the shape of this data," readable by every validation framework on the planet. Standard Schema is the modern runtime interface for "call any validator framework" without coupling to one.
+
+## Persisted format
+
+```toml
+# .gitsheets/users.toml
+[gitsheet]
+root = 'users'
+path = '${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email', 'fullName']
+additionalProperties = false
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+pattern = '^[a-z0-9][a-z0-9-]{1,49}$'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+format = 'email'
+
+[gitsheet.schema.properties.fullName]
+type = 'string'
+minLength = 1
+maxLength = 120
+
+[gitsheet.schema.properties.bio]
+type = 'string'
+maxLength = 10000
+```
+
+The `[gitsheet.schema]` block IS a JSON Schema, encoded in TOML. Top-level keys map straightforwardly: `type`, `required`, `additionalProperties`, `properties.<name>`, `format`, `pattern`, `minLength`, etc.
+
+For nested objects: `[gitsheet.schema.properties.address]` declares the address property; `[gitsheet.schema.properties.address.properties.city]` declares its nested property. Deeply nested schemas can use the JSON-file escape hatch (see below).
+
+## TOML conventions for JSON Schema
+
+- **Top-level table:** `[gitsheet.schema]`
+- **Properties:** `[gitsheet.schema.properties.<name>]`
+- **Arrays of types:** `type = ['string', 'null']` (TOML supports arrays of strings cleanly)
+- **Enums:** `enum = ['draft', 'active', 'archived']`
+- **`$ref`:** prefer inline definitions for record-shape schemas. For shared schemas across sheets, `$ref` to a sibling file is permitted: `$ref = './schemas/address.schema.json'` resolves relative to the `.gitsheets/<sheet>.toml`.
+- **Escape hatch:** if `[gitsheet.schema]` is awkward in TOML for a complex schema, set `[gitsheet.schema]` to `{ $ref = './schemas/<sheet>.schema.json' }` and put the full schema in a JSON file alongside.
+
+The single-TOML-file approach is the default. Use the escape hatch sparingly.
+
+## Validation engine
+
+- JSON Schema validation runs through **`ajv`** (or equivalent). The library configures `ajv` once per sheet with the sheet's schema compiled.
+- All formats from `ajv-formats` are available: `email`, `date-time`, `uri`, `uuid`, etc.
+- `strict: true` mode is enabled — unknown JSON Schema keywords produce a `ConfigError` (`config_invalid`) at sheet-open time rather than silently being ignored.
+
+## Standard Schema layer
+
+Consumers pass a [Standard Schema](https://standardschema.dev)–compatible validator:
+
+```typescript
+const sheet = await repo.openSheet('users', { validator: UserZodSchema });
+
+// or via Store
+const store = await openStore(repo, { validators: { users: UserZodSchema } });
+```
+
+The validator is called as:
+
+```typescript
+const result = await validator['~standard'].validate(record);
+if (result.issues) { /* ValidationError */ }
+else { record = result.value; }  // validator may transform
+```
+
+The transformed `result.value` (if the validator does coercion / transforms) becomes the record that gets written.
+
+The Standard Schema layer is optional. Without it, only JSON Schema runs.
+
+## Order
+
+1. Record arrives at `Sheet.upsert(record)` (or `Sheet.patch(query, partial)` after the merge step).
+2. JSON Schema validation. On failure: `ValidationError` with all JSON Schema issues. No transform.
+3. Standard Schema validation (if configured). On failure: `ValidationError` with all Standard Schema issues. Record may be transformed.
+4. Canonical normalization (see [behaviors/normalization.md](normalization.md)).
+5. Path render + write.
+
+`ValidationError.issues` combines both layers' issue arrays. Each issue's `source` field identifies which layer it came from.
+
+## Migration of pre-v1.0 `[gitsheet.fields]` config
+
+| Pre-v1.0 field | v1.0 placement | Notes |
+|---|---|---|
+| `type: 'number' \| 'string' \| 'boolean'` | `[gitsheet.schema.properties.<name>].type` | Lossless |
+| `enum: [...]` | `[gitsheet.schema.properties.<name>].enum` | Lossless |
+| `default: <value>` | `[gitsheet.schema.properties.<name>].default` | Lossless |
+| `sort: ...` | `[gitsheet.fields.<name>.sort]` (unchanged) | Stays — different concept (canonical normalization, not validation) |
+| `trueValues: [...]`, `falseValues: [...]` | Moves to CSV-ingest helper | Validation-time boolean coercion was always CSV-input-specific; surfaced separately |
+
+The `git sheet migrate-config <sheet>` CLI command (see [api/cli.md](../api/cli.md)) performs this migration. Lossless for the first three rows; emits a warning for the fourth pointing at the CSV-ingest helper.
+
+## Schema inference
+
+`git sheet infer <sheet>` scans existing records and writes a starter JSON Schema:
+
+- For each property observed, takes the union of observed types
+- For string properties, conservatively _omits_ `pattern` / `format` constraints (consumer adds these manually)
+- For numbers, records observed min/max as a hint
+- For arrays, records the element type
+
+Output is a starting point. The user reviews and tightens before committing.
+
+## Implication for the typed Store
+
+When `openStore(repo, { validators })` is called:
+
+- Each sheet's JSON Schema runs on every write
+- If `validators[sheetName]` exists, that validator runs after JSON Schema
+- TypeScript types flow from the consumer's validator (Zod's `z.infer`, etc.)
+- Sheets without a validator in the map type as `Sheet<Record<string, unknown>>` — JSON Schema still runs at runtime; only the TS type is loose
+
+## Coordinates with
+
+- [api/sheet.md](../api/sheet.md)
+- [api/store.md](../api/store.md)
+- [api/errors.md](../api/errors.md)
+- [behaviors/normalization.md](normalization.md)
+- [GitHub #130](https://github.com/JarvusInnovations/gitsheets/issues/130) — the implementation issue
+- [GitHub #136](https://github.com/JarvusInnovations/gitsheets/issues/136) — the error taxonomy

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -1,0 +1,115 @@
+# Concepts
+
+The vocabulary every consumer needs. Read this before the API specs.
+
+## Repository
+
+A git repository that contains gitsheets-managed data. Created from disk via `openRepo({ gitDir? })`. The library reads + writes git objects through hologit and through the underlying `git` CLI.
+
+A repository can also contain ordinary code, docs, anything — gitsheets only cares about paths under `.gitsheets/` (sheet configs) and the data paths each sheet declares.
+
+## Sheet
+
+A typed collection of records, declared by a TOML file at `.gitsheets/<name>.toml`. Each sheet has:
+
+- A **name** (the basename of its config file)
+- A **root path** — the directory under which the sheet's records live (default: `.`)
+- A **path template** — how a record maps to a file path
+- An optional **JSON Schema** — the record shape contract (see [behaviors/validation.md](behaviors/validation.md))
+- Optional **canonical normalization rules** for array field sorting (see [behaviors/normalization.md](behaviors/normalization.md))
+
+A repository may contain many sheets. They share the repo but otherwise are independent.
+
+## Record
+
+A single TOML document stored under the sheet's root, at the path rendered from the sheet's path template against the record's fields.
+
+Records are validated on every write — first against the persisted JSON Schema, then against any consumer-supplied Standard Schema validator.
+
+Records have implicit annotations gitsheets attaches at read time (the sheet name they came from, the path they were read from) — accessed via well-known Symbols (`Symbol.for('gitsheets-sheet')`, `Symbol.for('gitsheets-path')`) so they don't collide with the record's own fields.
+
+## Path Template
+
+A small DSL for "where does this record live in the tree, and how do queries prune the search."
+
+```text
+${{ field }}                # bare field reference
+${{ expression }}           # JS expression evaluated against the record
+${{ field/** }}             # recursive field — value may contain `/` and matches subtrees
+literal-text-${{ field }}   # literal prefix/suffix attached to an expression
+${{ a }}/${{ b }}           # path segments
+```
+
+Path templates serve two roles:
+
+1. **Where to write** — gitsheets renders the template against a record to determine its file path.
+2. **How to query efficiently** — when a query includes the path template's fields, gitsheets walks only matching subtrees instead of every record.
+
+See [behaviors/path-templates.md](behaviors/path-templates.md) for the syntax and traversal rules.
+
+## Attachment
+
+A binary blob colocated with a record. Stored at `<recordPath>/<attachmentName>` — e.g., a record at `users/jane.toml` may have an attachment at `users/jane/avatar.jpg`.
+
+Attachments are first-class — get/set methods on `Sheet`, included in tree commits the same way records are.
+
+## Transaction
+
+A scope that bundles one or more sheet mutations into a single commit. Opens against a parent ref, runs a handler that performs mutations, commits on success (no commit on throw).
+
+A transaction carries an **author**, **committer**, **commit message** (subject line + body), and **trailers** (git-style key/value metadata).
+
+Mutations outside a transaction (in permissive mode) implicitly open and commit a single-mutation transaction. The transaction model is the same either way; only the explicit-vs-implicit framing differs. See [behaviors/transactions.md](behaviors/transactions.md).
+
+## Store
+
+A top-level typed wrapper that auto-discovers sheets in a repository and binds them to consumer-supplied Standard Schema validators. Returns a typed object whose properties are the sheets:
+
+```typescript
+const store = await openStore(repo, { validators });
+store.users.upsert(record);    // typed against UserSchema
+store.transact(opts, async tx => {
+  tx.users.upsert(...);
+});
+```
+
+The Store is sugar around `Repository.openSheets()` + `Repository.transact()` with TypeScript-level sheet-name + record-shape inference.
+
+## Index
+
+An in-memory secondary index on a sheet, keyed by a function the consumer supplies. Lazy by default (built on first lookup), with an eager opt-in.
+
+```typescript
+sheet.defineIndex('byEmail', { unique: true }, (record) => record.email.toLowerCase());
+const jane = await sheet.findByIndex('byEmail', 'jane@example.com');
+```
+
+Indices are not persisted to the git repo. They live in process memory, invalidate on `upsert` / `delete` (same instance) or on out-of-band ref movement, and rebuild on demand. See [behaviors/indexing.md](behaviors/indexing.md).
+
+## Push Daemon
+
+An optional, library-side background task that pushes new commits to a configured git remote with retry/backoff. Push-only — no pull at runtime. See [behaviors/push-sync.md](behaviors/push-sync.md).
+
+## Validation layers
+
+Two layers run on every write, in order:
+
+1. **JSON Schema** (persisted in `.gitsheets/<sheet>.toml`) — the shape contract that travels with the repo.
+2. **Standard Schema** (consumer-supplied, optional) — richer validation: branded types, refinements, transforms.
+
+See [behaviors/validation.md](behaviors/validation.md).
+
+## Canonical normalization
+
+Independent of validation: rules that affect *how the record's bytes are written* so logically-equal records produce byte-identical TOML.
+
+- **Object keys** are alphabetically sorted (deep).
+- **Array fields** may declare a `sort` config to enforce a deterministic element order before write.
+
+See [behaviors/normalization.md](behaviors/normalization.md).
+
+## Commits as audit log
+
+There is no separate audit table. Every mutation produces a commit with author, committer, timestamp, full diff, message, and structured trailers. Queries that an audit table would serve are answered by `git log --grep` / `--author` / `-- <path>/`.
+
+This isn't a feature gitsheets builds — it's the *substrate* gitsheets sits on. But it's worth naming because it shapes downstream behavior: trailer conventions (see [behaviors/transactions.md](behaviors/transactions.md)) exist so that the commit log itself is queryable.

--- a/specs/deferred.md
+++ b/specs/deferred.md
@@ -1,0 +1,92 @@
+# Deferred Features
+
+Features intentionally **not in scope for v1.0**. Listed here so the omission is documented, not accidental.
+
+When an item is promoted, move it from this file into the relevant active spec and update the [GitHub issue](https://github.com/JarvusInnovations/gitsheets/issues) that tracks it.
+
+## Deferred to v1.1
+
+### Holo-tree migration (Rust substrate)
+
+- **What:** Swap the current hologit JS dependency for a Rust `holo-tree` crate via `napi-rs`. ~100x faster tree operations on the hot path.
+- **Why deferred:** Public API rewrite (v1.0) and internal engine swap (v1.1) are two distinct changes. Coupling them would balloon the v1.0 review surface and delay consumer feedback.
+- **Tracking:** [#127](https://github.com/JarvusInnovations/gitsheets/issues/127)
+- **Constraint:** Must not change the public API. Consumers see no difference, only performance.
+
+## Deferred (no scheduled release)
+
+### Watch mode
+
+- **What:** `repo.watch(callback)` API that emits events when the data tree changes externally (working-tree edits, ref updates from another process), letting consumers invalidate caches/indices live.
+- **Why deferred:** Gitsheets typically operates against refs, not the working tree. The use case is real for dev/seeding workflows but not load-bearing for production consumers.
+- **Tracking:** [#135](https://github.com/JarvusInnovations/gitsheets/issues/135)
+
+### Attachments iterator API
+
+- **What:** `for await (const { name, mimeType, blob } of sheet.attachments(record))` — a higher-level iterator over a record's attachments, replacing the current low-level `blobMap` surface.
+- **Why deferred:** The current `getAttachments` / `getAttachment` / `setAttachment` API works; iterator is sugar. Nice ergonomics, not 1.0-critical.
+- **Tracking:** [#140](https://github.com/JarvusInnovations/gitsheets/issues/140)
+
+### `git sheet init` scaffold command
+
+- **What:** A CLI command that writes a starter `.gitsheets/<name>.toml` from a JSON Schema file, from sample records, or from minimal flags.
+- **Why deferred:** Consumers can hand-author the TOML. Real ergonomics win but not on the 1.0 critical path.
+- **Tracking:** [#139](https://github.com/JarvusInnovations/gitsheets/issues/139)
+
+### YAML format support (input + output)
+
+- **What:** Accept and emit YAML in CLI ingest / export, alongside the existing JSON / TOML / CSV.
+- **Why deferred:** Long-standing backlog request with no concrete current consumer.
+- **Tracking:** [#61](https://github.com/JarvusInnovations/gitsheets/issues/61)
+
+### Persisted indexes
+
+- **What:** Allow secondary indices (currently in-memory only) to materialize to disk under a `.gitsheets/.indexes/` tree, so consumers don't pay rebuild cost across restarts.
+- **Why deferred:** At v1.0 corpus sizes, lazy rebuild is fast enough. If a consumer's corpus grows past the threshold where rebuild matters, this becomes a real concern.
+
+### Richer query operators
+
+- **What:** `$in`, `$or`, `$gt`-style operators on `Sheet.query`.
+- **Why deferred:** Consumers can iterate `queryAll(...)` and `.filter(...)` in their own code. The whole-repo-fits-in-memory premise makes the operator richness less load-bearing.
+
+### Persisted in-memory cache layer
+
+- **What:** A library-managed cache around parsed records, surviving across requests in a long-running consumer.
+- **Why deferred:** Once #138 (blob-hash record cache fix) lands, the existing per-sheet-instance cache covers most needs. A richer multi-instance cache can come if a consumer shows it's needed.
+
+## Dropped (no plan)
+
+### `backend/server.js` HTTP server
+
+- **What:** The pre-v1.0 Koa server that exposed gitsheets over HTTP.
+- **Why dropped:** Consumers building HTTP APIs around gitsheets build their own HTTP layer. The library doesn't ship one.
+
+### Vue frontend
+
+- **What:** The pre-v1.0 single-page app at `src/` that demonstrated upload/diff/commit workflows.
+- **Why dropped:** Demo-grade UI tied to the dropped HTTP server. If a UI is wanted, it's a separate project on top of the library.
+
+### Legacy `GitSheets` class
+
+- **What:** `backend/lib/GitSheets.js` — the pre-v1.0 single-class API with ref-oriented mutation and stream-based CSV import/export.
+- **Why dropped:** Early-prototype API with no current users. The modern `Sheet` / `Repository` / `Transaction` model supersedes it.
+
+### JSON:API surface
+
+- **What:** A built-in JSON:API-compliant HTTP layer.
+- **Why dropped:** JSON:API didn't take over, the library doesn't ship an HTTP layer anyway, and consumer-side framing is more flexible.
+
+### Multi-package monorepo (`@gitsheets/core` + `@gitsheets/cli`)
+
+- **What:** Split the npm package into separately-versioned core + CLI packages.
+- **Why dropped:** Single-package shipping is simpler. Splitting is reversible later if a consumer wants the core without the CLI dependency surface.
+
+## Out of scope (different responsibility)
+
+These belong to consumers, not to gitsheets:
+
+- **Authentication / authorization** — handled in consumer code or upstream
+- **HTTP layer / request handling** — Fastify, Koa, Express, Hono, etc. — consumer's choice
+- **Search index** — SQLite FTS, Meilisearch, etc. built on top
+- **Migration framework** — schema migrations are one-shot scripts that commit to the data repo
+- **Auth for the push daemon's git remote** — handled by the environment (SSH config, credential helper, GitHub App)


### PR DESCRIPTION
Establishes \`specs/\` as the source of truth for what gitsheets should be. The v1.0 surface (pre-rust, pre-#127) is documented end-to-end — every symbol, every behavior, every CLI command, every error class. Companion to the [1.0.0 milestone](https://github.com/JarvusInnovations/gitsheets/milestone/1) issues #128–#141.

## What lands

\`\`\`
specs/
├── README.md                       # workflow + index
├── architecture.md                 # stack, packaging, repo layout
├── concepts.md                     # Repository, Sheet, Record, Transaction, Store, Index
├── deferred.md                     # out of scope for v1.0
├── api/
│   ├── conventions.md
│   ├── repository.md
│   ├── sheet.md
│   ├── transaction.md
│   ├── store.md
│   ├── errors.md
│   └── cli.md
└── behaviors/
    ├── path-templates.md
    ├── validation.md
    ├── normalization.md
    ├── transactions.md
    ├── indexing.md
    ├── push-sync.md
    ├── attachments.md
    └── patch-semantics.md

CLAUDE.md
.claude/agents/spec-drift-auditor.md
.claude/commands/audit-spec-drift.md
\`\`\`

## Cross-references to the 1.0 issues

Every spec links to the GitHub issue tracking its implementation. Implementing-agent guidance is intentionally consolidated: the issue says \"what to do,\" the spec says \"what it should look like when done.\"

- [#128](https://github.com/JarvusInnovations/gitsheets/issues/128) — TS rewrite + purge → \`architecture.md\`, every API spec
- [#129](https://github.com/JarvusInnovations/gitsheets/issues/129) — Transaction class → \`api/transaction.md\`, \`behaviors/transactions.md\`
- [#130](https://github.com/JarvusInnovations/gitsheets/issues/130) — Validation (JSON Schema + Standard Schema) → \`behaviors/validation.md\`
- [#131](https://github.com/JarvusInnovations/gitsheets/issues/131) — Typed Store API → \`api/store.md\`
- [#132](https://github.com/JarvusInnovations/gitsheets/issues/132) — Push daemon → \`behaviors/push-sync.md\`, \`api/repository.md\`
- [#133](https://github.com/JarvusInnovations/gitsheets/issues/133) — RFC 7396 Patch → \`behaviors/patch-semantics.md\`
- [#134](https://github.com/JarvusInnovations/gitsheets/issues/134) — Secondary indexing → \`behaviors/indexing.md\`, \`api/sheet.md\`
- [#136](https://github.com/JarvusInnovations/gitsheets/issues/136) — Error taxonomy → \`api/errors.md\`
- [#137](https://github.com/JarvusInnovations/gitsheets/issues/137) — Test harness → referenced in \`architecture.md\`
- [#141](https://github.com/JarvusInnovations/gitsheets/issues/141) — Docs overhaul → the user-facing follow-up

## Historical note: PR #38

[PR #38 (Feature/transactions, 2020)](https://github.com/JarvusInnovations/gitsheets/pull/38) added \`gitSheets.createTransaction(parentRef)\` to the legacy \`GitSheets\` class as a draft prototype. The v1.0 \`Transaction\` design (per \`specs/behaviors/transactions.md\` + #129) preserves the kernel idea and adds the production pieces (commit-on-success, author/message/trailers, mutex, parent-moved detection). The spec acknowledges PR #38 in the \"Historical note\" section.

PR #38 should be closed as superseded by #129.

## Spec-drift auditing

The \`/audit-spec-drift\` Claude Code command launches a spec-drift-auditor agent that compares \`specs/\` against the implementation and produces three tables: specified-but-not-implemented, implemented-but-not-specified, conflicts. Useful before starting a new feature and before cutting a release.

## What this PR is NOT

- No code changes. The implementation of #128–#137 happens in separate PRs, each touching the relevant areas of \`src/\`.
- No public-API guarantees yet — the specs describe the v1.0 target. Until v1.0 ships, the current public surface (the modern \`Sheet\`/\`Repository\` API) is what consumers should use.

## Review notes

- The specs are written for an audience of \"me + AI agents\" per the issue-bodies framing. Future docs aimed at public OSS users are #141.
- Files are extensively cross-linked. Click around \`specs/README.md\` to navigate.
- \`specs/deferred.md\` is the canonical list of \"don't silently implement this in v1.0.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)