### PR TITLE
feat: gitsheets-axi MVP — agent-facing CLI as a workspace package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build first: gitsheets-axi consumes the `gitsheets` workspace through
+      # its `dist/` (the `main`/`types` fields point there), so type-check
+      # and test both need the library built before they run.
+      - name: Build
+        run: npm run build
+
       - name: Type-check
         run: npm run type-check
 
       - name: Test
         run: npm test
-
-      - name: Build
-        run: npm run build

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,11 +19,31 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false  # never use caching in release builds
 
-      - name: Set package.json version from tag
+      - name: Set versions from tag
         run: |
           set -e
           SOURCE_TAG="${GITHUB_REF#refs/tags/}"
-          npm version --no-git-tag-version -w gitsheets "${SOURCE_TAG#v}"
+          VERSION="${SOURCE_TAG#v}"
+          npm version --no-git-tag-version -w gitsheets "$VERSION"
+          npm version --no-git-tag-version -w gitsheets-axi "$VERSION"
+
+      - name: Pin gitsheets-axi → gitsheets dep range
+        run: |
+          set -e
+          SOURCE_TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${SOURCE_TAG#v}"
+          # gitsheets-axi declares `"gitsheets": "*"` so the workspace symlink
+          # resolves during development. At publish time, pin it to the exact
+          # matching minor — lockstep with gitsheets means `gitsheets-axi@1.3.x`
+          # always wants `gitsheets@^1.3.0`.
+          MINOR_RANGE="^${VERSION%%-*}"
+          node -e "
+            const fs = require('fs');
+            const p = require('./packages/gitsheets-axi/package.json');
+            p.dependencies.gitsheets = '$MINOR_RANGE';
+            fs.writeFileSync('./packages/gitsheets-axi/package.json', JSON.stringify(p, null, 2) + '\n');
+          "
+          cat packages/gitsheets-axi/package.json | grep gitsheets
 
       - run: npm ci
 
@@ -36,4 +56,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - run: npm publish --provenance --access public -w gitsheets
+      - name: Publish gitsheets
+        run: npm publish --provenance --access public -w gitsheets
+
+      - name: Publish gitsheets-axi
+        run: npm publish --provenance --access public -w gitsheets-axi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,14 +47,16 @@ jobs:
 
       - run: npm ci
 
+      # Build before type-check and test — gitsheets-axi consumes `gitsheets`
+      # through its `dist/` output.
+      - name: Build
+        run: npm run build
+
       - name: Type-check
         run: npm run type-check
 
       - name: Test
         run: npm test
-
-      - name: Build
-        run: npm run build
 
       - name: Publish gitsheets
         run: npm publish --provenance --access public -w gitsheets

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,6 +390,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@toon-format/toon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.2.0.tgz",
+      "integrity": "sha512-FMYqrlZnMN72YIT9KVt7Kxc41gat+RgMIzDmvRRPHw0J7pqW/FeBGDY/4BIWjT71Y+EdI9fCJip90uXuGuYhjw==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -704,6 +710,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/axi-sdk-js": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.6.tgz",
+      "integrity": "sha512-Nc/mNasFUVqBieSOLGt2A5u4pJEOZPpueq+ignqoY+vcg8j4VuAvhWTn3cJ7hhTkGVqLg4yjTdjMi4tXyOCsCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@toon-format/toon": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/axios": {
       "version": "1.16.1",
@@ -1336,6 +1354,10 @@
     },
     "node_modules/gitsheets": {
       "resolved": "packages/gitsheets",
+      "link": true
+    },
+    "node_modules/gitsheets-axi": {
+      "resolved": "packages/gitsheets-axi",
       "link": true
     },
     "node_modules/glob": {
@@ -3506,6 +3528,26 @@
         "@types/node": "^25.8.0",
         "@types/yargs": "^17.0.35",
         "tmp": "^0.2.5",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/gitsheets-axi": {
+      "version": "1.0.0-substrate.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@toon-format/toon": "^2.2.0",
+        "axi-sdk-js": "^0.1.6",
+        "gitsheets": "*"
+      },
+      "bin": {
+        "gitsheets-axi": "dist/bin/gitsheets-axi.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.8.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
       },

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w gitsheets",
-    "test": "npm test -w gitsheets",
+    "build": "npm run build -w gitsheets && npm run build -w gitsheets-axi",
+    "test": "npm test --workspaces --if-present",
     "test:watch": "npm run test:watch -w gitsheets",
-    "type-check": "npm run type-check -w gitsheets"
+    "type-check": "npm run type-check --workspaces --if-present"
   },
   "engines": {
     "node": ">=20"

--- a/packages/gitsheets-axi/bin/gitsheets-axi.ts
+++ b/packages/gitsheets-axi/bin/gitsheets-axi.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { main } from '../src/cli.js';
+
+main();

--- a/packages/gitsheets-axi/package.json
+++ b/packages/gitsheets-axi/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "gitsheets-axi",
+  "version": "1.0.0-substrate.0",
+  "description": "Agent-facing CLI for gitsheets — token-efficient TOON output, idempotent mutations, self-installing session hooks.",
+  "type": "module",
+  "bin": {
+    "gitsheets-axi": "dist/bin/gitsheets-axi.js"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && chmod +x dist/bin/gitsheets-axi.js",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "packages/gitsheets-axi"
+  },
+  "homepage": "https://github.com/JarvusInnovations/gitsheets#readme",
+  "bugs": {
+    "url": "https://github.com/JarvusInnovations/gitsheets/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "Jarvus Innovations",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "gitsheets",
+    "axi",
+    "agent",
+    "cli",
+    "toon",
+    "git"
+  ],
+  "dependencies": {
+    "@toon-format/toon": "^2.2.0",
+    "axi-sdk-js": "^0.1.6",
+    "gitsheets": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -11,6 +11,7 @@ import { readCommand, READ_HELP } from './commands/read.js';
 import { upsertCommand, UPSERT_HELP } from './commands/upsert.js';
 import { patchCommand, PATCH_HELP } from './commands/patch.js';
 import { deleteCommand, DELETE_HELP } from './commands/delete.js';
+import { checkCommand, CHECK_HELP } from './commands/check.js';
 
 const DESCRIPTION =
   'gitsheets — agent-facing interface for the git-backed document store. ' +
@@ -19,8 +20,8 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[7]:
-  (none)=home, sheets, query, read, upsert, patch, delete
+commands[8]:
+  (none)=home, sheets, query, read, upsert, patch, delete, check
 flags[2]:
   --help, -v/-V/--version
 examples:
@@ -31,6 +32,7 @@ examples:
   gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
   gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane"}'
   gitsheets-axi delete users jane
+  gitsheets-axi check users users/jane.toml --fix
 `;
 
 const COMMAND_HELP: Record<string, string> = {
@@ -40,6 +42,7 @@ const COMMAND_HELP: Record<string, string> = {
   upsert: UPSERT_HELP,
   patch: PATCH_HELP,
   delete: DELETE_HELP,
+  check: CHECK_HELP,
 };
 
 type CommandFn = (args: string[], ctx: GitsheetsContext) => Promise<string | Record<string, unknown>>;
@@ -51,6 +54,7 @@ const COMMANDS: Record<string, CommandFn> = {
   upsert: upsertCommand,
   patch: patchCommand,
   delete: deleteCommand,
+  check: checkCommand,
 };
 
 export async function main(): Promise<void> {

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -8,6 +8,9 @@ import { homeCommand } from './commands/home.js';
 import { sheetsCommand, SHEETS_HELP } from './commands/sheets.js';
 import { queryCommand, QUERY_HELP } from './commands/query.js';
 import { readCommand, READ_HELP } from './commands/read.js';
+import { upsertCommand, UPSERT_HELP } from './commands/upsert.js';
+import { patchCommand, PATCH_HELP } from './commands/patch.js';
+import { deleteCommand, DELETE_HELP } from './commands/delete.js';
 
 const DESCRIPTION =
   'gitsheets — agent-facing interface for the git-backed document store. ' +
@@ -16,22 +19,27 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[4]:
-  (none)=home, sheets, query, read
+commands[7]:
+  (none)=home, sheets, query, read, upsert, patch, delete
 flags[2]:
   --help, -v/-V/--version
 examples:
   gitsheets-axi
   gitsheets-axi sheets
-  gitsheets-axi sheets view users
   gitsheets-axi query users --filter status=active
   gitsheets-axi read posts hello --full
+  gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
+  gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane"}'
+  gitsheets-axi delete users jane
 `;
 
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
   query: QUERY_HELP,
   read: READ_HELP,
+  upsert: UPSERT_HELP,
+  patch: PATCH_HELP,
+  delete: DELETE_HELP,
 };
 
 type CommandFn = (args: string[], ctx: GitsheetsContext) => Promise<string | Record<string, unknown>>;
@@ -40,6 +48,9 @@ const COMMANDS: Record<string, CommandFn> = {
   sheets: sheetsCommand,
   query: queryCommand,
   read: readCommand,
+  upsert: upsertCommand,
+  patch: patchCommand,
+  delete: deleteCommand,
 };
 
 export async function main(): Promise<void> {

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runAxiCli } from 'axi-sdk-js';
+
+const DESCRIPTION =
+  'gitsheets — agent-facing interface for the git-backed document store. ' +
+  'Token-efficient TOON output, idempotent mutations, format-aware schemas.';
+
+const VERSION = readPackageVersion();
+
+export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
+commands[1]:
+  (none)=home
+flags[2]:
+  --help, -v/-V/--version
+examples:
+  gitsheets-axi
+`;
+
+export async function main(): Promise<void> {
+  await runAxiCli({
+    description: DESCRIPTION,
+    version: VERSION,
+    topLevelHelp: TOP_HELP,
+    ...(process.env.GITSHEETS_AXI_DISABLE_HOOKS === '1' ? { hooks: false as const } : {}),
+    home: async () => ({
+      status: 'scaffold — commands not yet wired up',
+      help: ['Run `gitsheets-axi --help` to see top-level usage'],
+    }),
+    commands: {},
+  });
+}
+
+function readPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  for (const candidate of [
+    join(here, '..', 'package.json'),
+    join(here, '..', '..', 'package.json'),
+  ]) {
+    if (!existsSync(candidate)) continue;
+
+    const parsed = JSON.parse(readFileSync(candidate, 'utf-8')) as {
+      version?: unknown;
+    };
+    if (typeof parsed.version === 'string' && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  }
+
+  throw new Error('Could not determine gitsheets-axi package version');
+}

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -3,6 +3,12 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runAxiCli } from 'axi-sdk-js';
 
+import { createContext, type GitsheetsContext } from './context.js';
+import { homeCommand } from './commands/home.js';
+import { sheetsCommand, SHEETS_HELP } from './commands/sheets.js';
+import { queryCommand, QUERY_HELP } from './commands/query.js';
+import { readCommand, READ_HELP } from './commands/read.js';
+
 const DESCRIPTION =
   'gitsheets — agent-facing interface for the git-backed document store. ' +
   'Token-efficient TOON output, idempotent mutations, format-aware schemas.';
@@ -10,25 +16,45 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[1]:
-  (none)=home
+commands[4]:
+  (none)=home, sheets, query, read
 flags[2]:
   --help, -v/-V/--version
 examples:
   gitsheets-axi
+  gitsheets-axi sheets
+  gitsheets-axi sheets view users
+  gitsheets-axi query users --filter status=active
+  gitsheets-axi read posts hello --full
 `;
 
+const COMMAND_HELP: Record<string, string> = {
+  sheets: SHEETS_HELP,
+  query: QUERY_HELP,
+  read: READ_HELP,
+};
+
+type CommandFn = (args: string[], ctx: GitsheetsContext) => Promise<string | Record<string, unknown>>;
+
+const COMMANDS: Record<string, CommandFn> = {
+  sheets: sheetsCommand,
+  query: queryCommand,
+  read: readCommand,
+};
+
 export async function main(): Promise<void> {
-  await runAxiCli({
+  await runAxiCli<GitsheetsContext>({
     description: DESCRIPTION,
     version: VERSION,
     topLevelHelp: TOP_HELP,
     ...(process.env.GITSHEETS_AXI_DISABLE_HOOKS === '1' ? { hooks: false as const } : {}),
-    home: async () => ({
-      status: 'scaffold — commands not yet wired up',
-      help: ['Run `gitsheets-axi --help` to see top-level usage'],
-    }),
-    commands: {},
+    resolveContext: () => createContext(),
+    home: (_args, ctx) => homeCommand(ctx as GitsheetsContext),
+    commands: COMMANDS as Record<
+      string,
+      (args: string[], ctx: GitsheetsContext | undefined) => Promise<string | Record<string, unknown>>
+    >,
+    getCommandHelp: (command) => COMMAND_HELP[command],
   });
 }
 

--- a/packages/gitsheets-axi/src/commands/check.ts
+++ b/packages/gitsheets-axi/src/commands/check.ts
@@ -1,0 +1,180 @@
+import { isAbsolute, join, relative } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { AxiError } from 'axi-sdk-js';
+import { ConfigError, getFormat, NotFoundError, validateRecord } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+
+export const CHECK_HELP = `usage: gitsheets-axi check <sheet> <file> [--fix] [--prefix p]
+flags[2]:
+  --fix                Rewrite the file in canonical form if not already canonical
+  --prefix <p>         Tenant sub-tree scope
+examples:
+  gitsheets-axi check users users/jane.toml
+  gitsheets-axi check users users/jane.toml --fix
+exit codes:
+  0   File is canonical (or rewritten if --fix)
+  1   File is not canonical and --fix was not passed
+  22  ValidationError — record fails the sheet's JSON Schema
+  64  ConfigError — file failed to parse as the sheet's format
+behavior:
+  Reads from the working tree (not git). Never commits. Designed as a
+  post-edit hook for agents that wrote a record directly: run with --fix
+  to land in canonical form; run without to verify pre-commit.
+`;
+
+interface CheckFlags {
+  sheet: string;
+  file: string;
+  fix: boolean;
+  prefix: string | undefined;
+}
+
+function parseCheckFlags(args: string[]): CheckFlags {
+  const flags: CheckFlags = {
+    sheet: '',
+    file: '',
+    fix: false,
+    prefix: undefined,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--fix') {
+      flags.fix = true;
+      continue;
+    }
+    if (arg === '--prefix') {
+      if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+      flags.prefix = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi check --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length !== 2) {
+    throw new AxiError('check requires <sheet> <file>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi check users users/jane.toml',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  flags.file = positional[1]!;
+  return flags;
+}
+
+export async function checkCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return CHECK_HELP;
+  }
+
+  const flags = parseCheckFlags(args);
+  const repo = await ctx.repo();
+
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const config = await sheet.readConfig();
+  const format = getFormat(config.format.type);
+
+  const absPath = isAbsolute(flags.file)
+    ? flags.file
+    : join(process.cwd(), flags.file);
+
+  let original: string;
+  try {
+    original = await readFile(absPath, 'utf-8');
+  } catch (err) {
+    throw translateError(
+      new NotFoundError(
+        'record_not_found',
+        `check: cannot read ${flags.file}: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    );
+  }
+
+  // Parse via the sheet's format. Failure → ConfigError → exit 64.
+  let record;
+  try {
+    record = format.parse(original, config.format);
+  } catch (err) {
+    throw translateError(
+      new ConfigError(
+        'config_invalid',
+        `check: failed to parse ${flags.file} as ${config.format.type}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      ),
+    );
+  }
+
+  // Validate against the sheet's schema → ValidationError → exit 22.
+  let validated;
+  try {
+    validated = await validateRecord({
+      record: { ...record },
+      schema: config.schema,
+      schemaSourcePath: `.gitsheets/${flags.sheet}.toml`,
+    });
+  } catch (err) {
+    throw translateError(err);
+  }
+
+  const normalized = await sheet.normalizeRecord(validated as never);
+  const newText = await format.serialize(
+    { ...(normalized as Record<string, unknown>) },
+    config.format,
+  );
+
+  const relPath = relative(process.cwd(), absPath) || flags.file;
+
+  if (newText === original) {
+    return renderObject({
+      result: 'ok',
+      file: relPath,
+      canonical: true,
+    });
+  }
+
+  if (flags.fix) {
+    try {
+      await writeFile(absPath, newText, 'utf-8');
+    } catch (err) {
+      throw new AxiError(
+        `check: could not write ${flags.file}: ${err instanceof Error ? err.message : String(err)}`,
+        'WRITE_ERROR',
+      );
+    }
+    return renderObject({
+      result: 'fixed',
+      file: relPath,
+      canonical: true,
+      bytes_changed: original.length !== newText.length || original !== newText,
+    });
+  }
+
+  // Not canonical, --fix not passed. AXI behavior: error on stdout, exit 1.
+  throw new AxiError(
+    `${flags.file} is not in canonical form`,
+    'NOT_CANONICAL',
+    [`Re-run with \`--fix\` to rewrite ${flags.file}`],
+  );
+}

--- a/packages/gitsheets-axi/src/commands/delete.ts
+++ b/packages/gitsheets-axi/src/commands/delete.ts
@@ -1,0 +1,152 @@
+import { AxiError } from 'axi-sdk-js';
+import { NotFoundError, RECORD_PATH_KEY } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+
+export const DELETE_HELP = `usage: gitsheets-axi delete <sheet> <path> [--prefix p] [--message m]
+flags[2]:
+  --prefix <p>         Tenant sub-tree scope
+  --message <m>        Commit message (default: "<sheet> delete <path>")
+examples:
+  gitsheets-axi delete users jane
+  gitsheets-axi delete posts hello --message "remove deprecated post"
+idempotency:
+  Already-missing records exit 0 with result: "no-op" — no commit, no
+  error. Pattern: an agent re-running a workflow can safely call delete
+  without checking existence first.
+`;
+
+interface DeleteFlags {
+  sheet: string;
+  path: string;
+  prefix: string | undefined;
+  message: string | undefined;
+}
+
+function parseDeleteFlags(args: string[]): DeleteFlags {
+  const flags: DeleteFlags = {
+    sheet: '',
+    path: '',
+    prefix: undefined,
+    message: undefined,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--prefix') {
+      if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+      flags.prefix = next;
+      i++;
+      continue;
+    }
+    if (arg === '--message') {
+      if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+      flags.message = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi delete --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length !== 2) {
+    throw new AxiError('delete requires <sheet> <path>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi delete users jane',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  flags.path = positional[1]!;
+  return flags;
+}
+
+export async function deleteCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return DELETE_HELP;
+  }
+
+  const flags = parseDeleteFlags(args);
+  const target = stripExtension(flags.path);
+
+  const repo = await ctx.repo();
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  // Pre-flight existence check — idempotent on already-missing.
+  let exists = false;
+  try {
+    for await (const record of sheet.query()) {
+      const pathSym = (record as Record<symbol, unknown>)[RECORD_PATH_KEY];
+      if (pathSym === target) {
+        exists = true;
+        break;
+      }
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (!exists) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      path: target,
+      reason: 'record already absent',
+    });
+  }
+
+  const commitMessage = flags.message ?? `${flags.sheet} delete ${target}`;
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(
+          flags.sheet,
+          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+        );
+        await txSheet.delete(target);
+      },
+    );
+    return renderObject({
+      result: 'committed',
+      sheet: flags.sheet,
+      path: target,
+      commit: result.commitHash,
+    });
+  } catch (error) {
+    // Edge: race where the record vanished between the existence check
+    // and the delete. Treat as no-op rather than failing.
+    if (error instanceof NotFoundError) {
+      return renderObject({
+        result: 'no-op',
+        sheet: flags.sheet,
+        path: target,
+        reason: 'record vanished between check and delete',
+      });
+    }
+    throw translateError(error);
+  }
+}
+
+function stripExtension(path: string): string {
+  if (path.endsWith('.toml')) return path.slice(0, -5);
+  if (path.endsWith('.md')) return path.slice(0, -3);
+  if (path.endsWith('.mdx')) return path.slice(0, -4);
+  return path;
+}

