### PR TITLE
feat: gitsheets-axi — remaining commands (diff, normalize, init, infer, migrate-config, attachment, push)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Targets Node.js ≥ 20 and Bun ≥ 1. ESM-only. CLI installs as `gitsheets` and 
 
 - **[CLI reference](cli.md)** — `git sheet <command>`, global flags, exit codes.
 - **[API reference](api.md)** — public exports + pointers into the per-symbol spec.
+- **[`gitsheets-axi`](axi.md)** — the agent-facing companion CLI (TOON output, idempotent mutations, session hooks).
 - **[Path templates](path-templates.md)** — syntax, recursive fields, query pruning, invalid-char handling.
 - **[Validation](validation.md)** — JSON Schema in `.gitsheets/<sheet>.toml`, optional Standard Schema layering.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,8 @@ import {
 
   // utilities
   mergePatch, validateRecord,
+  parseToml, parseConfigToml, stringifyRecord,
+  getFormat, hasFormat, registerFormat, resolveFormatConfig,
 
   // record annotation symbols
   RECORD_SHEET_KEY, RECORD_PATH_KEY,
@@ -32,7 +34,7 @@ Type-only exports (selected highlights):
 import type {
   OpenRepoOptions, OpenSheetOptions, OpenSheetsOptions,
   TransactionOptions, TransactionResult, TransactionHandler, Author,
-  SheetConfig, SheetFieldConfig, SortRule, UpsertResult, UpsertOptions,
+  SheetConfig, SheetFieldConfig, SortRule, UpsertResult, UpsertOptions, WillChangeResult,
   SheetConstructorOptions, IndexKeyFn, DefineIndexOptions, QueryFilter, QueryOptions,
   DiffStatus, DiffOptions, DiffChange,
   AttachmentBlobHandle, AttachmentEntry,
@@ -108,10 +110,13 @@ const store = await openStore(repo, {
 | `sheet.upsert(record, opts?)` | Insert or replace; returns `{ blob, path }`. `opts.allowMissingBody` for content-typed sheets |
 | `sheet.delete(recordOrPath)` | Remove a record + cascade attachments |
 | `sheet.patch(query, partial)` | RFC 7396 merge patch over an existing record |
+| `sheet.willChange(record, opts?)` | Pre-flight idempotency check — returns `{ changed, path, currentBlobHash?, nextText }` without mutating the tree (v1.3) |
 | `sheet.clear()` | Remove every record from the sheet's tree |
 | `sheet.clone()` | Clone the Sheet for staging tentative state |
 
 All write methods route through a transaction — permissive mode auto-opens one; strict mode requires `repo.transact`.
+
+`willChange` runs upsert's full validation + normalization + serialization pipeline and compares the resulting bytes to the existing blob at the rendered path. Useful for consumers that want commit-skipping idempotency semantics — "only commit if something actually changed." Throws the same errors upsert would on the same input (`ValidationError`, `IndexError`, `PathTemplateError`).
 
 ### Attachments
 
@@ -244,6 +249,27 @@ RFC 7396 JSON Merge Patch as a pure function. Useful when you want the patch sem
 ### `validateRecord({ record, schema, validator? })`
 
 Run the same validation pipeline `Sheet.upsert` uses without going through a Sheet. Useful for pre-flight (UI form submission, CSV ingest, audit passes against legacy records). Returns the possibly-transformed record on success, throws `ValidationError` on failure. See [`specs/behaviors/validation.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/validation.md).
+
+### TOML round-tripping
+
+| Symbol | Use |
+| --- | --- |
+| `parseToml(text)` | Parse TOML to a plain object; preserves `@iarna/toml` date types |
+| `parseConfigToml(text, sourcePath)` | Same parse with config-aware error messages — for `.gitsheets/<sheet>.toml` |
+| `stringifyRecord(record)` | Serialize an object to canonical TOML (deep-sorted keys) |
+
+Used by the AXI tool's config-scaffolding commands; available to consumers that need raw config-text round-tripping.
+
+### Format dispatch
+
+| Symbol | Use |
+| --- | --- |
+| `getFormat(type)` | Resolve a format implementation by name (`'toml'`, `'markdown'`, `'mdx'`) |
+| `hasFormat(type)` | Probe whether a format is registered |
+| `registerFormat(type, impl)` | Register a custom format implementation |
+| `resolveFormatConfig(raw)` | Validate and normalize a `[gitsheet.format]` block |
+
+Available for consumers who want to render records through a sheet's configured format without going through a `Sheet` instance.
 
 ## Conventions
 

--- a/docs/axi.md
+++ b/docs/axi.md
@@ -1,0 +1,131 @@
+# gitsheets-axi
+
+`gitsheets-axi` is the agent-facing companion to `gitsheets`. Same library underneath, different ergonomics: TOON output by default, errors on stdout, idempotent mutations, format-aware schemas, self-installing session hooks.
+
+```bash
+npm install -g gitsheets-axi
+gitsheets-axi              # session-aware home view in a gitsheets-managed repo
+```
+
+`gitsheets-axi` ships lockstep on minor with `gitsheets` (`gitsheets-axi@1.3.x` ↔ `gitsheets@1.3.x`). Patch versions are independent.
+
+## When to use which
+
+The two packages are intentionally separate because the AXI contract disagrees with a human-CLI contract on too many defaults to coexist in one binary without conditional logic at every output site.
+
+| Scenario | Use |
+|---|---|
+| Agent reads/writes records via shell execution | `gitsheets-axi` |
+| Writing TypeScript that imports the library | [`gitsheets`](api.md) library |
+| Authoring `.gitsheets/<name>.toml` configs | Either (configs are shared) |
+| Building a long-running consumer service | `gitsheets` library (with push daemon) |
+| Post-edit / pre-commit hook for record files | `gitsheets-axi check` |
+| Interactive human workflow | `gitsheets` (human CLI) |
+
+Sheet configs are the shared substrate — both tools read the same `.gitsheets/*.toml` files. Whichever way you read/write the data, the schema, path template, normalization rules, and format are the same.
+
+## What's different from the human CLI
+
+Every difference is in service of agents talking to the CLI through shell execution rather than humans driving it interactively.
+
+| Convention | `gitsheets` (human) | `gitsheets-axi` (agent) |
+|---|---|---|
+| Errors | stderr, non-zero exit | **stdout** (agents read it), non-zero exit |
+| `$ <bin>` with no args | usage / help | **live content** (sheets + counts + suggested actions) |
+| Duplicate / no-op mutation | throws `NotFoundError` / similar | **idempotent**, exit 0 with `result: "no-op"` |
+| Default output | JSON / pretty per `--format` | **TOON** (~40% fewer tokens), `--format=json` opt-out |
+| Default schema | every field a human might want | **minimal**, `--fields` opts in to more |
+| `--help` | full manual per command | concise reference + 2-3 examples |
+| Session-hook install | doesn't touch agent config | **self-installs** SessionStart hooks |
+
+## Output: TOON
+
+[TOON](https://toonformat.dev/) (Token-Oriented Object Notation) is the default output format on stdout:
+
+```text
+count: 2 of 2 total
+records[2]{slug,email,name,path}:
+  bob,bob@x.org,Bob Smith,bob
+  jane,jane@x.org,Jane Doe,jane
+help[1]: Run `gitsheets-axi read users <path>` to view a single record
+```
+
+The `records[2]{slug,email,name,path}:` header declares the schema; each subsequent line is a row. Object detail views use `key: value` shape. Suggestions arrive as `help[N]:` lists. TOON saves ~40% on tokens compared to equivalent JSON while staying readable.
+
+`--format=json` opts back to JSON for agents / pipelines that prefer it.
+
+## Idempotency
+
+Every mutation pre-flights against the current on-disk state. When the resulting bytes would match what's already there, the command exits `0` with `result: "no-op"` and **produces no commit**.
+
+```text
+$ gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
+result: committed
+sheet: users
+path: jane
+commit: a1b2c3...
+
+$ gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
+result: no-op
+sheet: users
+path: jane
+```
+
+Same goes for `patch`, `delete`, `check --fix`, `normalize`, `init`, `infer`, `migrate-config`, `attachment set`, `attachment delete`, and `push` — re-runs with unchanged input produce no commit.
+
+Under the hood, mutations use the library's [`Sheet.willChange()`](api.md) (added in v1.3) to check whether the canonical bytes would differ from what's already at the rendered path. Re-runnable workflows can safely retry on disconnects without bookkeeping.
+
+## Session hooks
+
+On first invocation, `gitsheets-axi` self-installs `SessionStart` hooks into:
+
+- **Claude Code** — `~/.claude/settings.json`
+- **Codex** — `~/.codex/hooks.json` + `[features].hooks = true` in `config.toml`
+
+The hook runs the bare home view at every session start, so the agent's initial context already includes a compact view of the current repo's sheets. The install is **self-healing** — every invocation re-checks the hook's binary path and updates it if the executable moved (reinstall, asdf version change, etc.).
+
+Set `GITSHEETS_AXI_DISABLE_HOOKS=1` to suppress installation.
+
+## Commands
+
+```text
+gitsheets-axi                            # home view (bare invocation)
+gitsheets-axi sheets [list|view <name>]  # sheets in this repo
+gitsheets-axi query <sheet> [filters]    # list records
+gitsheets-axi read <sheet> <path>        # single record detail
+gitsheets-axi upsert <sheet>             # create or replace (idempotent)
+gitsheets-axi patch <sheet> <q> <p>      # RFC 7396 merge patch (idempotent)
+gitsheets-axi delete <sheet> <path>      # remove a record (idempotent)
+gitsheets-axi check <sheet> <file>       # verify + optionally --fix
+gitsheets-axi diff <sheet> [<src-ref>]   # TOON change summary
+gitsheets-axi normalize <sheet>          # bulk re-canonicalize
+gitsheets-axi init <sheet>               # scaffold a starter config
+gitsheets-axi infer <sheet>              # observe records → schema
+gitsheets-axi migrate-config <sheet>     # pre-v1.0 [fields] → [schema]
+gitsheets-axi attachment <list|get|set|delete> <sheet> <path> [<name>]
+gitsheets-axi push                       # one-shot git push
+```
+
+Every command supports `--help` with its specific flags and 2-3 examples.
+
+## Errors
+
+Errors go to **stdout** (not stderr — agents typically don't read stderr), in the same structured shape:
+
+```text
+error: Record failed validation: slug: must NOT have fewer than 1 characters
+code: VALIDATION_FAILED
+help[1]: Run `gitsheets-axi sheets view users` to see the schema
+```
+
+Stable codes the agent can switch on: `VALIDATION_FAILED`, `NOT_FOUND`, `CONFIG_INVALID`, `NOT_CANONICAL`, `INDEX_CONFLICT`, `NOT_A_REPOSITORY`, `INVALID_JSON`, `PATH_TEMPLATE_ERROR`, `REF_ERROR`, `TRANSACTION_ERROR`, `CONFIG_EXISTS`, `NO_RECORDS`, `WRITE_ERROR`, `NON_FAST_FORWARD`, `PUSH_FAILED`.
+
+Exit codes are stable: `0` for success (incl. no-ops), `2` for validation/usage errors, `1` for everything else.
+
+## See also
+
+- [API reference](api.md) — the library both tools share
+- [CLI reference](cli.md) — the human `gitsheets` / `git sheet` CLI
+- [Concepts](concepts.md) — Repository, Sheet, Path Template, Transaction
+- [AXI specification](https://github.com/kunchenguid/axi) — the 10 ergonomic principles
+- [TOON specification](https://toonformat.dev/) — the output format

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -178,6 +178,28 @@ Fully additive minor release. Existing v1.1 code keeps working.
 
 - **`skills/gitsheets/`** — bundled Claude Code skill for developers consuming gitsheets. Reference material covering the CLI, the TypeScript API, and the sheet config syntax. Install it in your `.claude/skills/` (or via plugin) to give Claude focused gitsheets context.
 
+## v1.2 → v1.3
+
+Fully additive minor release. Existing v1.2 code keeps working.
+
+### Library
+
+- **`Sheet.willChange(record, opts?)`** — new. Pre-flight idempotency check that runs upsert's full validation + normalization + serialization pipeline and compares the resulting bytes to the existing blob at the rendered path — without mutating the tree. Returns `{ changed, path, currentBlobHash?, nextText }`. Consumers that want commit-skipping semantics ("only commit if something actually changed") can pre-flight + skip when `changed: false`. Throws the same errors `upsert` would.
+- **New utility exports**: `parseToml`, `parseConfigToml`, `stringifyRecord` (TOML round-tripping), `getFormat`, `hasFormat`, `registerFormat`, `resolveFormatConfig` (format dispatch). All were already in the package's internal modules; v1.3 surfaces them at the package root for consumers who need raw-bytes round-tripping or custom format registration.
+- **New public type**: `WillChangeResult`.
+
+### Tooling
+
+- **`gitsheets-axi`** — new sibling npm package. Agent-facing CLI with TOON output, idempotent mutations, self-installing session hooks (Claude Code + Codex), format-aware default schemas. Lockstep-versioned with the library on minor. See [`docs/axi.md`](axi.md). Install with `npm install -g gitsheets-axi`.
+
+### Repository layout (no consumer impact)
+
+- The repository was promoted to an npm workspaces monorepo. The published `gitsheets` package now lives at `packages/gitsheets/`; the agent-facing companion at `packages/gitsheets-axi/`. Consumer code is unaffected — `import { ... } from 'gitsheets'` resolves the same surface as before, and the published tarball has the same shape.
+
+### CLI
+
+No new commands on the human `gitsheets` CLI in v1.3. The agent-facing operations (TOON output, idempotent mutations) live in `gitsheets-axi` rather than as flags on the human CLI — the two contracts disagree on too many defaults to coexist in one binary.
+
 ## Going forward
 
 Once migrated, the recipes are the fastest path to common patterns:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Validation: validation.md
       - CLI: cli.md
       - API reference: api.md
+      - gitsheets-axi (agent CLI): axi.md
   - Recipes:
       - Typed sheet with Zod: recipes/typed-sheet-with-zod.md
       - Request-bound transactions: recipes/request-bound-transactions.md

--- a/packages/gitsheets-axi/LICENSE
+++ b/packages/gitsheets-axi/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/gitsheets-axi/README.md
+++ b/packages/gitsheets-axi/README.md
@@ -1,0 +1,116 @@
+# gitsheets-axi
+
+Agent-facing CLI for [`gitsheets`](https://www.npmjs.com/package/gitsheets) — designed with the [AXI](https://github.com/kunchenguid/axi) (Agent eXperience Interface) ergonomic standards.
+
+Same underlying library as the human `gitsheets` CLI, different ergonomics:
+
+- **TOON output** by default — ~40% fewer tokens than equivalent JSON
+- **Idempotent mutations** — re-running with unchanged state returns `result: "no-op"`, no commit
+- **Errors on stdout** with stable codes and actionable hints
+- **Self-installing session hooks** for Claude Code and Codex
+
+```bash
+npm install -g gitsheets-axi
+gitsheets-axi              # session-aware home view
+```
+
+Requires Node.js ≥ 20 and a `gitsheets`-managed git repository. Lockstep-versioned with the `gitsheets` library on minor (`gitsheets-axi@1.3.x` ↔ `gitsheets@1.3.x`).
+
+## When to use this vs. `gitsheets`
+
+| Scenario | Use |
+|---|---|
+| Agent reading or mutating records via shell | `gitsheets-axi` |
+| Writing TypeScript that imports the library | [`gitsheets`](https://www.npmjs.com/package/gitsheets) |
+| Authoring `.gitsheets/<name>.toml` configs | Either (configs are shared) |
+| Post-edit / pre-commit hook for record files | `gitsheets-axi check` |
+| Interactive human workflow | `gitsheets` (human CLI) |
+
+## Commands
+
+```text
+gitsheets-axi                            # home view (bare invocation)
+gitsheets-axi sheets [list|view <name>]
+gitsheets-axi query <sheet> [--filter k=v ...] [--fields ...] [--limit n]
+gitsheets-axi read <sheet> <path> [--full]
+gitsheets-axi upsert <sheet> [--data <json>] [--allow-missing-body]
+gitsheets-axi patch <sheet> <query-json> [--patch <json>]
+gitsheets-axi delete <sheet> <path>
+gitsheets-axi check <sheet> <file> [--fix]
+gitsheets-axi diff <sheet> [<src-ref>] [--patches]
+gitsheets-axi normalize <sheet>
+gitsheets-axi init <sheet> [--path <template>] [--schema <file>] [--force]
+gitsheets-axi infer <sheet>
+gitsheets-axi migrate-config <sheet>
+gitsheets-axi attachment <list|get|set|delete> <sheet> <path> [<name>]
+gitsheets-axi push [--remote r] [--branch b]
+```
+
+Run any command with `--help` for its flags + examples. Every command runs `--help` against itself, not the top-level manual.
+
+## Idempotency contract
+
+Every mutation pre-flights against the current on-disk state. When the resulting bytes would match what's already there, the command exits `0` with `result: "no-op"` and **produces no commit**. Agents can re-run workflows after disconnects, retries, or partial failures without double-committing.
+
+```text
+$ gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
+result: committed
+sheet: users
+path: jane
+commit: a1b2c3...
+
+$ gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
+result: no-op
+sheet: users
+path: jane
+```
+
+## Session hooks
+
+On first invocation, `gitsheets-axi` installs `SessionStart` hooks into:
+
+- **Claude Code** — `~/.claude/settings.json`
+- **Codex** — `~/.codex/hooks.json` + `[features].hooks = true` in `config.toml`
+
+The hook runs the bare home view at every session start, so the agent sees the current repo's sheets in its initial context. The install **self-heals** — every invocation re-checks the hook's binary path and updates it if the executable moved.
+
+Set `GITSHEETS_AXI_DISABLE_HOOKS=1` to suppress installation.
+
+## Output: TOON
+
+[TOON](https://toonformat.dev/) (Token-Oriented Object Notation) is the default output:
+
+```text
+count: 2 of 2 total
+records[2]{slug,email,name,path}:
+  bob,bob@x.org,Bob Smith,bob
+  jane,jane@x.org,Jane Doe,jane
+help[1]: Run `gitsheets-axi read users <path>` to view a single record
+```
+
+The leading `records[2]{slug,email,name,path}:` line declares the column schema; each subsequent line is a row. Object detail views use `key: value` shape. Help suggestions arrive as `help[N]: ...` lists, one per useful next command.
+
+## Errors
+
+Errors go to **stdout** (not stderr — agents typically don't read stderr), in the same TOON shape:
+
+```text
+error: Record failed validation: slug: must NOT have fewer than 1 characters
+code: VALIDATION_FAILED
+help[1]: Run `gitsheets-axi sheets view users` to see the schema
+```
+
+Stable codes: `VALIDATION_FAILED`, `NOT_FOUND`, `CONFIG_INVALID`, `NOT_CANONICAL`, `INDEX_CONFLICT`, `NOT_A_REPOSITORY`, `INVALID_JSON`, `PATH_TEMPLATE_ERROR`, `REF_ERROR`, `TRANSACTION_ERROR`, `CONFIG_EXISTS`, `NO_RECORDS`, `WRITE_ERROR`, `NON_FAST_FORWARD`, `PUSH_FAILED`.
+
+Exit codes: `0` for success (incl. no-ops), `2` for validation/usage errors, `1` for everything else.
+
+## See also
+
+- [gitsheets on npm](https://www.npmjs.com/package/gitsheets) — the underlying library
+- [gitsheets docs](https://jarvusinnovations.github.io/gitsheets/) — concepts, library API, sheet config grammar
+- [AXI specification](https://github.com/kunchenguid/axi) — the 10 ergonomic principles this CLI implements
+- [TOON specification](https://toonformat.dev/) — the output format
+
+## License
+
+Apache-2.0.

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -12,6 +12,13 @@ import { upsertCommand, UPSERT_HELP } from './commands/upsert.js';
 import { patchCommand, PATCH_HELP } from './commands/patch.js';
 import { deleteCommand, DELETE_HELP } from './commands/delete.js';
 import { checkCommand, CHECK_HELP } from './commands/check.js';
+import { diffCommand, DIFF_HELP } from './commands/diff.js';
+import { normalizeCommand, NORMALIZE_HELP } from './commands/normalize.js';
+import { initCommand, INIT_HELP } from './commands/init.js';
+import { inferCommand, INFER_HELP } from './commands/infer.js';
+import { migrateConfigCommand, MIGRATE_CONFIG_HELP } from './commands/migrate-config.js';
+import { attachmentCommand, ATTACHMENT_HELP } from './commands/attachment.js';
+import { pushCommand, PUSH_HELP } from './commands/push.js';
 
 const DESCRIPTION =
   'gitsheets — agent-facing interface for the git-backed document store. ' +
@@ -20,19 +27,26 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[8]:
-  (none)=home, sheets, query, read, upsert, patch, delete, check
+commands[15]:
+  (none)=home, sheets, query, read,
+  upsert, patch, delete,
+  check, diff, normalize,
+  init, infer, migrate-config,
+  attachment, push
 flags[2]:
   --help, -v/-V/--version
 examples:
   gitsheets-axi
-  gitsheets-axi sheets
   gitsheets-axi query users --filter status=active
-  gitsheets-axi read posts hello --full
   gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
   gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane"}'
-  gitsheets-axi delete users jane
   gitsheets-axi check users users/jane.toml --fix
+  gitsheets-axi diff posts HEAD~10
+  gitsheets-axi normalize users
+  gitsheets-axi init users
+  gitsheets-axi infer users
+  gitsheets-axi attachment list users jane
+  gitsheets-axi push
 `;
 
 const COMMAND_HELP: Record<string, string> = {
@@ -43,6 +57,13 @@ const COMMAND_HELP: Record<string, string> = {
   patch: PATCH_HELP,
   delete: DELETE_HELP,
   check: CHECK_HELP,
+  diff: DIFF_HELP,
+  normalize: NORMALIZE_HELP,
+  init: INIT_HELP,
+  infer: INFER_HELP,
+  'migrate-config': MIGRATE_CONFIG_HELP,
+  attachment: ATTACHMENT_HELP,
+  push: PUSH_HELP,
 };
 
 type CommandFn = (args: string[], ctx: GitsheetsContext) => Promise<string | Record<string, unknown>>;
@@ -55,6 +76,13 @@ const COMMANDS: Record<string, CommandFn> = {
   patch: patchCommand,
   delete: deleteCommand,
   check: checkCommand,
+  diff: diffCommand,
+  normalize: normalizeCommand,
+  init: initCommand,
+  infer: inferCommand,
+  'migrate-config': migrateConfigCommand,
+  attachment: attachmentCommand,
+  push: pushCommand,
 };
 
 export async function main(): Promise<void> {

--- a/packages/gitsheets-axi/src/commands/attachment.ts
+++ b/packages/gitsheets-axi/src/commands/attachment.ts
@@ -1,0 +1,419 @@
+import { isAbsolute, join } from 'node:path';
+import { readFile, stat } from 'node:fs/promises';
+
+import { AxiError } from 'axi-sdk-js';
+import { NotFoundError } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderListResponse, renderObject } from '../output/render.js';
+import { display, field } from '../output/schema.js';
+import { readStdin } from '../util/stdin.js';
+
+export const ATTACHMENT_HELP = `usage: gitsheets-axi attachment <subcommand> [args] [flags]
+subcommands[4]:
+  list <sheet> <path>                 List attachments on a record
+  get <sheet> <path> <name>           Get attachment metadata + base64 content
+  set <sheet> <path> <name> [--file f] [--data <text>]
+                                      Set an attachment (--file path, --data inline,
+                                      or piped on stdin)
+  delete <sheet> <path> [<name>]      Delete one attachment by name, or all if name omitted
+examples:
+  gitsheets-axi attachment list users jane
+  gitsheets-axi attachment get users jane avatar.jpg
+  gitsheets-axi attachment set users jane avatar.jpg --file ./pic.jpg
+  cat pic.jpg | gitsheets-axi attachment set users jane avatar.jpg
+  gitsheets-axi attachment delete users jane avatar.jpg
+  gitsheets-axi attachment delete users jane
+notes:
+  Binary content in \`get\` is base64-encoded. Use \`--full\` to opt into
+  larger payloads (default cap: 64KB).
+`;
+
+const GET_PREVIEW_LIMIT = 64 * 1024;
+
+export async function attachmentCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return ATTACHMENT_HELP;
+  }
+
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case 'list':
+      return attachmentList(rest, ctx);
+    case 'get':
+      return attachmentGet(rest, ctx);
+    case 'set':
+      return attachmentSet(rest, ctx);
+    case 'delete':
+      return attachmentDelete(rest, ctx);
+    case '--help':
+      return ATTACHMENT_HELP;
+    default:
+      throw new AxiError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
+        'Subcommands: list, get, set, delete',
+      ]);
+  }
+}
+
+function parseAttachmentBase(args: string[], requireName: boolean): {
+  sheet: string;
+  path: string;
+  name: string | undefined;
+  rest: string[];
+} {
+  const positional: string[] = [];
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    if (arg.startsWith('-')) {
+      rest.push(arg);
+      // Drag along the next token if it looks like a value
+      const next = args[i + 1];
+      if (next && !next.startsWith('-')) {
+        rest.push(next);
+        i++;
+      }
+      continue;
+    }
+    positional.push(arg);
+  }
+  if (positional.length < 2) {
+    throw new AxiError('attachment requires at least <sheet> <path>', 'VALIDATION_ERROR');
+  }
+  if (requireName && positional.length < 3) {
+    throw new AxiError('attachment requires <sheet> <path> <name>', 'VALIDATION_ERROR');
+  }
+  return {
+    sheet: positional[0]!,
+    path: positional[1]!,
+    name: positional[2],
+    rest,
+  };
+}
+
+async function openTargetSheet(
+  ctx: GitsheetsContext,
+  sheetName: string,
+  prefix: string | undefined,
+) {
+  const repo = await ctx.repo();
+  try {
+    return await repo.openSheet(
+      sheetName,
+      prefix !== undefined ? { prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
+function extractPrefix(rest: string[]): string | undefined {
+  const i = rest.indexOf('--prefix');
+  if (i === -1) return undefined;
+  const next = rest[i + 1];
+  if (!next) {
+    throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+  }
+  return next;
+}
+
+async function attachmentList(args: string[], ctx: GitsheetsContext): Promise<string> {
+  const { sheet: sheetName, path, rest } = parseAttachmentBase(args, false);
+  const prefix = extractPrefix(rest);
+  const sheet = await openTargetSheet(ctx, sheetName, prefix);
+
+  const items: Array<Record<string, unknown>> = [];
+  try {
+    for await (const attachment of sheet.attachments(path)) {
+      items.push({
+        name: attachment.name,
+        mime_type: attachment.mimeType,
+        hash: attachment.blob.hash,
+      });
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  return renderListResponse({
+    summary: { sheet: sheetName, record: path },
+    name: 'attachments',
+    items,
+    schema: [field('name'), display('mime_type'), field('hash')],
+    emptyMessage: 'no attachments on this record',
+    suggestions:
+      items.length > 0
+        ? [
+            `Run \`gitsheets-axi attachment get ${sheetName} ${path} <name>\` to inspect content`,
+          ]
+        : [
+            `Run \`gitsheets-axi attachment set ${sheetName} ${path} <name> --file <path>\` to add one`,
+          ],
+  });
+}
+
+async function attachmentGet(args: string[], ctx: GitsheetsContext): Promise<string> {
+  const { sheet: sheetName, path, name, rest } = parseAttachmentBase(args, true);
+  const prefix = extractPrefix(rest);
+  const full = rest.includes('--full');
+  const sheet = await openTargetSheet(ctx, sheetName, prefix);
+
+  let attachmentBlob;
+  try {
+    attachmentBlob = await sheet.getAttachment(path, name!);
+  } catch (error) {
+    throw translateError(error);
+  }
+  if (!attachmentBlob) {
+    throw new AxiError(
+      `${sheetName}: no attachment ${name} on record at ${path}`,
+      'NOT_FOUND',
+    );
+  }
+
+  let buffer: Buffer;
+  try {
+    const raw = await attachmentBlob.read();
+    buffer = typeof raw === 'string' ? Buffer.from(raw, 'utf-8') : Buffer.from(raw);
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const size = buffer.length;
+  const cap = full ? Number.POSITIVE_INFINITY : GET_PREVIEW_LIMIT;
+  const truncated = size > cap;
+  const slice = truncated ? buffer.subarray(0, GET_PREVIEW_LIMIT) : buffer;
+
+  const output: Record<string, unknown> = {
+    attachment: {
+      sheet: sheetName,
+      record: path,
+      name,
+      hash: attachmentBlob.hash,
+      size,
+      base64: slice.toString('base64'),
+    },
+  };
+  if (truncated) {
+    (output['attachment'] as Record<string, unknown>)['truncated'] = true;
+    output['help'] = [
+      `Run \`gitsheets-axi attachment get ${sheetName} ${path} ${name} --full\` to fetch all ${size} bytes`,
+    ];
+  }
+  return renderObject(output);
+}
+
+async function attachmentSet(args: string[], ctx: GitsheetsContext): Promise<string> {
+  const { sheet: sheetName, path, name, rest } = parseAttachmentBase(args, true);
+  const prefix = extractPrefix(rest);
+
+  const fileIdx = rest.indexOf('--file');
+  const dataIdx = rest.indexOf('--data');
+  const messageIdx = rest.indexOf('--message');
+  const fileArg = fileIdx >= 0 ? rest[fileIdx + 1] : undefined;
+  const dataArg = dataIdx >= 0 ? rest[dataIdx + 1] : undefined;
+  const message = messageIdx >= 0 ? rest[messageIdx + 1] : undefined;
+
+  // Acquire the content bytes.
+  let content: string;
+  if (fileArg) {
+    const absPath = isAbsolute(fileArg) ? fileArg : join(process.cwd(), fileArg);
+    try {
+      const buf = await readFile(absPath);
+      content = buf.toString('binary');
+    } catch (err) {
+      throw new AxiError(
+        `attachment set: cannot read ${fileArg}: ${err instanceof Error ? err.message : String(err)}`,
+        'NOT_FOUND',
+      );
+    }
+  } else if (dataArg) {
+    content = dataArg;
+  } else {
+    content = await readStdin();
+    if (!content) {
+      throw new AxiError(
+        'attachment set needs content — pass --file <path>, --data <text>, or pipe on stdin',
+        'VALIDATION_ERROR',
+      );
+    }
+  }
+
+  const repo = await ctx.repo();
+  const sheet = await openTargetSheet(ctx, sheetName, prefix);
+
+  // Idempotency: check the existing attachment's content.
+  let existing;
+  try {
+    existing = await sheet.getAttachment(path, name!);
+  } catch (error) {
+    throw translateError(error);
+  }
+  if (existing) {
+    try {
+      const existingText = await existing.read();
+      const existingStr =
+        typeof existingText === 'string'
+          ? existingText
+          : Buffer.from(existingText).toString('binary');
+      if (existingStr === content) {
+        return renderObject({
+          result: 'no-op',
+          sheet: sheetName,
+          record: path,
+          name,
+          hash: existing.hash,
+          reason: 'attachment bytes already match',
+        });
+      }
+    } catch {
+      // Fall through and overwrite.
+    }
+  }
+
+  const commitMessage = message ?? `${sheetName} setAttachment ${name} on ${path}`;
+  let commitHash = '';
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(
+          sheetName,
+          prefix !== undefined ? { prefix } : {},
+        );
+        await txSheet.setAttachment(path, name!, content);
+      },
+    );
+    commitHash = result.commitHash ?? '';
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  // Re-open the sheet to look up the new attachment hash — the `sheet`
+  // handle above is bound to the pre-commit tree.
+  let newHash = '';
+  try {
+    const fresh = await repo.openSheet(
+      sheetName,
+      prefix !== undefined ? { prefix } : {},
+    );
+    const created = await fresh.getAttachment(path, name!);
+    newHash = created?.hash ?? '';
+  } catch {
+    // not fatal — agent has the commit hash already
+  }
+
+  return renderObject({
+    result: existing ? 'overwritten' : 'created',
+    sheet: sheetName,
+    record: path,
+    name,
+    hash: newHash,
+    bytes: content.length,
+    commit: commitHash,
+  });
+}
+
+async function attachmentDelete(args: string[], ctx: GitsheetsContext): Promise<string> {
+  const { sheet: sheetName, path, name, rest } = parseAttachmentBase(args, false);
+  const prefix = extractPrefix(rest);
+  const messageIdx = rest.indexOf('--message');
+  const message = messageIdx >= 0 ? rest[messageIdx + 1] : undefined;
+
+  const repo = await ctx.repo();
+  const sheet = await openTargetSheet(ctx, sheetName, prefix);
+
+  if (name === undefined) {
+    // Delete all attachments on the record. Already idempotent in the library.
+    const before = await sheet.getAttachments(path);
+    const count = before ? Object.keys(before).length : 0;
+    if (count === 0) {
+      return renderObject({
+        result: 'no-op',
+        sheet: sheetName,
+        record: path,
+        reason: 'record has no attachments',
+      });
+    }
+    const commitMessage = message ?? `${sheetName} deleteAttachments on ${path}`;
+    let commitHash = '';
+    try {
+      const result = await repo.transact(
+        { message: commitMessage },
+        async (tx) => {
+          const txSheet = tx.sheet(
+            sheetName,
+            prefix !== undefined ? { prefix } : {},
+          );
+          await txSheet.deleteAttachments(path);
+        },
+      );
+      commitHash = result.commitHash ?? '';
+    } catch (error) {
+      throw translateError(error);
+    }
+    return renderObject({
+      result: 'committed',
+      sheet: sheetName,
+      record: path,
+      deleted: count,
+      commit: commitHash,
+    });
+  }
+
+  // Single-attachment delete; idempotent on already-missing.
+  const existing = await sheet.getAttachment(path, name);
+  if (!existing) {
+    return renderObject({
+      result: 'no-op',
+      sheet: sheetName,
+      record: path,
+      name,
+      reason: 'attachment already absent',
+    });
+  }
+
+  const commitMessage = message ?? `${sheetName} deleteAttachment ${name} on ${path}`;
+  let commitHash = '';
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(
+          sheetName,
+          prefix !== undefined ? { prefix } : {},
+        );
+        await txSheet.deleteAttachment(path, name);
+      },
+    );
+    commitHash = result.commitHash ?? '';
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return renderObject({
+        result: 'no-op',
+        sheet: sheetName,
+        record: path,
+        name,
+        reason: 'attachment vanished between check and delete',
+      });
+    }
+    throw translateError(error);
+  }
+  return renderObject({
+    result: 'committed',
+    sheet: sheetName,
+    record: path,
+    name,
+    commit: commitHash,
+  });
+}
+
+// stat() is exported here only to keep the import list tidy if we ever need
+// file-size pre-checks in attachment set; suppress unused-import noise.
+void stat;

--- a/packages/gitsheets-axi/src/commands/diff.ts
+++ b/packages/gitsheets-axi/src/commands/diff.ts
@@ -1,0 +1,156 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderListResponse } from '../output/render.js';
+import { display, field } from '../output/schema.js';
+
+export const DIFF_HELP = `usage: gitsheets-axi diff <sheet> [<src-ref>] [--patches] [--limit n] [--prefix p]
+flags[3]:
+  --patches            Include RFC 6902 JSON Patch ops on each change (default: false)
+  --limit <n>          Cap results (default: 1000)
+  --prefix <p>         Tenant sub-tree scope
+examples:
+  gitsheets-axi diff users
+  gitsheets-axi diff posts HEAD~10
+  gitsheets-axi diff users origin/main --patches
+output:
+  Default columns: status (added/modified/deleted/renamed), path, srcHash, dstHash.
+  --patches adds an inline patch column (RFC 6902 ops).
+src-ref:
+  Optional. Defaults to the empty tree, which makes every current record
+  show up as "added" — useful for a one-shot snapshot of the sheet.
+`;
+
+interface DiffFlags {
+  sheet: string;
+  srcRef: string | undefined;
+  patches: boolean;
+  limit: number;
+  prefix: string | undefined;
+}
+
+function parseDiffFlags(args: string[]): DiffFlags {
+  const flags: DiffFlags = {
+    sheet: '',
+    srcRef: undefined,
+    patches: false,
+    limit: 1000,
+    prefix: undefined,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--patches') {
+      flags.patches = true;
+      continue;
+    }
+    if (arg === '--limit') {
+      if (!next) throw new AxiError('--limit expects an integer', 'VALIDATION_ERROR');
+      flags.limit = Math.min(100_000, Math.max(1, parseInt(next, 10) || 1000));
+      i++;
+      continue;
+    }
+    if (arg === '--prefix') {
+      if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+      flags.prefix = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi diff --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length < 1 || positional.length > 2) {
+    throw new AxiError('diff requires <sheet> [<src-ref>]', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi diff users HEAD~10',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  if (positional.length === 2) flags.srcRef = positional[1];
+  return flags;
+}
+
+export async function diffCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return DIFF_HELP;
+  }
+
+  const flags = parseDiffFlags(args);
+  const repo = await ctx.repo();
+
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const items: Array<Record<string, unknown>> = [];
+  let total = 0;
+  try {
+    const opts = flags.patches ? { patches: true as const } : {};
+    for await (const change of sheet.diffFrom(flags.srcRef, opts)) {
+      total++;
+      if (items.length >= flags.limit) continue;
+      const row: Record<string, unknown> = {
+        status: change.status,
+        path: change.path,
+        src_hash: change.srcHash ?? '',
+        dst_hash: change.dstHash ?? '',
+      };
+      if (flags.patches && (change as { patch?: unknown }).patch !== undefined) {
+        // Serialize the RFC 6902 patch as JSON so it fits in a TOON cell.
+        // Empty arrays render as "[]"; small patches render compactly.
+        const patch = (change as { patch?: readonly unknown[] }).patch;
+        row['patch'] = JSON.stringify(patch ?? []);
+      }
+      items.push(row);
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const schema = [
+    field('status'),
+    field('path'),
+    display('src_hash'),
+    display('dst_hash'),
+  ];
+  if (flags.patches) schema.push(field('patch'));
+
+  const suggestions: string[] = [];
+  if (total === 0) {
+    suggestions.push('No changes between src ref and current tree');
+  } else if (total > items.length) {
+    suggestions.push(
+      `${total - items.length} changes hidden by --limit ${flags.limit}; raise --limit to see more`,
+    );
+  }
+  if (!flags.patches && total > 0) {
+    suggestions.push('Add `--patches` to include RFC 6902 ops per change');
+  }
+
+  return renderListResponse({
+    summary: {
+      count: `${items.length} of ${total} total`,
+      src_ref: flags.srcRef ?? '(empty tree)',
+    },
+    name: 'changes',
+    items,
+    schema,
+    suggestions,
+    emptyMessage: 'no changes',
+  });
+}

--- a/packages/gitsheets-axi/src/commands/infer.ts
+++ b/packages/gitsheets-axi/src/commands/infer.ts
@@ -1,0 +1,247 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { AxiError } from 'axi-sdk-js';
+import { parseToml, stringifyRecord } from 'gitsheets';
+import type { RecordLike } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+
+const exec = promisify(execFile);
+
+export const INFER_HELP = `usage: gitsheets-axi infer <sheet> [--prefix p] [--message m]
+flags[2]:
+  --prefix <p>         Tenant sub-tree scope
+  --message <m>        Commit message (default: "<sheet> infer schema (N fields)")
+examples:
+  gitsheets-axi infer users
+behavior:
+  Walks every record in the sheet, observes which fields appear with
+  which types, and emits a generated \`[gitsheet.schema]\` block back
+  into the sheet's config file. Fields that appear in every record
+  are marked \`required\`.
+idempotency:
+  If the inferred schema matches what's already in the config,
+  exits 0 with result: "no-op" — no commit produced.
+`;
+
+interface InferFlags {
+  sheet: string;
+  prefix: string | undefined;
+  message: string | undefined;
+}
+
+function parseInferFlags(args: string[]): InferFlags {
+  const flags: InferFlags = { sheet: '', prefix: undefined, message: undefined };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--prefix') {
+      if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+      flags.prefix = next;
+      i++;
+      continue;
+    }
+    if (arg === '--message') {
+      if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+      flags.message = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi infer --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length !== 1) {
+    throw new AxiError('infer requires <sheet>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi infer users',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  return flags;
+}
+
+interface FieldObservation {
+  types: Set<string>;
+  items: Set<string>;
+  min?: number;
+  max?: number;
+}
+
+function observeValue(obs: FieldObservation, value: unknown): void {
+  if (value === null) {
+    obs.types.add('null');
+    return;
+  }
+  if (Array.isArray(value)) {
+    obs.types.add('array');
+    for (const item of value) obs.items.add(typeOf(item));
+    return;
+  }
+  if (value instanceof Date) {
+    obs.types.add('string');
+    return;
+  }
+  const t = typeOf(value);
+  obs.types.add(t);
+  if (t === 'integer' || t === 'number') {
+    const n = value as number;
+    if (obs.min === undefined || n < obs.min) obs.min = n;
+    if (obs.max === undefined || n > obs.max) obs.max = n;
+  }
+}
+
+function typeOf(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  if (value instanceof Date) return 'string';
+  const t = typeof value;
+  if (t === 'number') {
+    return Number.isInteger(value) ? 'integer' : 'number';
+  }
+  if (t === 'object') return 'object';
+  return t;
+}
+
+export async function inferCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return INFER_HELP;
+  }
+
+  const flags = parseInferFlags(args);
+  const repo = await ctx.repo();
+  const configPath = `.gitsheets/${flags.sheet}.toml`;
+
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const observed = new Map<string, FieldObservation>();
+  const presence = new Map<string, number>();
+  let recordCount = 0;
+  try {
+    for await (const record of sheet.query()) {
+      recordCount++;
+      for (const [k, v] of Object.entries(record)) {
+        presence.set(k, (presence.get(k) ?? 0) + 1);
+        let obs = observed.get(k);
+        if (!obs) {
+          obs = { types: new Set(), items: new Set() };
+          observed.set(k, obs);
+        }
+        observeValue(obs, v);
+      }
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (recordCount === 0) {
+    throw new AxiError(
+      `${flags.sheet}: no records to infer from`,
+      'NO_RECORDS',
+      [`Upsert at least one record first, then re-run \`gitsheets-axi infer ${flags.sheet}\``],
+    );
+  }
+
+  const properties: Record<string, RecordLike> = {};
+  for (const [field, info] of observed.entries()) {
+    const types = [...info.types].sort();
+    const prop: RecordLike = {};
+    prop['type'] = types.length === 1 ? types[0]! : types;
+    if (info.items.size > 0) {
+      const itemTypes = [...info.items].sort();
+      prop['items'] = { type: itemTypes.length === 1 ? itemTypes[0]! : itemTypes };
+    }
+    if (info.min !== undefined) prop['minimum'] = info.min;
+    if (info.max !== undefined) prop['maximum'] = info.max;
+    properties[field] = prop;
+  }
+
+  const required = [...presence.entries()]
+    .filter(([, count]) => count === recordCount)
+    .map(([n]) => n)
+    .sort();
+
+  // Read existing config, merge schema into it.
+  const existingText = await readConfigText(repo.gitDir, configPath);
+  if (existingText === null) {
+    throw new AxiError(
+      `infer: ${configPath} doesn't exist — run \`gitsheets-axi init ${flags.sheet}\` first`,
+      'NOT_FOUND',
+    );
+  }
+  const parsed = parseToml(existingText) as RecordLike;
+  const gitsheet = (parsed['gitsheet'] ?? {}) as RecordLike;
+  const newSchema: RecordLike = { type: 'object', properties };
+  if (required.length > 0) newSchema['required'] = required;
+  gitsheet['schema'] = newSchema;
+  parsed['gitsheet'] = gitsheet;
+  const newText = stringifyRecord(parsed);
+
+  if (newText === existingText) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      config: configPath,
+      properties: Object.keys(properties).length,
+      required: required.length,
+      records_observed: recordCount,
+      reason: 'inferred schema already matches',
+    });
+  }
+
+  const commitMessage =
+    flags.message ?? `${flags.sheet} infer schema (${Object.keys(properties).length} fields)`;
+  let commitHash = '';
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        await tx.tree.writeChild(configPath, newText);
+        tx.markMutated();
+      },
+    );
+    commitHash = result.commitHash ?? '';
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  return renderObject({
+    result: 'committed',
+    sheet: flags.sheet,
+    config: configPath,
+    properties: Object.keys(properties).length,
+    required: required.length,
+    records_observed: recordCount,
+    commit: commitHash,
+  });
+}
+
+async function readConfigText(gitDir: string, path: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['show', `HEAD:${path}`], {
+      cwd: gitDir,
+      maxBuffer: 100 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}

--- a/packages/gitsheets-axi/src/commands/init.ts
+++ b/packages/gitsheets-axi/src/commands/init.ts
@@ -1,0 +1,212 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { AxiError } from 'axi-sdk-js';
+import { parseConfigToml, stringifyRecord } from 'gitsheets';
+import type { RecordLike, Repository } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+
+const exec = promisify(execFile);
+
+export const INIT_HELP = `usage: gitsheets-axi init <sheet> [--path <template>] [--schema <file>] [--force]
+flags[4]:
+  --path <template>    Path template (default: "\${{ id }}")
+  --schema <file>      Path to a JSON file with the schema to embed
+  --force              Overwrite an existing config
+  --message <m>        Commit message (default: "<sheet> init sheet config")
+examples:
+  gitsheets-axi init users
+  gitsheets-axi init posts --path '\${{ slug }}'
+  gitsheets-axi init users --schema users.schema.json
+behavior:
+  Writes a starter \`.gitsheets/<sheet>.toml\` with a default root,
+  path template, and optional schema. Refuses to overwrite an
+  existing config unless --force is set.
+idempotency:
+  When the rendered config matches the existing config byte-for-byte,
+  exits 0 with result: "no-op" — safe to re-run.
+`;
+
+interface InitFlags {
+  sheet: string;
+  path: string;
+  schemaFile: string | undefined;
+  force: boolean;
+  message: string | undefined;
+}
+
+function parseInitFlags(args: string[]): InitFlags {
+  const flags: InitFlags = {
+    sheet: '',
+    path: '${{ id }}',
+    schemaFile: undefined,
+    force: false,
+    message: undefined,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    switch (arg) {
+      case '--path':
+        if (!next) throw new AxiError('--path expects a template', 'VALIDATION_ERROR');
+        flags.path = next;
+        i++;
+        break;
+      case '--schema':
+        if (!next) throw new AxiError('--schema expects a file path', 'VALIDATION_ERROR');
+        flags.schemaFile = next;
+        i++;
+        break;
+      case '--force':
+        flags.force = true;
+        break;
+      case '--message':
+        if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+        flags.message = next;
+        i++;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+            'Run `gitsheets-axi init --help`',
+          ]);
+        }
+        positional.push(arg);
+    }
+  }
+  if (positional.length !== 1) {
+    throw new AxiError('init requires <sheet>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi init users',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  return flags;
+}
+
+/**
+ * Read the raw bytes of a tracked file at HEAD. Returns null if the file
+ * doesn't exist there (or if HEAD doesn't exist yet on a fresh repo).
+ */
+async function readBytesAtHead(
+  gitDir: string,
+  path: string,
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['show', `HEAD:${path}`], {
+      cwd: gitDir,
+      maxBuffer: 100 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+export async function initCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return INIT_HELP;
+  }
+
+  const flags = parseInitFlags(args);
+  const repo = await ctx.repo();
+  const configPath = `.gitsheets/${flags.sheet}.toml`;
+
+  const newConfig: RecordLike = {
+    gitsheet: { root: flags.sheet, path: flags.path },
+  };
+
+  if (flags.schemaFile) {
+    const absPath = isAbsolute(flags.schemaFile)
+      ? flags.schemaFile
+      : join(process.cwd(), flags.schemaFile);
+    let schemaText: string;
+    try {
+      schemaText = await readFile(absPath, 'utf-8');
+    } catch (err) {
+      throw new AxiError(
+        `init: cannot read schema file ${flags.schemaFile}: ${err instanceof Error ? err.message : String(err)}`,
+        'NOT_FOUND',
+      );
+    }
+    let schemaParsed: unknown;
+    try {
+      schemaParsed = JSON.parse(schemaText);
+    } catch (err) {
+      throw new AxiError(
+        `init: schema file isn't valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        'INVALID_JSON',
+      );
+    }
+    if (typeof schemaParsed !== 'object' || schemaParsed === null) {
+      throw new AxiError('init: --schema did not parse as a JSON object', 'VALIDATION_ERROR');
+    }
+    (newConfig['gitsheet'] as RecordLike)['schema'] = schemaParsed as RecordLike;
+  }
+
+  const newText = stringifyRecord(newConfig);
+
+  // Validate the new config parses cleanly before committing.
+  try {
+    parseConfigToml(newText, configPath);
+  } catch (err) {
+    throw new AxiError(
+      `init: produced an invalid config: ${err instanceof Error ? err.message : String(err)}`,
+      'CONFIG_INVALID',
+    );
+  }
+
+  const existing = await readBytesAtHead(repoGitDir(repo), configPath);
+
+  if (existing === newText) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      config: configPath,
+      reason: 'config already matches',
+    });
+  }
+
+  if (existing !== null && !flags.force) {
+    throw new AxiError(
+      `init: ${configPath} already exists and bytes differ — re-run with --force to overwrite`,
+      'CONFIG_EXISTS',
+      [`gitsheets-axi init ${flags.sheet} --force ...`],
+    );
+  }
+
+  const commitMessage = flags.message ?? `${flags.sheet} init sheet config`;
+  let commitHash = '';
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        await tx.tree.writeChild(configPath, newText);
+        tx.markMutated();
+      },
+    );
+    commitHash = result.commitHash ?? '';
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  return renderObject({
+    result: existing === null ? 'created' : 'overwritten',
+    sheet: flags.sheet,
+    config: configPath,
+    commit: commitHash,
+  });
+}
+
+function repoGitDir(repo: Repository): string {
+  return repo.gitDir;
+}

--- a/packages/gitsheets-axi/src/commands/migrate-config.ts
+++ b/packages/gitsheets-axi/src/commands/migrate-config.ts
@@ -1,0 +1,181 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { AxiError } from 'axi-sdk-js';
+import { parseToml, stringifyRecord } from 'gitsheets';
+import type { RecordLike } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+
+const exec = promisify(execFile);
+
+export const MIGRATE_CONFIG_HELP = `usage: gitsheets-axi migrate-config <sheet> [--message m]
+flags[1]:
+  --message <m>        Commit message (default: "<sheet> migrate-config")
+examples:
+  gitsheets-axi migrate-config users
+behavior:
+  Translates a pre-v1.0 \`[gitsheet.fields]\` block into the modern
+  \`[gitsheet.schema]\` block. type/enum/default move into JSON Schema
+  properties; sort rules stay on the field (they're a normalization
+  concern, not validation). trueValues/falseValues are dropped with
+  a warning — those moved out of validation in v1.0 (CSV ingest concern).
+idempotency:
+  If the config has no \`[gitsheet.fields]\` block, exits 0 with
+  result: "no-op". If the migration produces identical bytes, same.
+`;
+
+interface MigrateFlags {
+  sheet: string;
+  message: string | undefined;
+}
+
+function parseMigrateFlags(args: string[]): MigrateFlags {
+  const flags: MigrateFlags = { sheet: '', message: undefined };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--message') {
+      if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+      flags.message = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi migrate-config --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length !== 1) {
+    throw new AxiError('migrate-config requires <sheet>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi migrate-config users',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  return flags;
+}
+
+async function readConfigText(gitDir: string, path: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['show', `HEAD:${path}`], {
+      cwd: gitDir,
+      maxBuffer: 100 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+export async function migrateConfigCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return MIGRATE_CONFIG_HELP;
+  }
+
+  const flags = parseMigrateFlags(args);
+  const repo = await ctx.repo();
+  const configPath = `.gitsheets/${flags.sheet}.toml`;
+
+  const configText = await readConfigText(repo.gitDir, configPath);
+  if (configText === null) {
+    throw new AxiError(
+      `migrate-config: ${configPath} doesn't exist`,
+      'NOT_FOUND',
+    );
+  }
+
+  let parsed: RecordLike;
+  try {
+    parsed = parseToml(configText) as RecordLike;
+  } catch (err) {
+    throw new AxiError(
+      `migrate-config: ${configPath} failed to parse: ${err instanceof Error ? err.message : String(err)}`,
+      'CONFIG_INVALID',
+    );
+  }
+
+  const gitsheet = (parsed['gitsheet'] ?? {}) as RecordLike;
+  const fields = gitsheet['fields'] as Record<string, RecordLike> | undefined;
+
+  if (!fields || typeof fields !== 'object') {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      config: configPath,
+      reason: 'no [gitsheet.fields] block to migrate',
+    });
+  }
+
+  const properties: Record<string, RecordLike> = {};
+  const remainingFields: Record<string, RecordLike> = {};
+  const warnings: string[] = [];
+  for (const [name, cfg] of Object.entries(fields)) {
+    if (typeof cfg !== 'object' || cfg === null) continue;
+    const schemaProp: RecordLike = {};
+    const remainingField: RecordLike = {};
+    if (cfg['type'] !== undefined) schemaProp['type'] = cfg['type'];
+    if (cfg['enum'] !== undefined) schemaProp['enum'] = cfg['enum'];
+    if (cfg['default'] !== undefined) schemaProp['default'] = cfg['default'];
+    if (cfg['sort'] !== undefined) remainingField['sort'] = cfg['sort'];
+    if (cfg['trueValues'] !== undefined || cfg['falseValues'] !== undefined) {
+      warnings.push(`${name}.trueValues/falseValues dropped (moved to CSV ingest)`);
+    }
+    if (Object.keys(schemaProp).length > 0) properties[name] = schemaProp;
+    if (Object.keys(remainingField).length > 0) remainingFields[name] = remainingField;
+  }
+
+  const newGitsheet: RecordLike = {};
+  for (const [k, v] of Object.entries(gitsheet)) {
+    if (k === 'fields' || k === 'schema') continue;
+    newGitsheet[k] = v;
+  }
+  if (Object.keys(remainingFields).length > 0) newGitsheet['fields'] = remainingFields;
+  if (Object.keys(properties).length > 0) {
+    newGitsheet['schema'] = { type: 'object', properties };
+  }
+  parsed['gitsheet'] = newGitsheet;
+  const newText = stringifyRecord(parsed);
+
+  if (newText === configText) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      config: configPath,
+      reason: 'migration produced identical bytes',
+    });
+  }
+
+  const commitMessage = flags.message ?? `${flags.sheet} migrate-config`;
+  let commitHash = '';
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        await tx.tree.writeChild(configPath, newText);
+        tx.markMutated();
+      },
+    );
+    commitHash = result.commitHash ?? '';
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const output: Record<string, unknown> = {
+    result: 'committed',
+    sheet: flags.sheet,
+    config: configPath,
+    properties_migrated: Object.keys(properties).length,
+    commit: commitHash,
+  };
+  if (warnings.length > 0) output['warnings'] = warnings;
+  return renderObject(output);
+}

--- a/packages/gitsheets-axi/src/commands/normalize.ts
+++ b/packages/gitsheets-axi/src/commands/normalize.ts
@@ -1,0 +1,166 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderListResponse } from '../output/render.js';
+import { field } from '../output/schema.js';
+
+export const NORMALIZE_HELP = `usage: gitsheets-axi normalize <sheet> [--prefix p] [--message m]
+flags[2]:
+  --prefix <p>         Tenant sub-tree scope
+  --message <m>        Commit message (default: "<sheet> normalize")
+examples:
+  gitsheets-axi normalize users
+behavior:
+  Reads every record in the sheet, re-runs validation + canonical
+  serialization, and writes back any record whose bytes differ.
+  Idempotent per-record via Sheet.willChange: records that already
+  serialize to identical bytes are skipped. If every record is already
+  canonical, exits 0 with result: "no-op" and no commit is produced.
+exit codes:
+  0   Success (whether records were rewritten or no-op)
+`;
+
+interface NormalizeFlags {
+  sheet: string;
+  prefix: string | undefined;
+  message: string | undefined;
+}
+
+function parseNormalizeFlags(args: string[]): NormalizeFlags {
+  const flags: NormalizeFlags = { sheet: '', prefix: undefined, message: undefined };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--prefix') {
+      if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+      flags.prefix = next;
+      i++;
+      continue;
+    }
+    if (arg === '--message') {
+      if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+      flags.message = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi normalize --help`',
+      ]);
+    }
+    positional.push(arg);
+  }
+  if (positional.length !== 1) {
+    throw new AxiError('normalize requires <sheet>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi normalize users',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  return flags;
+}
+
+export async function normalizeCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return NORMALIZE_HELP;
+  }
+
+  const flags = parseNormalizeFlags(args);
+  const repo = await ctx.repo();
+
+  let sheet;
+  try {
+    sheet = await repo.openSheet(
+      flags.sheet,
+      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  // Collect all records first so we know what to rewrite + can skip the
+  // commit entirely if every record is already canonical.
+  const records: Array<Record<string, unknown>> = [];
+  try {
+    for await (const r of sheet.query()) {
+      records.push(r as Record<string, unknown>);
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (records.length === 0) {
+    return renderListResponse({
+      summary: { result: 'no-op', records: '0 — empty sheet' },
+      name: 'rewrites',
+      items: [],
+      schema: [field('path'), field('hash')],
+      emptyMessage: 'no records',
+    });
+  }
+
+  // Determine which records would actually change.
+  const toWrite: Array<{ record: Record<string, unknown>; path: string }> = [];
+  try {
+    for (const record of records) {
+      const will = await sheet.willChange(record as never, { allowMissingBody: true });
+      if (will.changed) {
+        toWrite.push({ record, path: will.path });
+      }
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  if (toWrite.length === 0) {
+    return renderListResponse({
+      summary: {
+        result: 'no-op',
+        records: `${records.length} already canonical`,
+      },
+      name: 'rewrites',
+      items: [],
+      schema: [field('path'), field('hash')],
+      emptyMessage: 'every record already canonical',
+    });
+  }
+
+  const commitMessage =
+    flags.message ?? `${flags.sheet} normalize (${toWrite.length} records)`;
+  const rewrites: Array<Record<string, unknown>> = [];
+  let commitHash = '';
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(
+          flags.sheet,
+          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+        );
+        for (const { record } of toWrite) {
+          const r = await txSheet.upsert(record as never, { allowMissingBody: true });
+          rewrites.push({ path: r.path, hash: r.blob.hash });
+        }
+      },
+    );
+    commitHash = result.commitHash ?? '';
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  return renderListResponse({
+    summary: {
+      result: 'committed',
+      records: `${rewrites.length} of ${records.length} rewritten`,
+      commit: commitHash,
+    },
+    name: 'rewrites',
+    items: rewrites,
+    schema: [field('path'), field('hash')],
+  });
+}

--- a/packages/gitsheets-axi/src/commands/push.ts
+++ b/packages/gitsheets-axi/src/commands/push.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { renderObject } from '../output/render.js';
+
+const exec = promisify(execFile);
+
+export const PUSH_HELP = `usage: gitsheets-axi push [--remote r] [--branch b]
+flags[2]:
+  --remote <r>         Git remote to push to (default: origin)
+  --branch <b>         Branch to push (default: the repo's current HEAD branch)
+examples:
+  gitsheets-axi push
+  gitsheets-axi push --remote upstream --branch main
+behavior:
+  One-shot push via \`git push <remote> <branch>\`. For agent workflows
+  that want to publish after a mutation without spinning up a background
+  daemon. This is NOT a daemon lifecycle command — for retry-with-backoff
+  semantics, use Repository.startPushDaemon from a long-running consumer.
+idempotency:
+  When the remote is already up to date, exits 0 with
+  result: "no-op" — git's natural "Everything up-to-date" path.
+errors:
+  NON_FAST_FORWARD     Remote has work the local doesn't — never force-pushed.
+                       Reconcile externally (pull or rebase), then re-run.
+  PUSH_FAILED          Network / auth / other transient failure. Re-run later.
+`;
+
+interface PushFlags {
+  remote: string;
+  branch: string | undefined;
+}
+
+function parsePushFlags(args: string[]): PushFlags {
+  const flags: PushFlags = { remote: 'origin', branch: undefined };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    if (arg === '--remote') {
+      if (!next) throw new AxiError('--remote expects a name', 'VALIDATION_ERROR');
+      flags.remote = next;
+      i++;
+      continue;
+    }
+    if (arg === '--branch') {
+      if (!next) throw new AxiError('--branch expects a name', 'VALIDATION_ERROR');
+      flags.branch = next;
+      i++;
+      continue;
+    }
+    if (arg === '--help') continue;
+    throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+      'Run `gitsheets-axi push --help`',
+    ]);
+  }
+  return flags;
+}
+
+async function resolveBranch(gitDir: string): Promise<string> {
+  const { stdout } = await exec(
+    'git',
+    ['symbolic-ref', '--short', 'HEAD'],
+    { cwd: gitDir },
+  );
+  const branch = stdout.trim();
+  if (!branch) {
+    throw new AxiError(
+      "Couldn't determine current branch (detached HEAD?)",
+      'REF_ERROR',
+      ['Pass --branch explicitly, e.g. `gitsheets-axi push --branch main`'],
+    );
+  }
+  return branch;
+}
+
+function classifyPushError(message: string): 'NON_FAST_FORWARD' | 'PUSH_FAILED' {
+  if (/!\s*\[rejected\]/.test(message) && /(non-fast-forward|fetch first)/i.test(message)) {
+    return 'NON_FAST_FORWARD';
+  }
+  return 'PUSH_FAILED';
+}
+
+export async function pushCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 1 && args[0] === '--help') return PUSH_HELP;
+
+  const flags = parsePushFlags(args);
+  const repo = await ctx.repo();
+  const gitDir = repo.gitDir;
+  const branch = flags.branch ?? (await resolveBranch(gitDir));
+
+  let stderr = '';
+  try {
+    const result = await exec(
+      'git',
+      ['push', flags.remote, branch],
+      { cwd: gitDir, maxBuffer: 10 * 1024 * 1024 },
+    );
+    stderr = result.stderr;
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const combined = `${err.stderr ?? ''}\n${err.stdout ?? ''}\n${err.message ?? ''}`;
+    const code = classifyPushError(combined);
+    const suggestions =
+      code === 'NON_FAST_FORWARD'
+        ? [
+            "Remote has commits the local doesn't — reconcile externally before retrying",
+            'Stop the writer, fetch + rebase or pull, then restart',
+          ]
+        : ['Network or auth failure — retry, or check the remote configuration'];
+    throw new AxiError(
+      `git push to ${flags.remote} ${branch} failed: ${(err.message ?? '').split('\n')[0] ?? 'unknown error'}`,
+      code,
+      suggestions,
+    );
+  }
+
+  // git's "Everything up-to-date" lands in stderr without an error code.
+  // Treat as no-op.
+  const upToDate = /everything up.to.date/i.test(stderr);
+  if (upToDate) {
+    return renderObject({
+      result: 'no-op',
+      remote: flags.remote,
+      branch,
+      reason: 'remote already up-to-date',
+    });
+  }
+
+  return renderObject({
+    result: 'pushed',
+    remote: flags.remote,
+    branch,
+    // Strip git's noisy "To <url>" / hash lines into a compact summary.
+    detail: stderr.split('\n').filter((l) => l.trim()).slice(0, 3).join('\n'),
+  });
+}

