### PR TITLE
chore: replace 1.0.0-substrate.0 version sentinel with 0.0.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3506,7 +3506,7 @@
       }
     },
     "packages/gitsheets": {
-      "version": "1.0.0-substrate.0",
+      "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -3536,7 +3536,7 @@
       }
     },
     "packages/gitsheets-axi": {
-      "version": "1.0.0-substrate.0",
+      "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@toon-format/toon": "^2.2.0",

--- a/packages/gitsheets-axi/package.json
+++ b/packages/gitsheets-axi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsheets-axi",
-  "version": "1.0.0-substrate.0",
+  "version": "0.0.0-dev",
   "description": "Agent-facing CLI for gitsheets — token-efficient TOON output, idempotent mutations, self-installing session hooks.",
   "type": "module",
   "bin": {

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsheets",
-  "version": "1.0.0-substrate.0",
+  "version": "0.0.0-dev",
   "description": "A git-backed document store for low-volume, high-touch, human-scale data",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Replace the stale `1.0.0-substrate.0` version sentinel in both workspaces' `package.json` (and the lockfile) with `0.0.0-dev`. Functionally nothing changes — `publish-npm.yml` always overrides this value at tag time via `npm version --no-git-tag-version`.

The reason this matters now: when bootstrapping `gitsheets-axi` on npm without OIDC (one-time first publish to register the package name), the workspace's local version is what gets shipped. `1.0.0-substrate.0` is a weird-looking thing to leak onto the public registry. `0.0.0-dev` reads clearly as "this is the development tip, not a release."

The sentinel was a leftover from the `1.0-substrate` branch that did the v1.0 purge (#128). It just never got cleaned up after the substrate branch merged.

## Files

- `packages/gitsheets/package.json` — `1.0.0-substrate.0` → `0.0.0-dev`
- `packages/gitsheets-axi/package.json` — same
- `package-lock.json` — regenerated by `npm version`

## Test plan

- [x] `npm run build && npm run type-check && npm test` — 337 tests green (274 library + 63 axi)
- [ ] CI green
- [ ] Bootstrap publish of `gitsheets-axi` (one-time, manual) then tag v1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)