--- a/packages/gitsheets-axi/src/commands/home.ts
+++ b/packages/gitsheets-axi/src/commands/home.ts
@@ -1,0 +1,88 @@
+import { dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+import type { GitsheetsContext } from '../context.js';
+import { renderListResponse } from '../output/render.js';
+import { countRecords } from '../output/sheet-schema.js';
+import { computed, display, field } from '../output/schema.js';
+import { translateError } from '../errors.js';
+
+function collapseHome(path: string): string {
+  const home = homedir();
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+interface SheetSummary {
+  name: string;
+  format: string;
+  records: number;
+  root: string;
+}
+
+export async function homeCommand(
+  ctx: GitsheetsContext,
+): Promise<Record<string, unknown> | string> {
+  const repo = await ctx.tryRepo();
+
+  if (!repo) {
+    return {
+      status: 'no gitsheets repo here',
+      help: [
+        '`cd` into a directory inside a gitsheets-managed git repository',
+        'Run `gitsheets-axi sheets` from there to see configured sheets',
+      ],
+    };
+  }
+
+  let sheets: Awaited<ReturnType<typeof repo.openSheets>>;
+  try {
+    sheets = await repo.openSheets();
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const summaries: SheetSummary[] = [];
+  for (const [name, sheet] of Object.entries(sheets)) {
+    let format = 'toml';
+    let root = '.';
+    let records = 0;
+    try {
+      const config = await sheet.readConfig();
+      format = config.format.type ?? 'toml';
+      root = (config as { root?: string }).root ?? '.';
+      records = await countRecords(sheet);
+    } catch {
+      // If a sheet's config is malformed, skip the record count but keep
+      // the row — agents need to see it exists.
+    }
+    summaries.push({ name, format, records, root });
+  }
+  summaries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const help: string[] = [];
+  if (summaries.length === 0) {
+    help.push(
+      'No sheets configured — add a `.gitsheets/<name>.toml` to declare one',
+    );
+  } else {
+    help.push('Run `gitsheets-axi sheets view <name>` to see a sheet\'s config');
+    help.push('Run `gitsheets-axi query <sheet>` to list records');
+  }
+
+  const gitDir = repo.gitDir;
+  const repoRoot = gitDir.endsWith('/.git') ? dirname(gitDir) : gitDir;
+
+  return renderListResponse({
+    header: { repo: collapseHome(repoRoot) },
+    name: 'sheets',
+    items: summaries as unknown as Array<Record<string, unknown>>,
+    schema: [
+      field('name'),
+      display('format'),
+      computed('records', (item) => `${item['records']}`),
+      field('root'),
+    ],
+    suggestions: help,
+    emptyMessage: 'no sheets configured in this repository',
+  });
+}

--- a/packages/gitsheets-axi/src/commands/patch.ts
+++ b/packages/gitsheets-axi/src/commands/patch.ts
@@ -1,0 +1,213 @@
+import { AxiError } from 'axi-sdk-js';
+import { mergePatch } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+import { readStdin } from '../util/stdin.js';
+
+export const PATCH_HELP = `usage: gitsheets-axi patch <sheet> <query-json> [--patch <json>] [--prefix p] [--message m]
+flags[3]:
+  --patch <json>       RFC 7396 partial. If omitted, reads stdin.
+  --prefix <p>         Tenant sub-tree scope
+  --message <m>        Commit message (default: "<sheet> patch <path>")
+examples:
+  gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane O. Doe"}'
+  echo '{"name":"Jane O. Doe"}' | gitsheets-axi patch users '{"slug":"jane"}'
+semantics:
+  RFC 7396 JSON Merge Patch. \`null\` deletes a field, arrays replace
+  in full, objects merge recursively. Same as gitsheets's library patch.
+idempotency:
+  Reads the existing record, applies the merge, runs the result through
+  willChange. If the canonical bytes are unchanged, exits 0 with
+  result: "no-op" and no commit is produced.
+`;
+
+interface PatchFlags {
+  sheet: string;
+  queryJson: string;
+  patchJson: string | undefined;
+  prefix: string | undefined;
+  message: string | undefined;
+}
+
+function parsePatchFlags(args: string[]): PatchFlags {
+  const flags: PatchFlags = {
+    sheet: '',
+    queryJson: '',
+    patchJson: undefined,
+    prefix: undefined,
+    message: undefined,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    switch (arg) {
+      case '--patch':
+        if (!next) throw new AxiError('--patch expects JSON', 'VALIDATION_ERROR');
+        flags.patchJson = next;
+        i++;
+        break;
+      case '--prefix':
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        flags.prefix = next;
+        i++;
+        break;
+      case '--message':
+        if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+        flags.message = next;
+        i++;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+            'Run `gitsheets-axi patch --help`',
+          ]);
+        }
+        positional.push(arg);
+    }
+  }
+  if (positional.length !== 2) {
+    throw new AxiError('patch requires <sheet> <query-json>', 'VALIDATION_ERROR', [
+      "Example: gitsheets-axi patch users '{\"slug\":\"jane\"}' --patch '{...}'",
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  flags.queryJson = positional[1]!;
+  return flags;
+}
+
+export async function patchCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return PATCH_HELP;
+  }
+
+  const flags = parsePatchFlags(args);
+
+  let query: Record<string, unknown>;
+  try {
+    query = JSON.parse(flags.queryJson) as Record<string, unknown>;
+  } catch (error) {
+    throw new AxiError(
+      `Could not parse query JSON: ${error instanceof Error ? error.message : String(error)}`,
+      'INVALID_JSON',
+    );
+  }
+
+  const patchJson = flags.patchJson ?? (await readStdin());
+  if (!patchJson.trim()) {
+    throw new AxiError(
+      'patch needs a partial — pass --patch <json> or pipe JSON on stdin',
+      'VALIDATION_ERROR',
+    );
+  }
+  let partial: unknown;
+  try {
+    partial = JSON.parse(patchJson);
+  } catch (error) {
+    throw new AxiError(
+      `Could not parse patch JSON: ${error instanceof Error ? error.message : String(error)}`,
+      'INVALID_JSON',
+    );
+  }
+  if (!partial || typeof partial !== 'object' || Array.isArray(partial)) {
+    throw new AxiError('Patch must be a JSON object', 'VALIDATION_ERROR');
+  }
+
+  const repo = await ctx.repo();
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  let existing;
+  try {
+    existing = await sheet.queryFirst(query);
+  } catch (error) {
+    throw translateError(error);
+  }
+  if (!existing) {
+    throw new AxiError(
+      `${flags.sheet}: no record matches the query`,
+      'NOT_FOUND',
+    );
+  }
+
+  // Apply RFC 7396 merge in-axi so we can run willChange against the result.
+  const merged = mergePatch(stripSymbols(existing), partial) as Record<
+    string,
+    unknown
+  >;
+
+  // Preserve the record's path annotation so willChange uses the rename path
+  // logic if any path-template field changed (matches Sheet.patch behavior).
+  const pathSym = (existing as Record<symbol, unknown>)[Symbol.for('gitsheets-path')];
+  if (typeof pathSym === 'string') {
+    (merged as Record<symbol, unknown>)[Symbol.for('gitsheets-path')] = pathSym;
+  }
+
+  // Body-presence on content-typed sheets: patch is body-preserving — the
+  // merged record carries the existing body forward unless the partial
+  // explicitly replaced it. Use allowMissingBody to defer the upsert guard
+  // since the merge produces the canonical record either way.
+  const upsertOpts = { allowMissingBody: true } as const;
+
+  let willResult;
+  try {
+    willResult = await sheet.willChange(merged as never, upsertOpts);
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (!willResult.changed) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      path: willResult.path,
+      hash: willResult.currentBlobHash ?? '',
+    });
+  }
+
+  const commitMessage =
+    flags.message ?? `${flags.sheet} patch ${willResult.path}`;
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(
+          flags.sheet,
+          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+        );
+        return txSheet.patch(query, partial);
+      },
+    );
+    return renderObject({
+      result: 'committed',
+      sheet: flags.sheet,
+      path: result.value.path,
+      hash: result.value.blob.hash,
+      commit: result.commitHash,
+    });
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
+function stripSymbols(record: unknown): unknown {
+  if (!record || typeof record !== 'object') return record;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(record as Record<string, unknown>)) {
+    out[key] = (record as Record<string, unknown>)[key];
+  }
+  return out;
+}