--- a/packages/gitsheets-axi/test/attachments.test.ts
+++ b/packages/gitsheets-axi/test/attachments.test.ts
@@ -1,0 +1,197 @@
+// AXI attachment command (list / get / set / delete).
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from 'gitsheets';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+`;
+
+async function seedRepo({ withAttachments = false }: { withAttachments?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users');
+
+  const repo = await openRepo({ gitDir: fixture.gitDir });
+  await repo.transact({ message: 'seed jane' }, async (tx) => {
+    await tx.sheet('users').upsert({ slug: 'jane' });
+    if (withAttachments) {
+      await tx.sheet('users').setAttachment({ slug: 'jane' }, 'avatar.png', 'PNGBYTES');
+      await tx.sheet('users').setAttachment({ slug: 'jane' }, 'cover.jpg', 'JPGBYTES');
+    }
+  });
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('attachment list', () => {
+  it('shows attachments on a record', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'list', 'users', 'jane'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('attachments[2]');
+    expect(stdout).toContain('avatar.png');
+    expect(stdout).toContain('cover.jpg');
+  });
+
+  it('emits empty state when no attachments exist', async () => {
+    const fixture = await seedRepo();
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'list', 'users', 'jane'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('no attachments');
+  });
+});
+
+describe('attachment get', () => {
+  it('returns base64-encoded content + metadata', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'get', 'users', 'jane', 'avatar.png'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('attachment:');
+    expect(stdout).toContain('name: avatar.png');
+    expect(stdout).toContain('size: 8');
+    expect(stdout).toContain('base64:');
+    // base64 of "PNGBYTES"
+    expect(stdout).toContain('UE5HQllURVM=');
+  });
+
+  it('errors when attachment is missing', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'get', 'users', 'jane', 'nope.png'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('NOT_FOUND');
+  });
+});
+
+describe('attachment set', () => {
+  it('creates a new attachment via --data', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      [
+        'attachment',
+        'set',
+        'users',
+        'jane',
+        'note.txt',
+        '--data',
+        'hello',
+      ],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: created');
+    expect(stdout).toContain('name: note.txt');
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+
+  it('idempotent — no-op when bytes match', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'set', 'users', 'jane', 'avatar.png', '--data', 'PNGBYTES'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('overwrites existing attachment when bytes differ', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'set', 'users', 'jane', 'avatar.png', '--data', 'NEW-BYTES'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: overwritten');
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+});
+
+describe('attachment delete', () => {
+  it('deletes a single named attachment', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'delete', 'users', 'jane', 'avatar.png'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+
+  it('idempotent — no-op when attachment already absent', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'delete', 'users', 'jane', 'nope.png'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('deletes all attachments when no name is given', async () => {
+    const fixture = await seedRepo({ withAttachments: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['attachment', 'delete', 'users', 'jane'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('deleted: 2');
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+});

--- a/packages/gitsheets-axi/test/config-commands.test.ts
+++ b/packages/gitsheets-axi/test/config-commands.test.ts
@@ -1,0 +1,210 @@
+// AXI config scaffolding: init, infer, migrate-config.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from 'gitsheets';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+async function emptyRepo(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('init', () => {
+  it('creates a starter config and commits', async () => {
+    const fixture = await emptyRepo();
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['init', 'users', '--path', '${{ slug }}'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: created');
+    expect(stdout).toContain('config: .gitsheets/users.toml');
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    // Sheet should be openable.
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const sheet = await repo.openSheet('users');
+    const cfg = await sheet.readConfig();
+    expect(cfg.path).toBe('${{ slug }}');
+  });
+
+  it('idempotent on re-run with the same args', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['init', 'users', '--path', '${{ slug }}'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('refuses to overwrite without --force', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+
+    const { stdout, exitCode } = await runCli(
+      ['init', 'users', '--path', '${{ id }}'], // different path
+      fixture.path,
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('CONFIG_EXISTS');
+  });
+
+  it('overwrites with --force', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+
+    const { stdout, exitCode } = await runCli(
+      ['init', 'users', '--path', '${{ id }}', '--force'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: overwritten');
+  });
+});
+
+describe('infer', () => {
+  it('infers schema from existing records', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+    // Seed via library so records exist.
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed' }, async (tx) => {
+      await tx.sheet('users').upsert({
+        slug: 'jane',
+        email: 'jane@x.org',
+        active: true,
+      });
+      await tx.sheet('users').upsert({
+        slug: 'bob',
+        email: 'bob@x.org',
+        active: false,
+      });
+    });
+
+    const { stdout, exitCode } = await runCli(['infer', 'users'], fixture.path);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toMatch(/properties: 3/);
+    expect(stdout).toMatch(/required: 3/);
+    expect(stdout).toMatch(/records_observed: 2/);
+  });
+
+  it('errors when no records exist', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+
+    const { stdout, exitCode } = await runCli(['infer', 'users'], fixture.path);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('NO_RECORDS');
+  });
+
+  it('idempotent when schema already matches', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    await runCli(['infer', 'users'], fixture.path);
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(['infer', 'users'], fixture.path);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+});
+
+describe('migrate-config', () => {
+  it('migrates a pre-v1.0 [gitsheet.fields] block into [gitsheet.schema]', async () => {
+    const fixture = await emptyRepo();
+    // Hand-write a legacy config.
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'legacy.toml'),
+      `[gitsheet]
+root = 'legacy'
+path = '\${{ slug }}'
+
+[gitsheet.fields.slug]
+type = 'string'
+
+[gitsheet.fields.score]
+type = 'number'
+default = 0
+`,
+      'utf-8',
+    );
+    await fixture.git('add', '.gitsheets/legacy.toml');
+    await fixture.git('commit', '-m', 'legacy config');
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['migrate-config', 'legacy'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toMatch(/properties_migrated: 2/);
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    // After migration the config should have [gitsheet.schema] and no
+    // [gitsheet.fields].
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const sheet = await repo.openSheet('legacy');
+    const cfg = await sheet.readConfig();
+    expect(cfg.schema).toBeDefined();
+  });
+
+  it('no-ops when no [gitsheet.fields] block exists', async () => {
+    const fixture = await emptyRepo();
+    await runCli(['init', 'users', '--path', '${{ slug }}'], fixture.path);
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['migrate-config', 'users'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(stdout).toContain('no [gitsheet.fields] block');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+});

--- a/packages/gitsheets-axi/test/diff-normalize.test.ts
+++ b/packages/gitsheets-axi/test/diff-normalize.test.ts
@@ -1,0 +1,148 @@
+// AXI diff + normalize commands.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from 'gitsheets';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+`;
+
+async function seedRepo({ withRecords = false }: { withRecords?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users');
+
+  if (withRecords) {
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+      await tx.sheet('users').upsert({ slug: 'bob', email: 'bob@x.org' });
+    });
+  }
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('diff', () => {
+  it('lists current records as added when no src ref is given', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(['diff', 'users'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('count: 2 of 2 total');
+    expect(stdout).toContain('src_ref: (empty tree)');
+    expect(stdout).toMatch(/added,bob/);
+    expect(stdout).toMatch(/added,jane/);
+  });
+
+  it('emits empty state with src_ref=HEAD', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(
+      ['diff', 'users', 'HEAD'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('src_ref: HEAD');
+    expect(stdout).toMatch(/changes: no changes|count: 0 of 0/);
+  });
+
+  it('--patches includes RFC 6902 patch ops per change', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const { stdout, exitCode } = await runCli(
+      ['diff', 'users', '--patches'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    // The header should now include a `patch` column.
+    expect(stdout).toMatch(/changes\[2\]\{status,path,src_hash,dst_hash,patch\}/);
+  });
+});
+
+describe('normalize', () => {
+  it('no-op when every record is already canonical', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['normalize', 'users'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(stdout).toContain('already canonical');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('no-op on an empty sheet', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['normalize', 'users'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('rewrites a non-canonical record (manual disk edit)', async () => {
+    const fixture = await seedRepo();
+    // Write a non-canonical record directly to disk + commit it. Library
+    // upserts always canonicalize, so this is the only way to get a
+    // non-canonical record into a tree.
+    await mkdir(join(fixture.path, 'users'), { recursive: true });
+    await writeFile(
+      join(fixture.path, 'users', 'mia.toml'),
+      `slug = "mia"\nemail = "mia@x.org"\n`, // keys out of order
+      'utf-8',
+    );
+    await fixture.git('add', 'users/mia.toml');
+    await fixture.git('commit', '-m', 'add mia (non-canonical)');
+    const before = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(
+      ['normalize', 'users'],
+      fixture.path,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('1 of 1 rewritten');
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+});

--- a/packages/gitsheets-axi/test/push.test.ts
+++ b/packages/gitsheets-axi/test/push.test.ts
@@ -1,0 +1,81 @@
+// AXI push command — one-shot push to a git remote.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+async function repoWithBareRemote(): Promise<{
+  repo: TestRepoHandle;
+  remote: TestRepoHandle;
+}> {
+  // Bare "remote" repo.
+  const remote = await testRepo();
+  handles.push(remote);
+  await remote.git('config', 'receive.denyCurrentBranch', 'updateInstead');
+
+  // Working repo with origin → bare remote.
+  const repo = await testRepo({ withInitialCommit: true });
+  handles.push(repo);
+  await repo.git('remote', 'add', 'origin', remote.path);
+  return { repo, remote };
+}
+
+describe('push', () => {
+  it('pushes commits to origin and reports success', async () => {
+    const { repo } = await repoWithBareRemote();
+    // Add a record-like change so HEAD moves.
+    await mkdir(join(repo.path, '.gitsheets'), { recursive: true });
+    await writeFile(
+      join(repo.path, '.gitsheets', 'users.toml'),
+      `[gitsheet]\nroot = 'users'\npath = '\${{ slug }}'\n`,
+    );
+    await repo.git('add', '.gitsheets/');
+    await repo.git('commit', '-m', 'add users');
+
+    const { stdout, exitCode } = await runCli(['push'], repo.path);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: pushed');
+    expect(stdout).toContain('remote: origin');
+  });
+
+  it('no-op when remote is already up to date', async () => {
+    const { repo } = await repoWithBareRemote();
+    await mkdir(join(repo.path, '.gitsheets'), { recursive: true });
+    await writeFile(
+      join(repo.path, '.gitsheets', 'users.toml'),
+      `[gitsheet]\nroot = 'users'\npath = '\${{ slug }}'\n`,
+    );
+    await repo.git('add', '.gitsheets/');
+    await repo.git('commit', '-m', 'add users');
+    await runCli(['push'], repo.path);
+
+    const { stdout, exitCode } = await runCli(['push'], repo.path);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(stdout).toContain('up-to-date');
+  });
+
+  it('errors with PUSH_FAILED when no remote exists', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+
+    const { stdout, exitCode } = await runCli(['push'], fixture.path);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('PUSH_FAILED');
+  });
+});

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -15,6 +15,16 @@ import { upsertCommand, UPSERT_HELP } from '../src/commands/upsert.js';
 import { patchCommand, PATCH_HELP } from '../src/commands/patch.js';
 import { deleteCommand, DELETE_HELP } from '../src/commands/delete.js';
 import { checkCommand, CHECK_HELP } from '../src/commands/check.js';
+import { diffCommand, DIFF_HELP } from '../src/commands/diff.js';
+import { normalizeCommand, NORMALIZE_HELP } from '../src/commands/normalize.js';
+import { initCommand, INIT_HELP } from '../src/commands/init.js';
+import { inferCommand, INFER_HELP } from '../src/commands/infer.js';
+import {
+  migrateConfigCommand,
+  MIGRATE_CONFIG_HELP,
+} from '../src/commands/migrate-config.js';
+import { attachmentCommand, ATTACHMENT_HELP } from '../src/commands/attachment.js';
+import { pushCommand, PUSH_HELP } from '../src/commands/push.js';
 
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
@@ -24,6 +34,13 @@ const COMMAND_HELP: Record<string, string> = {
   patch: PATCH_HELP,
   delete: DELETE_HELP,
   check: CHECK_HELP,
+  diff: DIFF_HELP,
+  normalize: NORMALIZE_HELP,
+  init: INIT_HELP,
+  infer: INFER_HELP,
+  'migrate-config': MIGRATE_CONFIG_HELP,
+  attachment: ATTACHMENT_HELP,
+  push: PUSH_HELP,
 };
 
 const COMMANDS = {
@@ -34,6 +51,13 @@ const COMMANDS = {
   patch: patchCommand,
   delete: deleteCommand,
   check: checkCommand,
+  diff: diffCommand,
+  normalize: normalizeCommand,
+  init: initCommand,
+  infer: inferCommand,
+  'migrate-config': migrateConfigCommand,
+  attachment: attachmentCommand,
+  push: pushCommand,
 } as Record<
   string,
   (args: string[], ctx: GitsheetsContext | undefined) => Promise<string | Record<string, unknown>>

--- a/packages/gitsheets/LICENSE
+++ b/packages/gitsheets/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/gitsheets/README.md
+++ b/packages/gitsheets/README.md
@@ -1,0 +1,83 @@
+# gitsheets
+
+A git-backed document store for low-volume, high-touch, human-scale data.
+
+Records are TOML files in a git repo, organized by a per-sheet path template. Every mutation is a commit — the commit log is the audit log. Schemas live alongside the data; validation runs on every write. Branches give you propose-review workflows for free. Content-typed sheets (markdown with TOML frontmatter) support documents-as-records workflows.
+
+```bash
+npm install gitsheets
+```
+
+ESM-only. Targets Node.js ≥ 20 and Bun ≥ 1. CLI installs as `gitsheets` and `git-sheet`.
+
+## Quick taste
+
+```typescript
+import { openRepo } from 'gitsheets';
+
+const repo = await openRepo();
+const users = await repo.openSheet('users');
+
+await repo.transact({ message: 'add jane' }, async (tx) => {
+  await tx.sheet('users').upsert({
+    slug: 'jane',
+    email: 'jane@x.org',
+    fullName: 'Jane Doe',
+  });
+});
+
+const jane = await users.queryFirst({ slug: 'jane' });
+```
+
+Sheet config (`.gitsheets/users.toml`):
+
+```toml
+[gitsheet]
+root = 'users'
+path = '${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+pattern = '^[a-z0-9-]+$'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+format = 'email'
+```
+
+That lands on disk as `users/jane.toml` with deep-sorted keys for byte-stable diffs.
+
+## What you get
+
+- **Typed reads + writes.** `Sheet<T>` is generic; combine with [Standard Schema](https://standardschema.dev) validators (Zod, Valibot, ArkType, Effect Schema) via `openStore` for end-to-end TS types.
+- **Transactions.** `repo.transact(opts, async tx => …)` bundles multi-sheet mutations into a single commit with author + structured trailers.
+- **JSON Schema validation** layered with optional consumer Standard Schema validators. Both run on every write.
+- **Canonical normalization** on write — deep-sorted keys, per-field array sort rules — so byte-equality means logical-equality and git diffs are meaningful.
+- **Path templates** with `${{ field }}` and `${{ expression }}` syntax, recursive `${{ field/** }}`, multi-variable per-segment.
+- **Content-typed sheets.** Opt into `[gitsheet.format] type = 'markdown'` for records as `.md` files with TOML frontmatter and a designated body field. Lazy body loading; markdownlint-normalized bodies.
+- **Secondary indices.** `sheet.defineIndex(name, fn)` — in-memory, lazy, auto-rebuilt on tree-hash change.
+- **Push daemon.** Optional library-side background task that pushes new commits with retry/backoff. Push-only (single-writer model).
+- **Attachments.** Binary blobs colocated with records; first-class API; cascade-delete with the record.
+- **CLI** (`gitsheets` / `git sheet`) for upsert / query / read / edit / check / normalize / init / infer / migrate-config.
+
+## Companion: `gitsheets-axi`
+
+For agent-driven shell invocation, see [`gitsheets-axi`](https://www.npmjs.com/package/gitsheets-axi) — same operations, agent ergonomics (TOON output, idempotent mutations, self-installing session hooks).
+
+## Docs
+
+- **[Quick start](https://jarvusinnovations.github.io/gitsheets/quick-start)** — install → declare a sheet → write a record → read it back
+- **[Concepts](https://jarvusinnovations.github.io/gitsheets/concepts)** — Repository, Sheet, Path Template, Transaction, Store, Index, Push Daemon
+- **[API reference](https://jarvusinnovations.github.io/gitsheets/api)** — public exports + pointers into per-symbol spec
+- **[CLI reference](https://jarvusinnovations.github.io/gitsheets/cli)** — every command, every flag, exit codes
+- **[Recipes](https://jarvusinnovations.github.io/gitsheets/)** — typed sheets with Zod, request-bound transactions, push-daemon setup, markdown CMS
+
+[`specs/`](https://github.com/JarvusInnovations/gitsheets/tree/develop/specs) in the source repository is the authoritative API + behavior contract.
+
+## License
+
+Apache-2.0.

--- a/packages/gitsheets/src/index.ts
+++ b/packages/gitsheets/src/index.ts
@@ -66,6 +66,8 @@ export type {
   TransactionHandler,
 } from './transaction.js';
 
+export { parseToml, parseConfigToml, stringifyRecord } from './toml.js';
+
 export { Template } from './path-template/index.js';
 export type {
   RecordLike,

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -159,6 +159,52 @@ Outputs:
 - `CONFIG_INVALID` when the file fails to parse as the sheet's format
 - `NOT_FOUND` when the target file doesn't exist
 
+### `gitsheets-axi diff <sheet> [<src-ref>] [--patches]`
+
+TOON change summary between a source ref and the current tree. With no `<src-ref>`, compares against the empty tree — every current record shows as `added`, useful for one-shot snapshots.
+
+Default columns: `status` (added/modified/deleted/renamed), `path`, `src_hash`, `dst_hash`. `--patches` adds an RFC 6902 patch column with the per-change ops as JSON-encoded TOON.
+
+### `gitsheets-axi normalize <sheet>`
+
+Bulk re-canonicalize every record in a sheet. Per-record idempotency via `sheet.willChange` means only records whose canonical bytes differ from disk get rewritten; if every record is already canonical, exits with `result: "no-op"` and no commit.
+
+Use this when migrating sheets to a new schema or after a normalization-rule change in the sheet config. For single-file fixes, `check --fix` is cheaper.
+
+### `gitsheets-axi init <sheet> [--path <template>] [--schema <file>] [--force]`
+
+Scaffold a starter `.gitsheets/<sheet>.toml`. `--path` defaults to `${{ id }}`; `--schema` loads a JSON file and embeds it as the sheet's JSON Schema. Refuses to overwrite an existing config unless `--force` is set; if the rendered config matches the existing one byte-for-byte, returns `result: "no-op"`.
+
+### `gitsheets-axi infer <sheet>`
+
+Walks the sheet's records, observes which fields appear with which types and how often, and writes back a generated `[gitsheet.schema]` block. Fields present in every record become `required`. Idempotent when the inferred schema matches the current config. Errors with `NO_RECORDS` if there's nothing to observe.
+
+### `gitsheets-axi migrate-config <sheet>`
+
+Translates a pre-v1.0 `[gitsheet.fields]` block into the modern `[gitsheet.schema]` block. `type`/`enum`/`default` move into JSON Schema properties; `sort` rules stay on the field (they're a normalization concern, not validation). `trueValues`/`falseValues` are dropped with a warning. No-op when there's no `[gitsheet.fields]` block.
+
+### `gitsheets-axi attachment <subcommand>`
+
+Manage binary blobs colocated with records. Subcommands:
+
+| Subcommand | Flags / Notes |
+|---|---|
+| `list <sheet> <path>` | Table of attachment names + mime types + blob hashes |
+| `get <sheet> <path> <name>` | Base64-encoded content + metadata; truncated at ~64 KB unless `--full` |
+| `set <sheet> <path> <name> [--file f / --data t / stdin]` | Idempotent on byte-match |
+| `delete <sheet> <path> [<name>]` | Delete one (idempotent on already-missing) or all if name omitted |
+
+### `gitsheets-axi push [--remote r] [--branch b]`
+
+One-shot `git push <remote> <branch>` from the repo's git dir. Defaults: `origin`, current HEAD branch. Reports `result: "pushed"` or `result: "no-op"` when the remote is already up to date.
+
+Errors map to:
+
+- `NON_FAST_FORWARD` — remote has work the local doesn't; reconcile externally before retrying
+- `PUSH_FAILED` — network/auth/transient; safe to retry
+
+This is **not** a daemon lifecycle command — for retry-with-backoff semantics in a long-running consumer, use `Repository.startPushDaemon` from the library.
+
 ## When to use `gitsheets-axi` vs `gitsheets`
 
 | Scenario | Use |


### PR DESCRIPTION
## Summary

Completes the `gitsheets-axi` command surface after the [MVP merge in #174](https://github.com/JarvusInnovations/gitsheets/pull/174). The agent-facing CLI now mirrors the full operational surface of `gitsheets` minus the genuinely human-only commands (`edit`).

Closes #170.

## Commands added

| Command | Notes |
|---|---|
| `diff <sheet> [<src-ref>] [--patches]` | TOON change summary; defaults to empty-tree (all current records as `added`) |
| `normalize <sheet>` | Bulk re-canonicalize; per-record idempotency via `sheet.willChange` |
| `init <sheet>` | Scaffold `.gitsheets/<sheet>.toml`; `--force` to overwrite |
| `infer <sheet>` | Observe records, generate `[gitsheet.schema]`; numeric min/max, presence-based `required` |
| `migrate-config <sheet>` | Pre-v1.0 `[gitsheet.fields]` → `[gitsheet.schema]` translation |
| `attachment list` | Names + mime types + hashes |
| `attachment get` | Base64 content, truncated at 64 KB with `--full` opt-out |
| `attachment set` | `--file`, `--data`, or stdin; byte-match idempotency |
| `attachment delete` | Single or all; idempotent on already-missing |
| `push` | One-shot `git push`, classifies NON_FAST_FORWARD vs PUSH_FAILED |

Every mutation participates in the same idempotency contract: re-runs that don't change state exit 0 with `result: "no-op"` and produce no commit.

## Library additions

- `parseToml`, `parseConfigToml`, `stringifyRecord` now exported from the public surface. The config-scaffolding commands need to round-trip raw TOML, which previously required reaching into internal modules.

## Tests

| | Count | |
|---|---|---|
| diff + normalize | 6 | empty/HEAD/--patches/no-op/empty-sheet/non-canonical-rewrite |
| init/infer/migrate-config | 10 | create/idempotent/--force/refuse-overwrite/schema-inference/no-records/no-fields-block/etc. |
| attachment | 9 | list/get/set/delete × happy + idempotent + missing |
| push | 3 | pushed/no-op/PUSH_FAILED |
| **Total axi** | **63** (was 35) | |
| Library | 250 (unchanged) | |

## Skill

`references/axi.md` documents every new command — same routing rule stands ("agent shell → axi, application code → library").

## Test plan

- [x] `npm install && npm run build && npm test && npm run type-check` from root — all green (313 tests)
- [x] Smoke-tested every command against a real test repo with seeded data + attachments + a bare remote for push
- [ ] CI green on this PR (multi-Node matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)