--- a/packages/gitsheets-axi/src/commands/query.ts
+++ b/packages/gitsheets-axi/src/commands/query.ts
@@ -1,0 +1,182 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderListResponse } from '../output/render.js';
+import { field } from '../output/schema.js';
+import {
+  defaultSheetSchema,
+  fieldsWithExtras,
+} from '../output/sheet-schema.js';
+
+export const QUERY_HELP = `usage: gitsheets-axi query <sheet> [--filter k=v ...] [--fields a,b,c] [--limit n]
+flags[4]:
+  --filter <k>=<v>     Equality match against record field (repeatable)
+  --fields <list>      Extra columns beyond the default schema (comma-separated)
+  --limit <n>          Cap results (default: 100, max: 10000)
+  --prefix <p>         Tenant sub-tree scope (see gitsheets --prefix)
+examples:
+  gitsheets-axi query users
+  gitsheets-axi query users --filter status=active --limit 50
+  gitsheets-axi query posts --fields title,published
+output:
+  Default schema is format-aware:
+    TOML sheets    — path-template fields + first scalar properties (cap 4)
+    Markdown/MDX   — path-template fields + title + body_size (never body content)
+  --fields appends additional columns.
+`;
+
+interface QueryFlags {
+  filters: Array<[string, string]>;
+  extras: string[];
+  limit: number;
+  prefix: string | undefined;
+}
+
+function parseQueryFlags(args: string[]): { sheetName: string; flags: QueryFlags } {
+  const sheetName = args[0];
+  if (!sheetName || sheetName.startsWith('-')) {
+    throw new AxiError('query requires a sheet name', 'VALIDATION_ERROR', [
+      'Run `gitsheets-axi query <sheet>`',
+    ]);
+  }
+
+  const flags: QueryFlags = {
+    filters: [],
+    extras: [],
+    limit: 100,
+    prefix: undefined,
+  };
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+    switch (arg) {
+      case '--filter': {
+        if (!next || !next.includes('=')) {
+          throw new AxiError(
+            '--filter expects key=value',
+            'VALIDATION_ERROR',
+            ['Example: --filter status=active'],
+          );
+        }
+        const eq = next.indexOf('=');
+        flags.filters.push([next.slice(0, eq), next.slice(eq + 1)]);
+        i++;
+        break;
+      }
+      case '--fields':
+        if (!next) {
+          throw new AxiError('--fields expects a comma-separated list', 'VALIDATION_ERROR');
+        }
+        flags.extras = next.split(',').map((s) => s.trim()).filter(Boolean);
+        i++;
+        break;
+      case '--limit':
+        if (!next) {
+          throw new AxiError('--limit expects an integer', 'VALIDATION_ERROR');
+        }
+        flags.limit = Math.min(10_000, Math.max(1, parseInt(next, 10) || 100));
+        i++;
+        break;
+      case '--prefix':
+        if (!next) {
+          throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        }
+        flags.prefix = next;
+        i++;
+        break;
+      default:
+        throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+          'Run `gitsheets-axi query --help` to see supported flags',
+        ]);
+    }
+  }
+
+  return { sheetName, flags };
+}
+
+export async function queryCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return QUERY_HELP;
+  }
+
+  const { sheetName, flags } = parseQueryFlags(args);
+  const repo = await ctx.repo();
+
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      sheetName,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const config = await sheet.readConfig();
+  const filter: Record<string, unknown> = {};
+  for (const [k, v] of flags.filters) {
+    filter[k] = v;
+  }
+
+  // Load bodies for content-typed sheets so the body_size column renders
+  // correctly. We never put body content itself into the default schema —
+  // per AXI's "long-form content belongs in detail views, not lists" — but
+  // the size is the cheap, agent-actionable summary.
+  const withBody = config.format.body !== undefined;
+
+  let records;
+  try {
+    records = await sheet.queryAll(filter, { withBody });
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const total = records.length;
+  const limited = records.slice(0, flags.limit);
+
+  const baseSchema = defaultSheetSchema(config);
+  const schema = fieldsWithExtras(baseSchema, flags.extras);
+
+  const suggestions: string[] = [];
+  if (limited.length === 0 && flags.filters.length > 0) {
+    suggestions.push(
+      'No records match the filter — try `gitsheets-axi query ' +
+        sheetName +
+        '` without filters',
+    );
+  } else if (limited.length > 0) {
+    suggestions.push(
+      `Run \`gitsheets-axi read ${sheetName} <path>\` to view a single record`,
+    );
+    if (config.format.body) {
+      suggestions.push(
+        `Add \`--full\` on \`read\` to see untruncated body content`,
+      );
+    }
+  }
+  if (total > limited.length) {
+    suggestions.push(
+      `${total - limited.length} records hidden by --limit ${flags.limit}; raise --limit to see more`,
+    );
+  }
+
+  return renderListResponse({
+    summary: { count: `${limited.length} of ${total} total` },
+    name: 'records',
+    items: limited.map((r) => ({
+      ...r,
+      // Surface the record's source path as a top-level "path" so default
+      // schemas that include it work without callers needing to know the
+      // RECORD_PATH_KEY symbol.
+      path: (r as Record<symbol, unknown>)[Symbol.for('gitsheets-path')] ?? '',
+    })) as Array<Record<string, unknown>>,
+    schema: [...schema, field('path')],
+    suggestions,
+    emptyMessage: `no records in ${sheetName}`,
+  });
+}

--- a/packages/gitsheets-axi/src/commands/read.ts
+++ b/packages/gitsheets-axi/src/commands/read.ts
@@ -1,0 +1,175 @@
+import { AxiError } from 'axi-sdk-js';
+import { NotFoundError, RECORD_PATH_KEY, RECORD_SHEET_KEY } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+
+export const READ_HELP = `usage: gitsheets-axi read <sheet> <path> [--full] [--prefix p]
+flags[2]:
+  --full               Don't truncate the body field on content-typed sheets
+  --prefix <p>         Tenant sub-tree scope (see gitsheets --prefix)
+examples:
+  gitsheets-axi read users jane
+  gitsheets-axi read posts hello --full
+output:
+  TOML sheet           — all fields, one per line
+  Markdown/MDX sheet   — frontmatter fields + body truncated to ~500 chars
+                         (with "(truncated, N chars total)" + --full hint)
+`;
+
+const BODY_PREVIEW_CHARS = 500;
+
+interface ReadFlags {
+  sheet: string;
+  path: string;
+  full: boolean;
+  prefix: string | undefined;
+}
+
+function parseReadFlags(args: string[]): ReadFlags {
+  const positional: string[] = [];
+  const flags: ReadFlags = {
+    sheet: '',
+    path: '',
+    full: false,
+    prefix: undefined,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--full') {
+      flags.full = true;
+      continue;
+    }
+    if (arg === '--prefix') {
+      if (!next) {
+        throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+      }
+      flags.prefix = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi read --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length !== 2) {
+    throw new AxiError('read requires <sheet> <path>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi read users jane',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  flags.path = positional[1]!;
+  return flags;
+}
+
+export async function readCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return READ_HELP;
+  }
+
+  const flags = parseReadFlags(args);
+  const repo = await ctx.repo();
+
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  // The path is the rendered template result; drop a trailing `.toml`/`.md`
+  // extension if the caller included one.
+  const target = stripExtension(flags.path);
+
+  let found: Record<string, unknown> | undefined;
+  try {
+    for await (const record of sheet.query()) {
+      const pathSym = (record as Record<symbol, unknown>)[RECORD_PATH_KEY];
+      if (pathSym === target) {
+        found = record as Record<string, unknown>;
+        break;
+      }
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (!found) {
+    throw translateError(
+      new NotFoundError('record_not_found', `${flags.sheet}: no record at ${target}`),
+    );
+  }
+
+  // Hydrate body for content-typed sheets — query() returns body-less records.
+  const config = await sheet.readConfig();
+  const bodyField = config.format.body;
+  if (bodyField && (found as Record<string, unknown>)[bodyField] === undefined) {
+    try {
+      found = (await sheet.loadBody(found as never)) as unknown as Record<string, unknown>;
+    } catch {
+      // Body load failure is non-fatal — agent can still see frontmatter.
+    }
+  }
+
+  const out: Record<string, unknown> = {};
+  out['record'] = projectRecord(found, bodyField, flags.full);
+
+  const help: string[] = [];
+  if (bodyField && !flags.full) {
+    const bodyValue = found[bodyField];
+    if (typeof bodyValue === 'string' && bodyValue.length > BODY_PREVIEW_CHARS) {
+      help.push(`Run \`gitsheets-axi read ${flags.sheet} ${target} --full\` to see complete body`);
+    }
+  }
+  if (help.length > 0) out['help'] = help;
+
+  return renderObject(out);
+}
+
+function stripExtension(path: string): string {
+  if (path.endsWith('.toml')) return path.slice(0, -5);
+  if (path.endsWith('.md')) return path.slice(0, -3);
+  if (path.endsWith('.mdx')) return path.slice(0, -4);
+  return path;
+}
+
+function projectRecord(
+  record: Record<string, unknown>,
+  bodyField: string | undefined,
+  full: boolean,
+): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === bodyField && !full && typeof value === 'string') {
+      if (value.length > BODY_PREVIEW_CHARS) {
+        cleaned[key] = `${value.slice(0, BODY_PREVIEW_CHARS)}…  (truncated, ${value.length} chars total)`;
+      } else {
+        cleaned[key] = value;
+      }
+      continue;
+    }
+    cleaned[key] = value;
+  }
+  // Symbol annotations: surface path as a plain field for visibility.
+  const pathSym = (record as Record<symbol, unknown>)[RECORD_PATH_KEY];
+  if (typeof pathSym === 'string') {
+    cleaned['_path'] = pathSym;
+  }
+  const sheetSym = (record as Record<symbol, unknown>)[RECORD_SHEET_KEY];
+  if (typeof sheetSym === 'string') {
+    cleaned['_sheet'] = sheetSym;
+  }
+  return cleaned;
+}

--- a/packages/gitsheets-axi/src/commands/sheets.ts
+++ b/packages/gitsheets-axi/src/commands/sheets.ts
@@ -1,0 +1,165 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderListResponse, renderObject } from '../output/render.js';
+import { computed, display, field } from '../output/schema.js';
+import { countRecords } from '../output/sheet-schema.js';
+import { Template } from 'gitsheets';
+
+export const SHEETS_HELP = `usage: gitsheets-axi sheets [<subcommand>] [flags]
+subcommands[2]:
+  list                  List sheets configured in this repository (default)
+  view <name>           Show a single sheet's config + summary
+examples:
+  gitsheets-axi sheets
+  gitsheets-axi sheets list
+  gitsheets-axi sheets view users
+`;
+
+export async function sheetsCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 1 && args[0] === '--help') return SHEETS_HELP;
+
+  const sub = args[0] ?? 'list';
+  if (sub === 'list') return sheetsList(ctx);
+  if (sub === 'view') return sheetsView(args.slice(1), ctx);
+  if (sub === '--help') return SHEETS_HELP;
+
+  throw new AxiError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
+    'Subcommands: list, view',
+  ]);
+}
+
+async function sheetsList(ctx: GitsheetsContext): Promise<string> {
+  const repo = await ctx.repo();
+  let sheets: Awaited<ReturnType<typeof repo.openSheets>>;
+  try {
+    sheets = await repo.openSheets();
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const summaries: Array<Record<string, unknown>> = [];
+  for (const [name, sheet] of Object.entries(sheets)) {
+    let format = 'toml';
+    let root = '.';
+    let records = 0;
+    try {
+      const config = await sheet.readConfig();
+      format = config.format.type ?? 'toml';
+      root = (config as { root?: string }).root ?? '.';
+      records = await countRecords(sheet);
+    } catch {
+      // skip count on malformed config
+    }
+    summaries.push({ name, format, records, root });
+  }
+  summaries.sort((a, b) =>
+    String(a['name']).localeCompare(String(b['name'])),
+  );
+
+  const help =
+    summaries.length === 0
+      ? ['No sheets — add `.gitsheets/<name>.toml` to declare one']
+      : [
+          'Run `gitsheets-axi sheets view <name>` to inspect a config',
+          'Run `gitsheets-axi query <sheet>` to list records',
+        ];
+
+  return renderListResponse({
+    name: 'sheets',
+    items: summaries,
+    schema: [
+      field('name'),
+      display('format'),
+      computed('records', (item) => `${item['records']}`),
+      field('root'),
+    ],
+    suggestions: help,
+    emptyMessage: 'no sheets configured in this repository',
+  });
+}
+
+async function sheetsView(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  const name = args[0];
+  if (!name || name.startsWith('-')) {
+    throw new AxiError('sheets view requires a sheet name', 'VALIDATION_ERROR', [
+      'Run `gitsheets-axi sheets view <name>`',
+    ]);
+  }
+  const repo = await ctx.repo();
+  let sheet;
+  try {
+    sheet = await repo.openSheet(name);
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  let config;
+  try {
+    config = await sheet.readConfig();
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const template = Template.fromString(config.path);
+  const pathFields = template.getFieldNames();
+
+  const schemaProps = schemaPropertyList(config);
+  const records = await countRecords(sheet);
+
+  const output: Record<string, unknown> = {
+    sheet: {
+      name,
+      root: (config as { root?: string }).root ?? '.',
+      format: config.format.type ?? 'toml',
+      path: config.path,
+      records,
+      path_fields: pathFields.length > 0 ? pathFields.join(', ') : '(none)',
+    },
+  };
+
+  if (config.format.body) {
+    (output['sheet'] as Record<string, unknown>)['body_field'] = config.format.body;
+  }
+
+  if (schemaProps.length > 0) {
+    output['schema'] = renderSchemaProperties(schemaProps);
+  }
+
+  output['help'] = [
+    `Run \`gitsheets-axi query ${name}\` to list records`,
+    `Run \`gitsheets-axi read ${name} <path>\` to view one record`,
+  ];
+
+  return renderObject(output);
+}
+
+function schemaPropertyList(
+  config: { schema?: unknown },
+): Array<[string, Record<string, unknown>]> {
+  const schema = config.schema as Record<string, unknown> | undefined;
+  if (!schema || typeof schema !== 'object') return [];
+  const props = schema['properties'];
+  if (!props || typeof props !== 'object') return [];
+  return Object.entries(props as Record<string, Record<string, unknown>>);
+}
+
+function renderSchemaProperties(
+  props: Array<[string, Record<string, unknown>]>,
+): Record<string, string> {
+  // Flat name → "type [required]" map for token-efficient display.
+  const out: Record<string, string> = {};
+  for (const [name, schema] of props) {
+    const type = String(schema['type'] ?? 'any');
+    const format = schema['format'] ? ` (${String(schema['format'])})` : '';
+    out[name] = `${type}${format}`;
+  }
+  return out;
+}

--- a/packages/gitsheets-axi/src/commands/upsert.ts
+++ b/packages/gitsheets-axi/src/commands/upsert.ts
@@ -1,0 +1,169 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+import { readStdin } from '../util/stdin.js';
+
+export const UPSERT_HELP = `usage: gitsheets-axi upsert <sheet> [--data <json>] [--allow-missing-body] [--prefix p] [--message m]
+flags[4]:
+  --data <json>        Record JSON inline. If omitted, reads stdin.
+  --allow-missing-body Content-typed sheets only — permit upsert without body field
+  --prefix <p>         Tenant sub-tree scope
+  --message <m>        Commit message (default: "<sheet> upsert <path>")
+examples:
+  gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
+  echo '{"slug":"jane","email":"jane@x.org"}' | gitsheets-axi upsert users
+idempotency:
+  Compares the canonical bytes the upsert would write against the
+  existing blob at the rendered path. If identical, exits 0 with
+  result: "no-op" and no commit is produced.
+`;
+
+interface UpsertFlags {
+  sheet: string;
+  data: string | undefined;
+  allowMissingBody: boolean;
+  prefix: string | undefined;
+  message: string | undefined;
+}
+
+function parseUpsertFlags(args: string[]): UpsertFlags {
+  const flags: UpsertFlags = {
+    sheet: '',
+    data: undefined,
+    allowMissingBody: false,
+    prefix: undefined,
+    message: undefined,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    switch (arg) {
+      case '--data':
+        if (!next) throw new AxiError('--data expects a JSON string', 'VALIDATION_ERROR');
+        flags.data = next;
+        i++;
+        break;
+      case '--allow-missing-body':
+        flags.allowMissingBody = true;
+        break;
+      case '--prefix':
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        flags.prefix = next;
+        i++;
+        break;
+      case '--message':
+        if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+        flags.message = next;
+        i++;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+            'Run `gitsheets-axi upsert --help`',
+          ]);
+        }
+        positional.push(arg);
+    }
+  }
+  if (positional.length !== 1) {
+    throw new AxiError('upsert requires <sheet>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi upsert users --data \'{"slug":"jane"}\'',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  return flags;
+}
+
+export async function upsertCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return UPSERT_HELP;
+  }
+
+  const flags = parseUpsertFlags(args);
+  const recordJson = flags.data ?? (await readStdin());
+  if (!recordJson.trim()) {
+    throw new AxiError(
+      'upsert needs a record — pass --data <json> or pipe JSON on stdin',
+      'VALIDATION_ERROR',
+      ['Example: gitsheets-axi upsert users --data \'{"slug":"jane"}\''],
+    );
+  }
+
+  let record: Record<string, unknown>;
+  try {
+    record = JSON.parse(recordJson) as Record<string, unknown>;
+  } catch (error) {
+    throw new AxiError(
+      `Could not parse record JSON: ${error instanceof Error ? error.message : String(error)}`,
+      'INVALID_JSON',
+      ['Ensure the input is a valid JSON object'],
+    );
+  }
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new AxiError('Record must be a JSON object', 'VALIDATION_ERROR');
+  }
+
+  const repo = await ctx.repo();
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const upsertOpts = flags.allowMissingBody ? { allowMissingBody: true } : {};
+
+  // Pre-flight idempotency check.
+  let willResult;
+  try {
+    willResult = await sheet.willChange(record as never, upsertOpts);
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (!willResult.changed) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      path: willResult.path,
+      hash: willResult.currentBlobHash ?? '',
+    });
+  }
+
+  // Carry through. willChange validated already; this re-validates inside
+  // upsert (cheap, idempotent at the validate layer). Future optimization
+  // could expose a "skip validation" path keyed off willChange's result.
+  const commitMessage =
+    flags.message ?? `${flags.sheet} upsert ${willResult.path}`;
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(
+          flags.sheet,
+          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+        );
+        return txSheet.upsert(record as never, upsertOpts);
+      },
+    );
+    return renderObject({
+      result: 'committed',
+      sheet: flags.sheet,
+      path: result.value.path,
+      hash: result.value.blob.hash,
+      commit: result.commitHash,
+    });
+  } catch (error) {
+    throw translateError(error);
+  }
+}

--- a/packages/gitsheets-axi/src/context.ts
+++ b/packages/gitsheets-axi/src/context.ts
@@ -1,0 +1,67 @@
+import { AxiError } from 'axi-sdk-js';
+import { openRepo, type Repository } from 'gitsheets';
+
+/**
+ * Lazy gitsheets repo resolver. Opens the repo when a command actually needs
+ * it. Commands that operate without a repo (currently: none — even `home`
+ * shows the repo) call `requireRepo()` to surface a structured error when
+ * the cwd isn't inside a git repo.
+ */
+export interface GitsheetsContext {
+  repo(): Promise<Repository>;
+  /**
+   * Returns `null` rather than throwing when the cwd isn't inside a git repo —
+   * `home` uses this to render a "no repo here" message instead of erroring.
+   */
+  tryRepo(): Promise<Repository | null>;
+}
+
+export function createContext(): GitsheetsContext {
+  let cached: Repository | null | undefined;
+  let cachedError: unknown;
+
+  async function load(): Promise<Repository | null> {
+    if (cached !== undefined) return cached;
+    if (cachedError !== undefined) throw cachedError;
+    try {
+      cached = await openRepo();
+      return cached;
+    } catch (error) {
+      cached = null;
+      cachedError = error;
+      throw error;
+    }
+  }
+
+  return {
+    async repo() {
+      try {
+        const result = await load();
+        if (!result) {
+          throw new AxiError(
+            'Not inside a git repository.',
+            'NOT_A_REPOSITORY',
+            ['Run this command from a directory inside a gitsheets-managed git repository.'],
+          );
+        }
+        return result;
+      } catch (error) {
+        if (error instanceof AxiError) throw error;
+        // openRepo throws when there's no git repo. Translate.
+        throw new AxiError(
+          'Not inside a git repository.',
+          'NOT_A_REPOSITORY',
+          ['Run this command from a directory inside a gitsheets-managed git repository.'],
+        );
+      }
+    },
+
+    async tryRepo() {
+      try {
+        return await load();
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/packages/gitsheets-axi/src/errors.ts
+++ b/packages/gitsheets-axi/src/errors.ts
@@ -1,0 +1,83 @@
+import { AxiError } from 'axi-sdk-js';
+import {
+  ConfigError,
+  GitsheetsError,
+  IndexError,
+  NotFoundError,
+  PathTemplateError,
+  RefError,
+  TransactionError,
+  ValidationError,
+  type ValidationIssue,
+} from 'gitsheets';
+
+/**
+ * Translate a thrown gitsheets error into an AxiError. Centralizes the
+ * error→AXI code map so individual commands can `try { ... } catch (e)
+ * { throw translateError(e); }` once.
+ *
+ * The library throws structured `GitsheetsError` subclasses with stable
+ * codes. We map each to an AxiError code that aligns with AXI conventions
+ * + add tailored next-step suggestions so agents see actionable hints
+ * rather than bare error messages.
+ */
+export function translateError(error: unknown): AxiError {
+  if (error instanceof AxiError) return error;
+
+  if (error instanceof ValidationError) {
+    const issues = formatValidationIssues(error.issues);
+    return new AxiError(
+      `Record failed validation: ${issues[0] ?? 'unknown issue'}`,
+      'VALIDATION_FAILED',
+      issues.slice(1).length > 0 ? issues.slice(1) : [],
+    );
+  }
+
+  if (error instanceof NotFoundError) {
+    return new AxiError(error.message, 'NOT_FOUND', []);
+  }
+
+  if (error instanceof ConfigError) {
+    return new AxiError(error.message, 'CONFIG_INVALID', [
+      'Inspect `.gitsheets/<sheet>.toml` — the sheet config is malformed or missing.',
+    ]);
+  }
+
+  if (error instanceof IndexError) {
+    return new AxiError(error.message, 'INDEX_CONFLICT', []);
+  }
+
+  if (error instanceof PathTemplateError) {
+    return new AxiError(error.message, 'PATH_TEMPLATE_ERROR', [
+      'Check the sheet config\'s `path` template against the record fields.',
+    ]);
+  }
+
+  if (error instanceof RefError) {
+    return new AxiError(error.message, 'REF_ERROR', []);
+  }
+
+  if (error instanceof TransactionError) {
+    return new AxiError(error.message, 'TRANSACTION_ERROR', []);
+  }
+
+  if (error instanceof GitsheetsError) {
+    return new AxiError(error.message, error.code.toUpperCase(), []);
+  }
+
+  if (error instanceof Error) {
+    return new AxiError(error.message, 'UNKNOWN_ERROR', []);
+  }
+
+  return new AxiError(String(error), 'UNKNOWN_ERROR', []);
+}
+
+function formatValidationIssues(
+  issues: readonly ValidationIssue[] | undefined,
+): string[] {
+  if (!issues || issues.length === 0) return ['(no issue details)'];
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    return `${path}: ${issue.message}`;
+  });
+}

--- a/packages/gitsheets-axi/src/output/index.ts
+++ b/packages/gitsheets-axi/src/output/index.ts
@@ -1,0 +1,2 @@
+export * from './schema.js';
+export * from './render.js';

--- a/packages/gitsheets-axi/src/output/render.ts
+++ b/packages/gitsheets-axi/src/output/render.ts
@@ -1,0 +1,70 @@
+import { encode } from '@toon-format/toon';
+
+import type { FieldDef } from './schema.js';
+
+/**
+ * Render a list of items as a TOON table.
+ *
+ * Output:
+ *   <name>[N]{col1,col2,col3}:
+ *     val1,val2,val3
+ *     val1,val2,val3
+ */
+export function renderList(
+  name: string,
+  items: Array<Record<string, unknown>>,
+  schema: FieldDef[],
+): string {
+  const projected = items.map((item) =>
+    Object.fromEntries(schema.map((f) => [f.name, f.extract(item) ?? ''])),
+  );
+  return encode({ [name]: projected });
+}
+
+export function renderObject(value: Record<string, unknown>): string {
+  return encode(value);
+}
+
+export function renderHelp(suggestions: string[]): string {
+  if (suggestions.length === 0) return '';
+  return encode({ help: suggestions });
+}
+
+export function joinBlocks(...blocks: string[]): string {
+  return blocks.filter((b) => b.length > 0).join('\n');
+}
+
+/**
+ * Compose a list response with optional header, summary, items, and help.
+ * Empty results collapse to a scalar message under the list's field name —
+ * matches the AXI "definitive empty state" convention.
+ */
+export function renderListResponse(options: {
+  header?: Record<string, unknown>;
+  name: string;
+  items: Array<Record<string, unknown>>;
+  schema: FieldDef[];
+  summary?: Record<string, unknown>;
+  suggestions?: string[];
+  emptyMessage?: string;
+}): string {
+  const blocks: string[] = [];
+  if (options.header) blocks.push(renderObject(options.header));
+  if (options.summary) blocks.push(renderObject(options.summary));
+
+  if (options.items.length === 0) {
+    blocks.push(
+      renderObject({
+        [options.name]: options.emptyMessage ?? `0 ${options.name} found`,
+      }),
+    );
+  } else {
+    blocks.push(renderList(options.name, options.items, options.schema));
+  }
+
+  if (options.suggestions?.length) {
+    blocks.push(renderHelp(options.suggestions));
+  }
+
+  return joinBlocks(...blocks);
+}

--- a/packages/gitsheets-axi/src/output/schema.ts
+++ b/packages/gitsheets-axi/src/output/schema.ts
@@ -1,0 +1,59 @@
+/**
+ * Schema builders for TOON table rendering. Each FieldDef projects from a
+ * source object (a gitsheets record or library response shape) onto a named
+ * column in the output table. Modeled after the gws-axi pattern.
+ *
+ * Usage:
+ *   const schema = [
+ *     field('slug'),
+ *     truncated('title', 60),
+ *     computed('size', (r) => Buffer.byteLength(String(r.body ?? ''), 'utf-8')),
+ *   ];
+ *   renderList('records', items, schema);
+ */
+
+export interface FieldDef {
+  name: string;
+  extract: (item: Record<string, unknown>) => unknown;
+}
+
+export function field(name: string): FieldDef {
+  return { name, extract: (item) => item[name] };
+}
+
+export function computed(
+  name: string,
+  fn: (item: Record<string, unknown>) => unknown,
+): FieldDef {
+  return { name, extract: fn };
+}
+
+/**
+ * Truncate a string to `max` chars with ellipsis. Pass-through for non-strings.
+ */
+export function truncated(name: string, max: number, alias?: string): FieldDef {
+  return {
+    name: alias ?? name,
+    extract: (item) => {
+      const value = item[name];
+      if (typeof value !== 'string') return value;
+      return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+    },
+  };
+}
+
+/**
+ * Coerce a value to its display string. Empty for null/undefined; otherwise
+ * `String(value)`. Useful when a column might hold numbers, dates, or strings.
+ */
+export function display(name: string, alias?: string): FieldDef {
+  return {
+    name: alias ?? name,
+    extract: (item) => {
+      const value = item[name];
+      if (value === null || value === undefined) return '';
+      if (value instanceof Date) return value.toISOString();
+      return String(value);
+    },
+  };
+}

--- a/packages/gitsheets-axi/src/output/sheet-schema.ts
+++ b/packages/gitsheets-axi/src/output/sheet-schema.ts
@@ -1,0 +1,119 @@
+import type { Sheet, SheetConfig } from 'gitsheets';
+import { Template } from 'gitsheets';
+
+import { computed, field, truncated, type FieldDef } from './schema.js';
+
+/**
+ * Body-size column for content-typed sheets. Reports the configured body
+ * field's byte length so agents see at a glance which records are long.
+ */
+function bodySizeField(bodyField: string): FieldDef {
+  return computed('body_size', (item) => {
+    const value = (item as Record<string, unknown>)[bodyField];
+    if (typeof value !== 'string') return '';
+    return `${Buffer.byteLength(value, 'utf-8')}`;
+  });
+}
+
+/**
+ * Build the default TOON schema for `query` against a sheet. Introspects
+ * the sheet's path template + format config so:
+ *   - TOML sheets show path-template fields plus a couple of scalar fields
+ *     from the JSON Schema (whatever's named first).
+ *   - Markdown/mdx sheets show path-template fields, `title` (denormalized
+ *     from body's H1 once #169 lands; currently a frontmatter field), and
+ *     `body_size` — never the body content.
+ *
+ * Capped at ~4 columns total to stay within the AXI "minimal default schema"
+ * budget. Consumers extend via `--fields`.
+ */
+export function defaultSheetSchema(config: SheetConfig): FieldDef[] {
+  const template = Template.fromString(config.path);
+  const pathFields = template.getFieldNames();
+  const bodyField = config.format.body;
+  const fields: FieldDef[] = [];
+  const seen = new Set<string>();
+
+  for (const name of pathFields) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    fields.push(field(name));
+  }
+
+  if (bodyField !== undefined) {
+    // Markdown/MDX: include `title` if the schema declares it, then body size.
+    if (!seen.has('title') && schemaHasProperty(config, 'title')) {
+      seen.add('title');
+      fields.push(truncated('title', 60));
+    }
+    if (!seen.has('body_size')) {
+      seen.add('body_size');
+      fields.push(bodySizeField(bodyField));
+    }
+    return fields.slice(0, 4);
+  }
+
+  // TOML: pad out with the first few non-template scalar properties from the
+  // JSON schema, capped at 4 total. Skips array/object properties — those
+  // don't tabulate well.
+  const props = schemaProperties(config);
+  for (const [name, prop] of props) {
+    if (fields.length >= 4) break;
+    if (seen.has(name)) continue;
+    if (!isScalarSchema(prop)) continue;
+    seen.add(name);
+    fields.push(field(name));
+  }
+
+  return fields;
+}
+
+function schemaProperties(config: SheetConfig): Array<[string, unknown]> {
+  const schema = config.schema as Record<string, unknown> | undefined;
+  if (!schema || typeof schema !== 'object') return [];
+  const props = schema['properties'];
+  if (!props || typeof props !== 'object') return [];
+  return Object.entries(props as Record<string, unknown>);
+}
+
+function schemaHasProperty(config: SheetConfig, name: string): boolean {
+  return schemaProperties(config).some(([n]) => n === name);
+}
+
+function isScalarSchema(prop: unknown): boolean {
+  if (!prop || typeof prop !== 'object') return false;
+  const type = (prop as Record<string, unknown>)['type'];
+  if (type === 'string' || type === 'number' || type === 'integer' || type === 'boolean') {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve the field list for a list-rendering command, optionally extending
+ * the default schema with user-supplied `--fields a,b,c` entries.
+ */
+export function fieldsWithExtras(
+  defaults: FieldDef[],
+  extras: string[],
+): FieldDef[] {
+  if (extras.length === 0) return defaults;
+  const out = [...defaults];
+  const seen = new Set(out.map((f) => f.name));
+  for (const name of extras) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    out.push(field(name));
+  }
+  return out;
+}
+
+/**
+ * Count records in a sheet. Uses queryAll under the hood — fine for repos
+ * with thousands of records; cap-checking is the consumer's job if their
+ * corpus pushes higher.
+ */
+export async function countRecords(sheet: Sheet): Promise<number> {
+  const rows = await sheet.queryAll({}, { withBody: false });
+  return rows.length;
+}

--- a/packages/gitsheets-axi/src/util/stdin.ts
+++ b/packages/gitsheets-axi/src/util/stdin.ts
@@ -1,0 +1,16 @@
+/**
+ * Read all of process.stdin to a string. Resolves to '' if stdin is a TTY
+ * (interactive — nothing to read) or when the GITSHEETS_AXI_NO_STDIN env is
+ * set (test-mode opt-out to avoid hangs in in-process test runners).
+ */
+export async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  if (process.env['GITSHEETS_AXI_NO_STDIN'] === '1') return '';
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}

--- a/packages/gitsheets-axi/test/check.test.ts
+++ b/packages/gitsheets-axi/test/check.test.ts
@@ -1,0 +1,162 @@
+// AXI check command — post-edit hook for agents that wrote a record directly.
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+pattern = '^[a-z0-9-]+$'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+
+[gitsheet.schema.properties.name]
+type = 'string'
+`;
+
+async function seedRepo(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users sheet');
+  await mkdir(join(fixture.path, 'users'), { recursive: true });
+  return fixture;
+}
+
+describe('check', () => {
+  it('reports canonical=true when the file is already in canonical form', async () => {
+    const fixture = await seedRepo();
+    // Canonical TOML: keys sorted alphabetically, double-quoted strings.
+    const canonical = `email = "jane@x.org"\nslug = "jane"\n`;
+    const target = join(fixture.path, 'users', 'jane.toml');
+    await writeFile(target, canonical, 'utf-8');
+
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/jane.toml'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: ok');
+    expect(stdout).toContain('canonical: true');
+  });
+
+  it('reports error on non-canonical file without --fix', async () => {
+    const fixture = await seedRepo();
+    // Non-canonical: keys reversed (slug should come after email alphabetically).
+    const messy = `slug = "jane"\nemail = "jane@x.org"\n`;
+    const target = join(fixture.path, 'users', 'jane.toml');
+    await writeFile(target, messy, 'utf-8');
+
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/jane.toml'],
+      fixture.path,
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toContain('NOT_CANONICAL');
+    expect(stdout).toContain('--fix');
+  });
+
+  it('rewrites the file in canonical form when --fix is passed', async () => {
+    const fixture = await seedRepo();
+    const messy = `slug = "jane"\nemail = "jane@x.org"\n`;
+    const target = join(fixture.path, 'users', 'jane.toml');
+    await writeFile(target, messy, 'utf-8');
+
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/jane.toml', '--fix'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: fixed');
+    expect(stdout).toContain('canonical: true');
+
+    const after = await readFile(target, 'utf-8');
+    // Canonical: alphabetically sorted keys.
+    expect(after.indexOf('email')).toBeLessThan(after.indexOf('slug'));
+  });
+
+  it('returns ok (not fixed) when --fix on already-canonical file', async () => {
+    const fixture = await seedRepo();
+    const canonical = `email = "jane@x.org"\nslug = "jane"\n`;
+    const target = join(fixture.path, 'users', 'jane.toml');
+    await writeFile(target, canonical, 'utf-8');
+
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/jane.toml', '--fix'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: ok');
+  });
+
+  it('reports ValidationError code for invalid records', async () => {
+    const fixture = await seedRepo();
+    const invalid = `email = "jane@x.org"\nslug = "INVALID UPPERCASE"\n`;
+    const target = join(fixture.path, 'users', 'jane.toml');
+    await writeFile(target, invalid, 'utf-8');
+
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/jane.toml'],
+      fixture.path,
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toContain('VALIDATION');
+  });
+
+  it('reports CONFIG_INVALID for unparseable files', async () => {
+    const fixture = await seedRepo();
+    const garbage = `this is not !!! valid TOML at all\n[ [ broken\n`;
+    const target = join(fixture.path, 'users', 'jane.toml');
+    await writeFile(target, garbage, 'utf-8');
+
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/jane.toml'],
+      fixture.path,
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toContain('CONFIG_INVALID');
+  });
+
+  it('reports NOT_FOUND when the target file is missing', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(
+      ['check', 'users', 'users/never-existed.toml'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toContain('NOT_FOUND');
+  });
+});

--- a/packages/gitsheets-axi/test/mutations.test.ts
+++ b/packages/gitsheets-axi/test/mutations.test.ts
@@ -1,0 +1,250 @@
+// AXI mutation commands: upsert, patch, delete — all idempotent.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from 'gitsheets';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+pattern = '^[a-z0-9-]+$'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+
+[gitsheet.schema.properties.name]
+type = 'string'
+`;
+
+async function seedRepo({ withRecords = false }: { withRecords?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add sheets');
+
+  if (withRecords) {
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed' }, async (tx) => {
+      await tx.sheet('users').upsert({
+        slug: 'jane',
+        email: 'jane@x.org',
+        name: 'Jane Doe',
+      });
+    });
+  }
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('upsert', () => {
+  it('creates a new record and commits', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      [
+        'upsert',
+        'users',
+        '--data',
+        '{"slug":"jane","email":"jane@x.org"}',
+      ],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('path: jane');
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+
+  it('is idempotent — no-op when bytes match', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      [
+        'upsert',
+        'users',
+        '--data',
+        '{"slug":"jane","email":"jane@x.org","name":"Jane Doe"}',
+      ],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('errors out when no record JSON is provided (no --data, no stdin)', async () => {
+    // In-process test runner short-circuits stdin via GITSHEETS_AXI_NO_STDIN,
+    // so this simulates the human-CLI shape of `gitsheets-axi upsert users`
+    // with no input.
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(['upsert', 'users'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toMatch(/needs a record/);
+  });
+
+  it('validation errors surface as VALIDATION_FAILED', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(
+      ['upsert', 'users', '--data', '{"slug":"INVALID UPPERCASE","email":"e@x.org"}'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toMatch(/VALIDATION/);
+  });
+
+  it('errors out on invalid JSON', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(
+      ['upsert', 'users', '--data', '{not json'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('INVALID_JSON');
+  });
+});
+
+describe('patch', () => {
+  it('applies an RFC 7396 patch and commits', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      [
+        'patch',
+        'users',
+        '{"slug":"jane"}',
+        '--patch',
+        '{"name":"Jane O. Doe"}',
+      ],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    // Verify the merge happened — name changed, email preserved.
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const updated = await (await repo.openSheet('users')).queryFirst({
+      slug: 'jane',
+    });
+    expect((updated as Record<string, unknown>)['name']).toBe('Jane O. Doe');
+    expect((updated as Record<string, unknown>)['email']).toBe('jane@x.org');
+  });
+
+  it('is idempotent — no-op when patch produces identical bytes', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '{"slug":"jane"}', '--patch', '{"name":"Jane Doe"}'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('errors when the query matches no record', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '{"slug":"nobody"}', '--patch', '{"name":"X"}'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('NOT_FOUND');
+  });
+
+  it('null deletes a field (RFC 7396)', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '{"slug":"jane"}', '--patch', '{"name":null}'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const updated = await (await repo.openSheet('users')).queryFirst({
+      slug: 'jane',
+    });
+    expect((updated as Record<string, unknown>)['name']).toBeUndefined();
+  });
+});
+
+describe('delete', () => {
+  it('removes an existing record and commits', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['delete', 'users', 'jane'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const after = await (await repo.openSheet('users')).queryFirst({
+      slug: 'jane',
+    });
+    expect(after).toBeUndefined();
+  });
+
+  it('is idempotent — no-op when the record is already absent', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['delete', 'users', 'nobody'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('errors out on missing args', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(['delete', 'users'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+  });
+});

--- a/packages/gitsheets-axi/test/read-commands.test.ts
+++ b/packages/gitsheets-axi/test/read-commands.test.ts
@@ -1,0 +1,251 @@
+// AXI read-only commands: home, sheets, query, read.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from 'gitsheets';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+
+[gitsheet.schema.properties.name]
+type = 'string'
+`;
+
+const POSTS_TOML = `[gitsheet]
+root = 'posts'
+path = '\${{ slug }}'
+
+[gitsheet.format]
+type = 'markdown'
+body = 'body'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'title']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.title]
+type = 'string'
+
+[gitsheet.schema.properties.body]
+type = 'string'
+`;
+
+async function seedRepo({ withRecords = false }: { withRecords?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await writeFile(join(fixture.path, '.gitsheets', 'posts.toml'), POSTS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add sheets');
+
+  if (withRecords) {
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed users' }, async (tx) => {
+      await tx.sheet('users').upsert({
+        slug: 'jane',
+        email: 'jane@x.org',
+        name: 'Jane Doe',
+      });
+      await tx.sheet('users').upsert({
+        slug: 'bob',
+        email: 'bob@x.org',
+        name: 'Bob Smith',
+      });
+    });
+    await repo.transact({ message: 'seed posts' }, async (tx) => {
+      await tx.sheet('posts').upsert({
+        slug: 'hello',
+        title: 'Hello World',
+        body: '# Hello\n\nA short post.\n',
+      });
+      await tx.sheet('posts').upsert({
+        slug: 'long',
+        title: 'A Long Post',
+        body: '# Long\n\n' + 'word '.repeat(200),
+      });
+    });
+  }
+
+  return fixture;
+}
+
+describe('home', () => {
+  it('emits sheets table when inside a repo with sheets', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli([], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('sheets[2]');
+    expect(stdout).toContain('users');
+    expect(stdout).toContain('posts');
+  });
+
+  it('surfaces record counts in home', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli([], fixture.path);
+    // 2 users + 2 posts; counts render as quoted strings (TOON column).
+    expect(stdout).toMatch(/users,toml,"2"/);
+    expect(stdout).toMatch(/posts,markdown,"2"/);
+  });
+});
+
+describe('sheets', () => {
+  it('list shows every sheet', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(['sheets'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('sheets[2]');
+  });
+
+  it('view shows the sheet config + schema', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(['sheets', 'view', 'users'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('sheet:');
+    expect(stdout).toContain('name: users');
+    expect(stdout).toContain('records: 2');
+    expect(stdout).toContain('path_fields: slug');
+    expect(stdout).toContain('schema:');
+  });
+
+  it('view shows body_field for content-typed sheets', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(['sheets', 'view', 'posts'], fixture.path);
+    expect(stdout).toContain('format: markdown');
+    expect(stdout).toContain('body_field: body');
+  });
+
+  it('view errors out when sheet is missing', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(
+      ['sheets', 'view', 'nonexistent'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+  });
+});
+
+describe('query', () => {
+  it('lists records with the default schema', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(['query', 'users'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('count: 2 of 2 total');
+    expect(stdout).toContain('records[2]');
+    expect(stdout).toContain('jane');
+    expect(stdout).toContain('bob');
+  });
+
+  it('filters via --filter k=v', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(
+      ['query', 'users', '--filter', 'slug=jane'],
+      fixture.path,
+    );
+    expect(stdout).toContain('count: 1 of 1 total');
+    expect(stdout).toContain('jane');
+    expect(stdout).not.toContain('bob');
+  });
+
+  it('content-typed sheet shows body_size, not body content', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(['query', 'posts'], fixture.path);
+    expect(stdout).toContain('body_size');
+    expect(stdout).not.toContain('A short post');
+    expect(stdout).not.toContain('word word word');
+  });
+
+  it('extra --fields columns append after defaults', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(
+      ['query', 'users', '--fields', 'email'],
+      fixture.path,
+    );
+    expect(stdout).toContain('email');
+    expect(stdout).toContain('jane@x.org');
+  });
+
+  it('emits a definitive empty state when no records match', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(
+      ['query', 'users', '--filter', 'slug=nobody'],
+      fixture.path,
+    );
+    expect(stdout).toMatch(/records: 0 records found|no records/);
+  });
+});
+
+describe('read', () => {
+  it('shows a single record', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(['read', 'users', 'jane'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('record:');
+    expect(stdout).toContain('jane@x.org');
+    expect(stdout).toContain('Jane Doe');
+    expect(stdout).toContain('_path: jane');
+  });
+
+  it('truncates body content on markdown sheets by default', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(['read', 'posts', 'long'], fixture.path);
+    expect(stdout).toContain('(truncated');
+    expect(stdout).toContain('--full');
+  });
+
+  it('--full shows untruncated body', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout } = await runCli(
+      ['read', 'posts', 'long', '--full'],
+      fixture.path,
+    );
+    expect(stdout).not.toContain('(truncated');
+  });
+
+  it('returns a NOT_FOUND error for missing records', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(
+      ['read', 'users', 'nobody'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toMatch(/no record at|NOT_FOUND/);
+  });
+
+  it('errors out without two positional args', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(['read', 'users'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+  });
+});

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -11,17 +11,26 @@ import { homeCommand } from '../src/commands/home.js';
 import { sheetsCommand, SHEETS_HELP } from '../src/commands/sheets.js';
 import { queryCommand, QUERY_HELP } from '../src/commands/query.js';
 import { readCommand, READ_HELP } from '../src/commands/read.js';
+import { upsertCommand, UPSERT_HELP } from '../src/commands/upsert.js';
+import { patchCommand, PATCH_HELP } from '../src/commands/patch.js';
+import { deleteCommand, DELETE_HELP } from '../src/commands/delete.js';
 
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
   query: QUERY_HELP,
   read: READ_HELP,
+  upsert: UPSERT_HELP,
+  patch: PATCH_HELP,
+  delete: DELETE_HELP,
 };
 
 const COMMANDS = {
   sheets: sheetsCommand,
   query: queryCommand,
   read: readCommand,
+  upsert: upsertCommand,
+  patch: patchCommand,
+  delete: deleteCommand,
 } as Record<
   string,
   (args: string[], ctx: GitsheetsContext | undefined) => Promise<string | Record<string, unknown>>
@@ -40,6 +49,9 @@ export async function runCli(argv: string[], cwd: string): Promise<RunResult> {
   const prevCwd = process.cwd();
   const prevExit = process.exitCode;
   let captured = '';
+
+  const prevNoStdin = process.env['GITSHEETS_AXI_NO_STDIN'];
+  process.env['GITSHEETS_AXI_NO_STDIN'] = '1';
 
   try {
     process.chdir(cwd);
@@ -63,5 +75,10 @@ export async function runCli(argv: string[], cwd: string): Promise<RunResult> {
   } finally {
     process.chdir(prevCwd);
     process.exitCode = prevExit;
+    if (prevNoStdin === undefined) {
+      delete process.env['GITSHEETS_AXI_NO_STDIN'];
+    } else {
+      process.env['GITSHEETS_AXI_NO_STDIN'] = prevNoStdin;
+    }
   }
 }

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -1,0 +1,67 @@
+// Test helper: run gitsheets-axi commands programmatically against a given
+// working directory. We can't just spawn the bin because the built `dist/`
+// might not exist during a fresh checkout. Instead, capture process.cwd(),
+// chdir to the test repo, run the SDK dispatcher, restore cwd, and return
+// the captured stdout.
+
+import { runAxiCli } from 'axi-sdk-js';
+
+import { createContext, type GitsheetsContext } from '../src/context.js';
+import { homeCommand } from '../src/commands/home.js';
+import { sheetsCommand, SHEETS_HELP } from '../src/commands/sheets.js';
+import { queryCommand, QUERY_HELP } from '../src/commands/query.js';
+import { readCommand, READ_HELP } from '../src/commands/read.js';
+
+const COMMAND_HELP: Record<string, string> = {
+  sheets: SHEETS_HELP,
+  query: QUERY_HELP,
+  read: READ_HELP,
+};
+
+const COMMANDS = {
+  sheets: sheetsCommand,
+  query: queryCommand,
+  read: readCommand,
+} as Record<
+  string,
+  (args: string[], ctx: GitsheetsContext | undefined) => Promise<string | Record<string, unknown>>
+>;
+
+export interface RunResult {
+  stdout: string;
+  exitCode: number;
+}
+
+/**
+ * Run the CLI dispatcher in-process against `cwd`. Captures stdout and the
+ * `process.exitCode` the SDK sets. Restores cwd + exitCode on return.
+ */
+export async function runCli(argv: string[], cwd: string): Promise<RunResult> {
+  const prevCwd = process.cwd();
+  const prevExit = process.exitCode;
+  let captured = '';
+
+  try {
+    process.chdir(cwd);
+    process.exitCode = 0;
+
+    await runAxiCli<GitsheetsContext>({
+      description: 'test-instance',
+      version: '0.0.0-test',
+      topLevelHelp: 'test',
+      hooks: false,
+      argv,
+      resolveContext: () => createContext(),
+      home: (_args, ctx) => homeCommand(ctx as GitsheetsContext),
+      commands: COMMANDS,
+      getCommandHelp: (command) => COMMAND_HELP[command],
+      stdout: { write: (chunk: string) => { captured += chunk; return true; } },
+    });
+
+    const exitCode = process.exitCode ?? 0;
+    return { stdout: captured, exitCode: Number(exitCode) };
+  } finally {
+    process.chdir(prevCwd);
+    process.exitCode = prevExit;
+  }
+}

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -14,6 +14,7 @@ import { readCommand, READ_HELP } from '../src/commands/read.js';
 import { upsertCommand, UPSERT_HELP } from '../src/commands/upsert.js';
 import { patchCommand, PATCH_HELP } from '../src/commands/patch.js';
 import { deleteCommand, DELETE_HELP } from '../src/commands/delete.js';
+import { checkCommand, CHECK_HELP } from '../src/commands/check.js';
 
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
@@ -22,6 +23,7 @@ const COMMAND_HELP: Record<string, string> = {
   upsert: UPSERT_HELP,
   patch: PATCH_HELP,
   delete: DELETE_HELP,
+  check: CHECK_HELP,
 };
 
 const COMMANDS = {
@@ -31,6 +33,7 @@ const COMMANDS = {
   upsert: upsertCommand,
   patch: patchCommand,
   delete: deleteCommand,
+  check: checkCommand,
 } as Record<
   string,
   (args: string[], ctx: GitsheetsContext | undefined) => Promise<string | Record<string, unknown>>

--- a/packages/gitsheets-axi/test/test-repo.ts
+++ b/packages/gitsheets-axi/test/test-repo.ts
@@ -1,0 +1,65 @@
+// Test fixture: isolated git repo in a tmpdir.
+// Used by vitest specs that exercise repo/sheet behavior against real git.
+//
+// Per #19, gitsheets v1.0 supports fresh repositories — the helper does NOT
+// create an initial commit by default. Specs that need a non-empty repo opt
+// in via `withInitialCommit: true`.
+
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+
+export interface TestRepoHandle {
+  /** Absolute path to the repo's working directory. */
+  readonly path: string;
+  /** Absolute path to the .git directory. */
+  readonly gitDir: string;
+  /** Run a git command in this repo and capture stdout/stderr. */
+  readonly git: (...args: string[]) => Promise<{ stdout: string; stderr: string }>;
+  /** Remove the temporary directory. Idempotent. */
+  readonly cleanup: () => Promise<void>;
+}
+
+export interface TestRepoOptions {
+  /** Initial branch name; defaults to `main`. */
+  readonly initialBranch?: string;
+  /** If true, create an empty initial commit. Defaults to false (fresh repo, #19). */
+  readonly withInitialCommit?: boolean;
+}
+
+export async function testRepo(opts: TestRepoOptions = {}): Promise<TestRepoHandle> {
+  const dir = await mkdtemp(join(tmpdir(), 'gitsheets-test-'));
+  const gitDir = join(dir, '.git');
+  const initialBranch = opts.initialBranch ?? 'main';
+
+  const git = (...args: string[]): Promise<{ stdout: string; stderr: string }> =>
+    exec('git', args, { cwd: dir });
+
+  await git('init', '-b', initialBranch);
+  await git('config', 'user.email', 'test@gitsheets.local');
+  await git('config', 'user.name', 'gitsheets test');
+  // Disable signing for hermetic runs.
+  await git('config', 'commit.gpgsign', 'false');
+  // Avoid noisy hooks if a contributor has globals.
+  await git('config', 'core.hooksPath', '/dev/null');
+
+  if (opts.withInitialCommit === true) {
+    await git('commit', '--allow-empty', '-m', 'initial');
+  }
+
+  let cleaned = false;
+  return {
+    path: dir,
+    gitDir,
+    git,
+    cleanup: async () => {
+      if (cleaned) return;
+      cleaned = true;
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/gitsheets-axi/tsconfig.build.json
+++ b/packages/gitsheets-axi/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "**/*.test.ts"]
+}

--- a/packages/gitsheets-axi/tsconfig.json
+++ b/packages/gitsheets-axi/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*", "bin/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/gitsheets-axi/vitest.config.ts
+++ b/packages/gitsheets-axi/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import { cpus } from 'node:os';
+
+// Match the library package's vitest layout — integration-style tests
+// against on-disk git repos benefit from the same worker cap + timeout.
+const halfCpus = Math.max(2, Math.floor(cpus().length / 2));
+
+export default defineConfig({
+  test: {
+    testTimeout: 20_000,
+    maxWorkers: halfCpus,
+    minWorkers: 1,
+  },
+});

--- a/packages/gitsheets/src/index.ts
+++ b/packages/gitsheets/src/index.ts
@@ -30,6 +30,12 @@ export type {
   AttachmentEntry,
 } from './sheet.js';
 
+export {
+  getFormat,
+  hasFormat,
+  registerFormat,
+  resolveFormatConfig,
+} from './format/index.js';
 export type { Format, FormatConfig } from './format/index.js';
 
 export { mergePatch } from './patch.js';

--- a/packages/gitsheets/src/index.ts
+++ b/packages/gitsheets/src/index.ts
@@ -17,6 +17,7 @@ export type {
   SortRule,
   UpsertResult,
   UpsertOptions,
+  WillChangeResult,
   SheetConstructorOptions,
   IndexKeyFn,
   DefineIndexOptions,

--- a/packages/gitsheets/src/sheet-will-change.test.ts
+++ b/packages/gitsheets/src/sheet-will-change.test.ts
@@ -1,0 +1,187 @@
+// Sheet.willChange — pre-flight idempotency check for upsert.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ValidationError } from './errors.js';
+import { openRepo } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_CONFIG = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+pattern = '^[a-z0-9-]+$'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+format = 'email'
+`;
+
+async function seedRepo(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_CONFIG);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users sheet');
+  return fixture;
+}
+
+describe('Sheet.willChange', () => {
+  it('returns changed=true when no record exists at the path', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const sheet = await repo.openSheet('users');
+
+    const result = await sheet.willChange({ slug: 'jane', email: 'jane@x.org' });
+
+    expect(result.changed).toBe(true);
+    expect(result.path).toBe('jane');
+    expect(result.currentBlobHash).toBeUndefined();
+    expect(result.nextText).toContain('email = "jane@x.org"');
+    expect(result.nextText).toContain('slug = "jane"');
+  });
+
+  it('returns changed=false when canonical bytes match existing blob', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed jane' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    const sheet = await repo.openSheet('users');
+    const result = await sheet.willChange({ slug: 'jane', email: 'jane@x.org' });
+
+    expect(result.changed).toBe(false);
+    expect(result.path).toBe('jane');
+    expect(result.currentBlobHash).toBeDefined();
+  });
+
+  it('returns changed=true when bytes differ from existing blob', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed jane' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    const sheet = await repo.openSheet('users');
+    const result = await sheet.willChange({ slug: 'jane', email: 'jane@new.org' });
+
+    expect(result.changed).toBe(true);
+    expect(result.path).toBe('jane');
+    expect(result.currentBlobHash).toBeDefined();
+    expect(result.nextText).toContain('email = "jane@new.org"');
+  });
+
+  it('ignores semantic-no-op input differences (object key order)', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed jane' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    const sheet = await repo.openSheet('users');
+    // Same fields, different insertion order — canonical normalization should
+    // produce identical bytes.
+    const result = await sheet.willChange({ email: 'jane@x.org', slug: 'jane' });
+
+    expect(result.changed).toBe(false);
+  });
+
+  it('does NOT mutate the tree', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    const sheet = await repo.openSheet('users');
+    await sheet.willChange({ slug: 'jane', email: 'jane@x.org' });
+
+    // queryAll should still return zero records — the willChange call must
+    // not have written anything.
+    const rows = await sheet.queryAll({});
+    expect(rows).toHaveLength(0);
+  });
+
+  it('throws ValidationError for invalid records, same as upsert', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const sheet = await repo.openSheet('users');
+
+    await expect(
+      sheet.willChange({ slug: '', email: 'jane@x.org' }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('returns the same path upsert would render', async () => {
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const sheet = await repo.openSheet('users');
+
+    const result = await sheet.willChange({ slug: 'bob-tables', email: 'bob@x.org' });
+    expect(result.path).toBe('bob-tables');
+  });
+
+  it('handles markdown sheets — body included in byte comparison', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'posts.toml'),
+      `[gitsheet]
+root = 'posts'
+path = '\${{ slug }}'
+
+[gitsheet.format]
+type = 'markdown'
+body = 'body'
+`,
+    );
+    await fixture.git('add', '.gitsheets/');
+    await fixture.git('commit', '-m', 'add posts sheet');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed post' }, async (tx) => {
+      await tx.sheet('posts').upsert({
+        slug: 'hello',
+        title: 'Hi',
+        body: '# Hello\n\nWorld\n',
+      });
+    });
+
+    const sheet = await repo.openSheet('posts');
+
+    const same = await sheet.willChange({
+      slug: 'hello',
+      title: 'Hi',
+      body: '# Hello\n\nWorld\n',
+    });
+    expect(same.changed).toBe(false);
+
+    const bodyChanged = await sheet.willChange({
+      slug: 'hello',
+      title: 'Hi',
+      body: '# Hello\n\nWorld!\n',
+    });
+    expect(bodyChanged.changed).toBe(true);
+  });
+});

--- a/packages/gitsheets/src/sheet.ts
+++ b/packages/gitsheets/src/sheet.ts
@@ -66,6 +66,24 @@ export interface UpsertResult {
 }
 
 /**
+ * Result of `Sheet.willChange` — the pre-flight idempotency check for upsert.
+ *
+ * `changed` is `false` when the canonical bytes for the supplied record
+ * match the current blob byte-for-byte. Consumers use this to skip
+ * commits that would produce empty diffs.
+ */
+export interface WillChangeResult {
+  /** Would `upsert(record)` write different bytes than what's already at `path`? */
+  readonly changed: boolean;
+  /** Sheet-relative path the record renders to (per the path template). */
+  readonly path: string;
+  /** Hash of the existing blob at `path`. `undefined` when the record doesn't exist on disk yet. */
+  readonly currentBlobHash?: string;
+  /** Serialized bytes (UTF-8 text) that `upsert` would write. */
+  readonly nextText: string;
+}
+
+/**
  * Options for `Sheet.upsert`. For content-typed (markdown) sheets only:
  * `allowMissingBody: true` permits an upsert whose record omits the body
  * field. Default `false` because upsert is a full-record replace — silently
@@ -1291,6 +1309,47 @@ export class Sheet<T extends RecordLike = RecordLike> {
     record: T,
     opts: UpsertOptions = {},
   ): Promise<UpsertResult> {
+    const { config, format, normalized, recordPath, previousPath, text } =
+      await this.#prepareUpsert(record, opts);
+
+    // Rename: if the source record was loaded from a different path, delete the old one.
+    if (previousPath !== undefined && previousPath !== recordPath) {
+      try {
+        await this.#dataTree.deleteChild(
+          joinTreePath(this.#effectiveRoot(config), `${previousPath}${format.extension}`),
+        );
+      } catch {
+        // Old path may not exist — ignore.
+      }
+    }
+
+    const blob = await this.#dataTree.writeChild(
+      joinTreePath(this.#effectiveRoot(config), `${recordPath}${format.extension}`),
+      text,
+    );
+    tx.markMutated();
+    this.#invalidateIndexes();
+    void normalized; // referenced in prepare for unique-index check
+    return { blob, path: recordPath };
+  }
+
+  /**
+   * Shared pipeline used by `upsert` and `willChange`. Runs validation,
+   * normalization, path rendering, body-presence guard, unique-index check,
+   * and format serialization — every check `upsert` would perform — but
+   * stops short of writing to the tree.
+   */
+  async #prepareUpsert(
+    record: T,
+    opts: UpsertOptions,
+  ): Promise<{
+    config: SheetConfig;
+    format: Format;
+    normalized: T;
+    recordPath: string;
+    previousPath: string | undefined;
+    text: string;
+  }> {
     const config = await this.readConfig();
     const template = Template.fromString(config.path);
 
@@ -1310,7 +1369,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
 
     // Validate before normalizing — per specs/behaviors/validation.md order:
     // JSON Schema → Standard Schema (may transform) → normalize → render → write.
-    let validated = (await validateRecord({
+    const validated = (await validateRecord({
       record: stripSymbols(record as RecordLike),
       schema: config.schema,
       schemaSourcePath: this.#configPath,
@@ -1318,9 +1377,9 @@ export class Sheet<T extends RecordLike = RecordLike> {
     })) as T;
     // Standard Schema may have transformed; re-attach annotations if the
     // caller supplied them (for rename detection below).
-    const existing = (record as Record<symbol, unknown>)[RECORD_PATH_KEY];
-    if (typeof existing === 'string') {
-      (validated as Record<symbol, unknown>)[RECORD_PATH_KEY] = existing;
+    const previousPath = (record as Record<symbol, unknown>)[RECORD_PATH_KEY];
+    if (typeof previousPath === 'string') {
+      (validated as Record<symbol, unknown>)[RECORD_PATH_KEY] = previousPath;
     }
 
     const normalized = await this.normalizeRecord(validated);
@@ -1353,26 +1412,52 @@ export class Sheet<T extends RecordLike = RecordLike> {
     }
 
     const format = this.#getFormat(config);
+    const text = await format.serialize(
+      stripSymbols(normalized as RecordLike),
+      config.format,
+    );
 
-    // Rename: if the source record was loaded from a different path, delete the old one.
-    if (typeof existing === 'string' && existing !== recordPath) {
-      try {
-        await this.#dataTree.deleteChild(
-          joinTreePath(this.#effectiveRoot(config), `${existing}${format.extension}`),
-        );
-      } catch {
-        // Old path may not exist — ignore.
-      }
+    return {
+      config,
+      format,
+      normalized,
+      recordPath,
+      previousPath: typeof previousPath === 'string' ? previousPath : undefined,
+      text,
+    };
+  }
+
+  /**
+   * Pre-flight idempotency check for `upsert`. Runs validation, normalization,
+   * and serialization but does NOT mutate the tree. Compares the resulting
+   * bytes to the current blob at the rendered path.
+   *
+   * Returns `{ changed: false, ... }` when the canonical serialization matches
+   * the existing blob — consumers can skip the commit. Throws the same errors
+   * `upsert` would on the same input (`ValidationError`, `IndexError`,
+   * `PathTemplateError`).
+   */
+  async willChange(record: T, opts: UpsertOptions = {}): Promise<WillChangeResult> {
+    const { config, format, recordPath, text } = await this.#prepareUpsert(record, opts);
+
+    const fullPath = joinTreePath(
+      this.#effectiveRoot(config),
+      `${recordPath}${format.extension}`,
+    );
+    const existing = await this.#dataTree.getChild(fullPath);
+
+    if (!existing || !isBlob(existing)) {
+      return { changed: true, path: recordPath, nextText: text };
     }
 
-    const text = await format.serialize(stripSymbols(normalized as RecordLike), config.format);
-    const blob = await this.#dataTree.writeChild(
-      joinTreePath(this.#effectiveRoot(config), `${recordPath}${format.extension}`),
-      text,
-    );
-    tx.markMutated();
-    this.#invalidateIndexes();
-    return { blob, path: recordPath };
+    const currentText = await readBlobTextCached(existing);
+    const changed = currentText !== text;
+    return {
+      changed,
+      path: recordPath,
+      currentBlobHash: existing.hash,
+      nextText: text,
+    };
   }
 
   async #deleteInTx(tx: Transaction, target: T | string): Promise<void> {

--- a/skills/gitsheets/SKILL.md
+++ b/skills/gitsheets/SKILL.md
@@ -11,15 +11,18 @@ This skill helps you assist a developer who consumes the published `gitsheets` p
 
 ## Routing
 
-Three reference files cover the surface. Read the relevant one(s) for the user's question:
+Four reference files cover the surface. Read the relevant one(s) for the user's question:
 
 | User is asking about… | Read |
 |---|---|
 | The `gitsheets` / `git sheet` CLI (commands, flags, exit codes) | `references/cli.md` |
 | The TypeScript API (`openRepo`, `Sheet`, `Transaction`, `Store`, push daemon, errors) | `references/api.md` |
 | Authoring `.gitsheets/<name>.toml` configs (path template, schema, fields, format, indices) | `references/sheet-config.md` |
+| The **agent-facing** `gitsheets-axi` CLI (TOON output, idempotent mutations, session hooks) | `references/axi.md` |
 
-If unsure or the question spans multiple surfaces, read all three. They're sized to fit comfortably in context together.
+If unsure or the question spans multiple surfaces, read all four. They're sized to fit comfortably in context together.
+
+If the user is working *inside an agent session* and wants to read/mutate gitsheets data via shell, prefer `gitsheets-axi` (`references/axi.md`). If they're writing application code, prefer the library API. If they're authoring configs or asking conceptual questions, sheet-config or api references are right.
 
 ## Always-true facts
 

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -1,0 +1,190 @@
+# gitsheets-axi reference
+
+`gitsheets-axi` is the **agent-facing** companion to `gitsheets`. Same underlying library, different ergonomics: TOON output by default, errors on stdout, idempotent mutations, format-aware schemas, self-installing session hooks.
+
+**Use `gitsheets-axi` when an agent is reading or mutating gitsheets data via shell execution.** Use the `gitsheets` library (TypeScript imports) when authoring code that runs inside an application.
+
+```bash
+npm install -g gitsheets-axi    # one-time global install
+gitsheets-axi                   # session-aware home view
+```
+
+`gitsheets-axi` shares the gitsheets minor version (1.3.x ↔ 1.3.x). Major and minor stay in lockstep; patch versions are independent. The binary self-installs `SessionStart` hooks for Claude Code and Codex on first invocation — once installed, every new agent session sees a TOON home view of the current repo's sheets.
+
+## Output: TOON
+
+[TOON](https://toonformat.dev/) is a compact JSON-like format that's ~40% cheaper in tokens. A `gitsheets-axi query users` invocation looks like:
+
+```
+count: 2 of 2 total
+records[2]{slug,email,name,path}:
+  bob,bob@x.org,Bob Smith,bob
+  jane,jane@x.org,Jane Doe,jane
+help[1]: Run `gitsheets-axi read users <path>` to view a single record
+```
+
+The leading row in a list (`records[2]{slug,email,...}`) declares the column schema; subsequent lines are the rows. Object detail views use `key: value` shape. Help suggestions arrive as `help[N]: ...` lists, one per useful next command.
+
+## Idempotency
+
+Every mutation runs a pre-flight check against the current on-disk state. When the resulting bytes would be identical to what's already there, the command exits 0 with `result: "no-op"` and **no commit is produced**. Re-running the same `upsert` ten times produces one commit (or zero, if the record already exists with those bytes).
+
+This makes agent workflows safe to retry without bookkeeping. An agent that wrote a record, lost connection, and reconnected to re-run the same upsert won't double-commit.
+
+## Errors
+
+All errors go to **stdout** (not stderr — agents typically don't read stderr). Format:
+
+```
+error: <human-readable message>
+code: <STABLE_CODE>
+help[N]: <actionable next-step suggestion>
+```
+
+The exit code is `0` for success and `(no-op)`, `2` for validation/usage errors, `1` for everything else. Stable codes include `VALIDATION_FAILED`, `NOT_FOUND`, `CONFIG_INVALID`, `NOT_CANONICAL`, `INDEX_CONFLICT`, `NOT_A_REPOSITORY`, `INVALID_JSON`, `PATH_TEMPLATE_ERROR`, `REF_ERROR`, `TRANSACTION_ERROR`.
+
+## Command surface
+
+### `gitsheets-axi` (bare)
+
+Home view. Repo path + table of sheets (name, format, record count, root) + 2-3 suggested next commands. Runs as the SessionStart hook so this state is in agent context from turn 1.
+
+### `gitsheets-axi sheets [list]`
+
+List sheets configured in the current repo. Same data as the home view, separated command for explicit invocation.
+
+### `gitsheets-axi sheets view <name>`
+
+Single-sheet detail: config summary (root, format, path template), schema property types, record count. Surfaces `body_field` for content-typed sheets.
+
+### `gitsheets-axi query <sheet> [flags]`
+
+List records.
+
+| Flag | Notes |
+|---|---|
+| `--filter <k>=<v>` | Equality match; repeatable |
+| `--fields <list>` | Extra columns beyond the default schema |
+| `--limit <n>` | Default 100, max 10000 |
+| `--prefix <p>` | Tenant sub-tree scope (matches the library's `prefix` option) |
+
+**Default schema is format-aware:**
+
+- **TOML sheets** — path-template fields + first scalar schema properties, capped at 4 columns.
+- **Markdown/MDX sheets** — path-template fields + `title` (if in schema) + `body_size` (byte count). Body content itself never appears in lists — that belongs in `read`.
+
+The summary line `count: N of M total` is always present so agents know when results are paginated.
+
+### `gitsheets-axi read <sheet> <path> [--full]`
+
+Single-record detail. For markdown/mdx sheets, the body field is truncated to ~500 chars with `(truncated, N chars total)` and a `--full` hint. Surfaces `_path` and `_sheet` as plain fields (the `RECORD_PATH_KEY` / `RECORD_SHEET_KEY` Symbol annotations).
+
+### `gitsheets-axi upsert <sheet> [--data <json>] [flags]`
+
+Create or replace a record.
+
+| Flag | Notes |
+|---|---|
+| `--data <json>` | Record JSON inline. If omitted, reads stdin. |
+| `--allow-missing-body` | Content-typed sheets only — opt in to upserting without body field |
+| `--prefix <p>` | Tenant scope |
+| `--message <m>` | Commit message (default: `<sheet> upsert <path>`) |
+
+**Idempotent:** if the canonical bytes match the existing record, exits 0 with `result: "no-op"` and no commit.
+
+Output on commit:
+
+```
+result: committed
+sheet: users
+path: jane
+hash: 4d3f...
+commit: a1b2c3...
+```
+
+Output on no-op:
+
+```
+result: no-op
+sheet: users
+path: jane
+hash: 4d3f...
+```
+
+### `gitsheets-axi patch <sheet> <query-json> [--patch <json>] [flags]`
+
+RFC 7396 JSON Merge Patch against the record matched by `<query-json>`. `null` deletes a field, arrays replace, objects merge recursively.
+
+| Flag | Notes |
+|---|---|
+| `--patch <json>` | Partial JSON. If omitted, reads stdin. |
+| `--prefix <p>` | Tenant scope |
+| `--message <m>` | Commit message |
+
+**Idempotent.** Same no-op semantics as upsert.
+
+Throws `NOT_FOUND` if the query matches no record.
+
+### `gitsheets-axi delete <sheet> <path> [flags]`
+
+Delete the record at `<path>`.
+
+| Flag | Notes |
+|---|---|
+| `--prefix <p>` | Tenant scope |
+| `--message <m>` | Commit message |
+
+**Idempotent on already-missing.** Agents can call `delete` without checking existence; an already-absent record exits 0 with `result: "no-op"`.
+
+### `gitsheets-axi check <sheet> <file> [--fix]`
+
+Verify a record file in the working tree is parseable, valid against the sheet's schema, and in canonical form. Reads from the working tree (not git). **Never commits.**
+
+| Flag | Notes |
+|---|---|
+| `--fix` | Rewrite the file in canonical form if not already canonical |
+| `--prefix <p>` | Tenant scope |
+
+Designed as a post-edit hook for agents that wrote a record directly:
+
+- With `--fix` (post-edit): `gitsheets-axi check users users/jane.toml --fix` lands the file in canonical form
+- Without `--fix` (pre-commit): non-zero exit blocks the commit when the file isn't canonical
+
+Outputs:
+
+- `result: ok` — already canonical
+- `result: fixed` — rewritten by --fix
+- `NOT_CANONICAL` error (exit 1) when not canonical and --fix wasn't passed
+- `VALIDATION_FAILED` (exit 2) when the record fails schema validation
+- `CONFIG_INVALID` when the file fails to parse as the sheet's format
+- `NOT_FOUND` when the target file doesn't exist
+
+## When to use `gitsheets-axi` vs `gitsheets`
+
+| Scenario | Use |
+|---|---|
+| Agent is reading/writing records via shell | `gitsheets-axi` |
+| Writing TypeScript that imports `gitsheets` | `gitsheets` library |
+| Authoring `.gitsheets/<name>.toml` configs | Either (the configs are the same) |
+| Building a long-running consumer service | `gitsheets` library (with push daemon) |
+| Post-edit / pre-commit hook for record files | `gitsheets-axi check` |
+| Interactive human workflow | `gitsheets` (human CLI) |
+
+When in doubt: `gitsheets-axi` for agent shell invocations; `gitsheets` for everything else. Sheet configs (`.gitsheets/*.toml`) are shared — both tools read the same files.
+
+## Hook installation
+
+`gitsheets-axi` self-installs SessionStart hooks on first invocation:
+
+- **Claude Code** — `~/.claude/settings.json` SessionStart entry
+- **Codex** — `~/.codex/hooks.json` SessionStart entry + `[features].hooks = true` in `config.toml`
+
+The hook runs `gitsheets-axi` (the bare home view), so every new session opens with a compact view of the current repo's sheets already in context. The install is **self-healing**: every invocation re-checks the hook's binary path and updates it if the executable moved (reinstall, asdf version change).
+
+Disable hooks for the current invocation with `GITSHEETS_AXI_DISABLE_HOOKS=1`.
+
+## See also
+
+- `references/cli.md` — the human-facing `gitsheets` / `git sheet` CLI
+- `references/api.md` — the TypeScript library API
+- `references/sheet-config.md` — `.gitsheets/<name>.toml` grammar (shared)

--- a/specs/api/sheet.md
+++ b/specs/api/sheet.md
@@ -75,6 +75,32 @@ const { blob, path } = await sheet.upsert({
 
 Throws `ValidationError` on invalid input. Throws `PathTemplateError` if the template can't render against the record.
 
+### `sheet.willChange(record, opts?)`
+
+Pre-flight idempotency check for `upsert`. Returns the canonical bytes the upsert would write and whether they differ from the current blob at the rendered path. Does NOT mutate the tree.
+
+```typescript
+const { changed, path, currentBlobHash, nextText } = await sheet.willChange({
+  slug: 'janedoe',
+  email: 'jane@x.org',
+});
+if (changed) {
+  await sheet.upsert({ slug: 'janedoe', email: 'jane@x.org' });
+}
+```
+
+- Runs the same pipeline as `upsert` (body-presence guard, JSON Schema + Standard Schema validation, canonical normalization, path rendering, unique-index conflict check, format serialization) — throws the same errors `upsert` would on the same input.
+- Compares the serialized bytes to the existing blob at the rendered path.
+- Returns `{ changed, path, currentBlobHash, nextText }`:
+  - `changed: boolean` — `true` if the bytes differ, `false` for a logical no-op.
+  - `path: string` — sheet-relative path the record renders to.
+  - `currentBlobHash?: string` — hash of the existing blob, or `undefined` when the record doesn't exist on disk yet.
+  - `nextText: string` — the UTF-8 serialized bytes that `upsert` would write.
+
+`opts` matches `upsert` — `allowMissingBody` behaves the same way.
+
+Intended for consumers that want commit-skipping idempotency semantics: "only commit when something actually changed." The agent-facing CLI (`gitsheets-axi`) uses this to make mutations idempotent — an `upsert` of unchanged content exits 0 with `(no-op)` rather than producing an empty commit.
+
 ### `sheet.delete(recordOrPath)`
 
 ```typescript


### PR DESCRIPTION
## Summary

Lands the **MVP** of `gitsheets-axi`, the agent-facing companion CLI: TOON output, idempotent mutations, format-aware schemas, self-installing session hooks (Claude Code + Codex via the AXI SDK).

Same gitsheets library underneath — `gitsheets-axi` is a thin facade on top, no operation is reimplemented.

Resolves a major slice of #170. The remaining items (diff, normalize, init/infer/migrate-config, attachments, one-shot push) are deferred to follow-up PRs.

## What's in the MVP

| Command | Behavior |
|---|---|
| `gitsheets-axi` (bare) | Home view — repo + sheets table + next-step suggestions |
| `sheets [list]` | Sheets table |
| `sheets view <name>` | Sheet config + schema + record count |
| `query <sheet>` | Records list with format-aware default schema, `--filter`/`--fields`/`--limit`/`--prefix` |
| `read <sheet> <path>` | Record detail; body truncated to ~500 chars with `--full` opt-out |
| `upsert <sheet>` | Idempotent (via `sheet.willChange`) — no-op exits 0 |
| `patch <sheet> <query> <patch>` | RFC 7396, idempotent |
| `delete <sheet> <path>` | Idempotent on already-missing |
| `check <sheet> <file> [--fix]` | Post-edit hook for agents that wrote records directly |

Every mutation returns `result: "committed"` or `result: "no-op"` so workflows are safe to retry.

## Library-side addition

**`sheet.willChange(record, opts?)`** — pre-flight idempotency check. Runs upsert's full validate→normalize→render→serialize pipeline and compares the resulting bytes to the current blob at the path — without mutating. Returns `{ changed, path, currentBlobHash?, nextText }`. This is what powers `gitsheets-axi`'s no-op detection, but it's a useful primitive for any consumer that wants commit-skipping semantics. Speced in [`specs/api/sheet.md`](https://github.com/JarvusInnovations/gitsheets/blob/feat/axi-scaffold/specs/api/sheet.md).

Also exposed from the public surface: `getFormat`, `hasFormat`, `registerFormat`, `resolveFormatConfig` — needed so the AXI tool can dispatch on a sheet's format the same way the library does internally.

## Layout

`packages/gitsheets-axi/` — sibling workspace package next to `packages/gitsheets/`. Lockstep minor versioning (`gitsheets-axi@1.3.x` ↔ `gitsheets@1.3.x`).

Built on [`axi-sdk-js`](https://www.npmjs.com/package/axi-sdk-js) — the AXI authors' shared runtime that handles dispatch, hook installation, `--help`/`--version`, and TOON encoding at the output boundary.

## Tests

- **35 axi tests** — every command's happy path + error paths + idempotency assertions (incl. commit-count checks proving no-ops truly don't commit)
- **+8 library tests** for `sheet.willChange` (byte-match, key-order canonicalization, no-mutation, error pass-through, markdown sheets)
- Library suite still 250/250 green

## Skill

`skills/gitsheets/references/axi.md` covers the full agent-facing surface. `SKILL.md` routes to it with a "shell-invocation → axi, application-code → library" decision rule.

## Release pipeline

`publish-npm.yml` now publishes both packages on tag pushes. The axi package's `gitsheets` dep is `"*"` in-repo (workspace symlink); the workflow rewrites it to `^<minor>` before publishing so consumers see a proper version range.

## Deferred to follow-up PRs

- `diff <sheet> <ref>` — TOON change summary
- `normalize <sheet>` — bulk `check --fix` across a sheet
- `init` / `infer` / `migrate-config` — config scaffolding for agents
- `attachment {list,get,set,delete}` — binary blob ops
- `push` — one-shot push (daemon control is a lifecycle concern, deferred)
- OpenCode hook support — currently constrained by what `axi-sdk-js` ships (Claude Code + Codex only)

## Test plan

- [x] `npm install && npm run build && npm test && npm run type-check` from root — all green
- [x] `gitsheets-axi` smoke-tested against a seeded local repo (home, sheets, sheets view, query, read, upsert/no-op cycle, patch idempotency, delete idempotency, check --fix)
- [x] `npm publish --dry-run -w gitsheets-axi` — 27.8 kB tarball, 69 files
- [ ] CI green on this PR (multi-Node matrix)
- [ ] After merge: cut v1.3.0 tag — publish-npm.yml ships both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)