### PR TITLE
v1.3.1: O(1) Sheet#clear() + no-op commit detection in Transaction#finalize

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -214,7 +214,7 @@ Patch release. Two fixes in service of snapshot-importer-style workflows.
 
 ### Dependency
 
-- `hologit` bumped to a version that ships `TreeObject.clearChildren()` (the O(1) primitive — added in hologit 0.50.1, with the corresponding `index.d.ts` declaration in 0.50.2).
+- `hologit` bumped from `^0.49.1` to `^0.50.2` to pick up `TreeObject.clearChildren()` (the O(1) primitive backing the new `Sheet#clear()`).
 
 ## Going forward
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -184,7 +184,7 @@ Fully additive minor release. Existing v1.2 code keeps working.
 
 ### Library
 
-- **`Sheet.willChange(record, opts?)`** — new. Pre-flight idempotency check that runs upsert's full validation + normalization + serialization pipeline and compares the resulting bytes to the existing blob at the rendered path — without mutating the tree. Returns `{ changed, path, currentBlobHash?, nextText }`. Consumers that want commit-skipping semantics ("only commit if something actually changed") can pre-flight + skip when `changed: false`. Throws the same errors `upsert` would.
+- **`Sheet.willChange(record, opts?)`** — new in v1.3.0. Pre-flight idempotency check that runs upsert's full validation + normalization + serialization pipeline and compares the resulting bytes to the existing blob at the rendered path — without mutating the tree. Returns `{ changed, path, currentBlobHash?, nextText }`. Consumers that want commit-skipping semantics ("only commit if something actually changed") can pre-flight + skip when `changed: false`. Throws the same errors `upsert` would.
 - **Title from body's H1.** Content-typed sheets can opt into `[gitsheet.format].title = '<field>'` to denormalize the body's first H1 into a frontmatter field. The library enforces `record.title === <body's first H1, or undefined>` on every write — `upsert` with disagreeing values throws `ValidationError`; `Sheet.patch({title: 'X'})` rewrites the body's H1 for you, `Sheet.patch({body: '# Y\n…'})` re-derives the title. Markdownlint's `MD041` auto-enables to fail loud on bodies that start with prose. Fully backward-compatible — sheets without `[gitsheet.format].title` behave exactly as v1.2. See [`behaviors/content-types.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/content-types.md#title-from-h1) and the [Markdown CMS recipe](recipes/markdown-cms.md#title-from-bodys-h1-recommended).
 - **New utility exports**: `parseToml`, `parseConfigToml`, `stringifyRecord` (TOML round-tripping), `getFormat`, `hasFormat`, `registerFormat`, `resolveFormatConfig` (format dispatch). All were already in the package's internal modules; v1.3 surfaces them at the package root for consumers who need raw-bytes round-tripping or custom format registration.
 - **New public type**: `WillChangeResult`.
@@ -200,6 +200,21 @@ Fully additive minor release. Existing v1.2 code keeps working.
 ### CLI
 
 No new commands on the human `gitsheets` CLI in v1.3. The agent-facing operations (TOON output, idempotent mutations) live in `gitsheets-axi` rather than as flags on the human CLI — the two contracts disagree on too many defaults to coexist in one binary.
+
+## v1.3.0 → v1.3.1
+
+Patch release. Two fixes in service of snapshot-importer-style workflows.
+
+### Library
+
+- **`Sheet.clear()` is now O(1).** Previously walked the sheet's subtree and called `deleteChild` for every entry — fine at sheet sizes of a few hundred records, problematic at tens of thousands. The new implementation uses hologit's `TreeObject.clearChildren()` (added in hologit 0.50.2) to point the subtree at git's empty-tree hash in constant time. Same observable behavior; existing code unchanged.
+- **No-op transactions no longer produce empty commits.** `Transaction#finalize` now compares the resulting tree-hash to the parent commit's tree-hash; equality means the staged state matches the parent and no commit is created. Concretely, **every "clear + re-upsert from snapshot" pattern against unchanged upstream data is now a clean no-op** (`commitHash === null`). Same goes for `upsert(record)` where the record's canonical bytes match what's on disk, and `delete` + re-`upsert` of an identical record.
+
+  **Subtle behavior change:** an explicit `tx.markMutated()` call that isn't paired with a real tree mutation no longer produces a commit. Internal callers (upsert/delete/setAttachments/etc.) always pair `markMutated` with an actual mutation, so this shouldn't affect any real consumer. Consumers who genuinely want empty commits should use `git commit --allow-empty` outside the library.
+
+### Dependency
+
+- `hologit` bumped to a version that ships `TreeObject.clearChildren()` (the O(1) primitive — added in hologit 0.50.1, with the corresponding `index.d.ts` declaration in 0.50.2).
 
 ## Going forward
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,9 +1341,9 @@
       }
     },
     "node_modules/git-client": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.11.1.tgz",
-      "integrity": "sha512-N3tsTCjaELPf3HiAI+Fg4ua74hRl6AT1v6EICbhvykg0pnAXfWqdjGXOY5TgA99r555N2SOtqIgKuwluB9F5kQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.12.1.tgz",
+      "integrity": "sha512-Px7HE2ug+IKiOhNE/vezkwpDE7IUYHnoRHQfds2BlRf6CZglNq7lmlxVoRtprJ4ZHTq0ZWrQLZtrcMxFw18zvw==",
       "license": "MIT",
       "dependencies": {
         "async-exit-hook": "^2.0.1",
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/hologit": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/hologit/-/hologit-0.49.1.tgz",
-      "integrity": "sha512-W9gUMB4cKdYoOniE6MRxEc1k426O22khyuJ7atraj85IEFiJQEAs4TWxwKbcdVDJ09XwQt9sMrOm05KMmP1KBA==",
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/hologit/-/hologit-0.50.1.tgz",
+      "integrity": "sha512-/Wx7KZ/6XPvSbJA/jb6zVXDqrHfQKF5/ZELW5N010h2l23LpX0uwFrvgKigEGPSUlmtaBzpHGk3LQvTeXcFaPg==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -1504,13 +1504,13 @@
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "async-exit-hook": "^2.0.1",
-        "axios": "^1.13.6",
+        "axios": "^1.14.0",
         "chokidar": "^5.0.0",
         "debounce": "^3.0.0",
         "fb-watchman": "^2.0.2",
-        "git-client": "^1.11.0",
+        "git-client": "^1.12.0",
         "hab-client": "^1.1.3",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "minimatch": "^10.2.4",
         "mz": "^2.7.0",
         "mz-modules": "^2.1.0",
@@ -3514,7 +3514,7 @@
         "ajv-formats": "^3.0.1",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
-        "hologit": "^0.49.1",
+        "hologit": "^0.50.1",
         "markdownlint": "^0.40.0",
         "rfc6902": "^5.2.0",
         "sort-keys": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/hologit": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/hologit/-/hologit-0.50.1.tgz",
-      "integrity": "sha512-/Wx7KZ/6XPvSbJA/jb6zVXDqrHfQKF5/ZELW5N010h2l23LpX0uwFrvgKigEGPSUlmtaBzpHGk3LQvTeXcFaPg==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/hologit/-/hologit-0.50.2.tgz",
+      "integrity": "sha512-9StuAaE8TkdnJE/cA5vdq+pwt/hZH1JGa9qsGfAz7rvwsXrVlQT/lBJd+pedpJHOJgPdA4NXC0lqljFzOWV+7A==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -3514,7 +3514,7 @@
         "ajv-formats": "^3.0.1",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
-        "hologit": "^0.50.1",
+        "hologit": "^0.50.2",
         "markdownlint": "^0.40.0",
         "rfc6902": "^5.2.0",
         "sort-keys": "^6.0.0",

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -46,7 +46,7 @@
     "ajv-formats": "^3.0.1",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
-    "hologit": "^0.49.1",
+    "hologit": "^0.50.1",
     "markdownlint": "^0.40.0",
     "rfc6902": "^5.2.0",
     "sort-keys": "^6.0.0",

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -46,7 +46,7 @@
     "ajv-formats": "^3.0.1",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
-    "hologit": "^0.50.1",
+    "hologit": "^0.50.2",
     "markdownlint": "^0.40.0",
     "rfc6902": "^5.2.0",
     "sort-keys": "^6.0.0",

--- a/packages/gitsheets/src/sheet-clear.test.ts
+++ b/packages/gitsheets/src/sheet-clear.test.ts
@@ -1,0 +1,177 @@
+// Sheet.clear() — #178 fix: uses hologit TreeObject.clearChildren()
+// (O(1)) instead of walking + deleteChild per entry.
+//
+// The behavioral observable is the serialized hash of the sheet's subtree
+// in the working tree's TreeObject mid-transaction: after clear() it must
+// equal git's empty-tree hash.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+
+const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_CONFIG = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+`;
+
+async function seedRepo({
+  withRecords = false,
+}: { withRecords?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_CONFIG);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users');
+
+  if (withRecords) {
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+      await tx.sheet('users').upsert({ slug: 'bob', email: 'bob@x.org' });
+      await tx.sheet('users').upsert({ slug: 'mia', email: 'mia@x.org' });
+    });
+  }
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('Sheet.clear', () => {
+  it('subtree serializes to EMPTY_TREE_HASH after clear', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    let observedHash = '';
+    await repo.transact({ message: 'clear users' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await sheet.clear();
+      // Reach into the workspace tree at the sheet's root and assert its
+      // serialized hash. The shape of `tx.tree` is the data root; the
+      // sheet root is 'users' (per USERS_CONFIG).
+      const sheetSubtree = await tx.tree.getSubtree('users', false);
+      if (sheetSubtree) {
+        observedHash = await sheetSubtree.getHash();
+      }
+    });
+
+    expect(observedHash).toBe(EMPTY_TREE_HASH);
+  });
+
+  it('committed sheet has no records after clear', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'clear users' }, async (tx) => {
+      await tx.sheet('users').clear();
+    });
+
+    const sheet = await repo.openSheet('users');
+    const rows = await sheet.queryAll({});
+    expect(rows).toEqual([]);
+  });
+
+  it('clear then re-upsert leaves only the new records', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'reset + reseed' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await sheet.clear();
+      await sheet.upsert({ slug: 'new-only', email: 'new@x.org' });
+    });
+
+    const sheet = await repo.openSheet('users');
+    const rows = await sheet.queryAll({});
+    const slugs = rows.map((r) => (r as Record<string, unknown>)['slug']);
+    expect(slugs).toEqual(['new-only']);
+  });
+
+  it('clear on an already-empty sheet is a safe no-op (still produces a commit due to markMutated)', async () => {
+    // After the #179 no-op-detection fix, the commit count should NOT
+    // increase if no actual tree mutation occurred. That assertion lives
+    // in the transaction test file; here we just check that clear() on
+    // an already-empty sheet doesn't throw.
+    const fixture = await seedRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'clear empty' }, async (tx) => {
+      await tx.sheet('users').clear();
+    });
+  });
+
+  it('invalidates indexes — subsequent findByIndex sees the cleared state', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    const sheet = await repo.openSheet('users');
+    sheet.defineIndex(
+      'byEmail',
+      { unique: true },
+      (r) => (r as Record<string, unknown>)['email'] as string,
+    );
+
+    // Prime the index.
+    const before = await sheet.findByIndex('byEmail', 'jane@x.org');
+    expect(before).toBeDefined();
+
+    // Clear via a different sheet handle (sharing the underlying repo) to
+    // simulate an external mutation; the per-instance handle's index
+    // wouldn't auto-invalidate, but the clear() inside the transaction
+    // does invalidate the in-tx sheet's indexes. The behavior under test
+    // is that clear() invokes #invalidateIndexes() (added with the fix).
+    await repo.transact({ message: 'clear' }, async (tx) => {
+      const txSheet = tx.sheet('users');
+      txSheet.defineIndex(
+        'byEmail',
+        { unique: true },
+        (r) => (r as Record<string, unknown>)['email'] as string,
+      );
+      // Build the index so we can verify it's invalidated.
+      const found = await txSheet.findByIndex('byEmail', 'jane@x.org');
+      expect(found).toBeDefined();
+
+      await txSheet.clear();
+
+      // After clear(), the index should rebuild from the now-empty subtree.
+      const afterClear = await txSheet.findByIndex('byEmail', 'jane@x.org');
+      expect(afterClear).toBeUndefined();
+    });
+  });
+
+  it('multiple clears in different transactions produce expected commit counts', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const beforeClear = await commitCount(fixture);
+
+    await repo.transact({ message: 'clear 1' }, async (tx) => {
+      await tx.sheet('users').clear();
+    });
+    const afterFirstClear = await commitCount(fixture);
+    expect(afterFirstClear).toBe(beforeClear + 1);
+
+    // Second clear on an already-empty sheet — after #179, no commit.
+    await repo.transact({ message: 'clear 2' }, async (tx) => {
+      await tx.sheet('users').clear();
+    });
+    const afterSecondClear = await commitCount(fixture);
+    expect(afterSecondClear).toBe(afterFirstClear);
+  });
+});

--- a/packages/gitsheets/src/sheet.ts
+++ b/packages/gitsheets/src/sheet.ts
@@ -9,6 +9,15 @@ import type { Readable } from 'node:stream';
 import type { BlobObject, TreeObject, Workspace } from 'hologit';
 import { createPatch as rfc6902CreatePatch, type Operation as JsonPatchOp } from 'rfc6902';
 
+// TODO: remove once hologit ships >=0.50.2 with this in its index.d.ts.
+// JS method was added in hologit#455 (shipped in 0.50.1); the type
+// declaration was a follow-up in hologit#457.
+declare module 'hologit' {
+  interface TreeObject {
+    clearChildren(): void;
+  }
+}
+
 import {
   ConfigError,
   IndexError,
@@ -946,14 +955,14 @@ export class Sheet<T extends RecordLike = RecordLike> {
     const config = await this.readConfig();
     const sheetTree = await this.#dataTree.getSubtree(this.#effectiveRoot(config), true);
     if (sheetTree) {
-      const children = await sheetTree.getChildren();
-      const names: string[] = [];
-      for (const k in children) names.push(k);
-      for (const childName of names) {
-        await sheetTree.deleteChild(childName);
-      }
+      // O(1) — drops both pending and base children in-place. The
+      // serialized subtree becomes git's empty-tree hash, which hologit's
+      // tree write() already skips when emitting parent entries.
+      // See specs/api/sheet.md#clear.
+      sheetTree.clearChildren();
     }
     this.#transaction.markMutated();
+    this.#invalidateIndexes();
   }
 
   async clone(): Promise<Sheet<T>> {

--- a/packages/gitsheets/src/sheet.ts
+++ b/packages/gitsheets/src/sheet.ts
@@ -9,15 +9,6 @@ import type { Readable } from 'node:stream';
 import type { BlobObject, TreeObject, Workspace } from 'hologit';
 import { createPatch as rfc6902CreatePatch, type Operation as JsonPatchOp } from 'rfc6902';
 
-// TODO: remove once hologit ships >=0.50.2 with this in its index.d.ts.
-// JS method was added in hologit#455 (shipped in 0.50.1); the type
-// declaration was a follow-up in hologit#457.
-declare module 'hologit' {
-  interface TreeObject {
-    clearChildren(): void;
-  }
-}
-
 import {
   ConfigError,
   IndexError,

--- a/packages/gitsheets/src/transaction-no-op.test.ts
+++ b/packages/gitsheets/src/transaction-no-op.test.ts
@@ -1,0 +1,168 @@
+// Transaction#finalize no-op detection (#179).
+//
+// Before the fix, `#anyMutation = true` was sufficient to produce a
+// commit, even when the resulting tree-hash matched the parent's. The
+// fix compares tree hashes after `workspace.root.write()`; equality
+// short-circuits to the same return shape as the `!#anyMutation` path.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_CONFIG = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+`;
+
+async function seedRepo({
+  withRecords = false,
+}: { withRecords?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_CONFIG);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users');
+
+  if (withRecords) {
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'seed' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+      await tx.sheet('users').upsert({ slug: 'bob', email: 'bob@x.org' });
+    });
+  }
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('Transaction#finalize no-op detection', () => {
+  it('upsert of byte-identical record produces no commit', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const before = await commitCount(fixture);
+
+    const result = await repo.transact({ message: 'reupsert same' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    expect(result.commitHash).toBeNull();
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('clear + reupsert with identical data produces no commit', async () => {
+    // The snapshot-importer pattern from #179.
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const before = await commitCount(fixture);
+
+    const result = await repo.transact({ message: 'snapshot reimport' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await sheet.clear();
+      await sheet.upsert({ slug: 'jane', email: 'jane@x.org' });
+      await sheet.upsert({ slug: 'bob', email: 'bob@x.org' });
+    });
+
+    expect(result.commitHash).toBeNull();
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('clear + reupsert with ONE record changed produces exactly one commit', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const before = await commitCount(fixture);
+
+    const result = await repo.transact({ message: 'snapshot diff' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await sheet.clear();
+      await sheet.upsert({ slug: 'jane', email: 'jane@x.org' });
+      // bob's email changed
+      await sheet.upsert({ slug: 'bob', email: 'bob@new.org' });
+    });
+
+    expect(result.commitHash).not.toBeNull();
+    expect(await commitCount(fixture)).toBe(before + 1);
+  });
+
+  it('markMutated alone (no tree change) produces no commit — behavior change vs v1.3.0', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const before = await commitCount(fixture);
+
+    const result = await repo.transact({ message: 'force?' }, async (tx) => {
+      // markMutated alone used to produce an empty commit; after #179, the
+      // tree-hash comparison short-circuits.
+      tx.markMutated();
+    });
+
+    expect(result.commitHash).toBeNull();
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('initial commit on a fresh repo IS produced when transaction runs (no parent to compare against)', async () => {
+    const fixture = await testRepo({ withInitialCommit: false });
+    handles.push(fixture);
+
+    // .gitsheets/users.toml created INSIDE the transaction so the tx has
+    // real tree changes; the assertion is that `commitHash` is non-null
+    // because there's no parent to compare against.
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const result = await repo.transact(
+      {
+        message: 'initial',
+        branch: 'refs/heads/main',
+        // No `parent` — fresh repo, no parent commit to compare against.
+      },
+      async (tx) => {
+        await tx.tree.writeChild('.gitsheets/users.toml', USERS_CONFIG);
+        tx.markMutated();
+      },
+    );
+
+    expect(result.commitHash).not.toBeNull();
+  });
+
+  it('delete then re-add identical record produces no commit', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const before = await commitCount(fixture);
+
+    const result = await repo.transact({ message: 'rebuild jane' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await sheet.delete('jane');
+      await sheet.upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    expect(result.commitHash).toBeNull();
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('returns the same shape as the !anyMutation path on no-op (treeHash: null)', async () => {
+    const fixture = await seedRepo({ withRecords: true });
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    const result = await repo.transact({ message: 'noop' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    expect(result.commitHash).toBeNull();
+    expect(result.treeHash).toBeNull();
+    expect(result.ref).toBeNull();
+    expect(result.parentCommitHash).not.toBeNull();
+  });
+});

--- a/packages/gitsheets/src/transaction.ts
+++ b/packages/gitsheets/src/transaction.ts
@@ -243,6 +243,34 @@ export class Transaction {
 
     const gitDir = this.#hologitRepo.gitDir;
     const treeHash = await this.#workspace.root.write();
+
+    // No-op detection: if the resulting tree-hash matches the parent
+    // commit's tree-hash, nothing actually changed. Skip the commit-tree
+    // spawn + ref update — same return shape as the `!#anyMutation` path
+    // above. The `#anyMutation` flag tracks "a mutating method was
+    // called," which over-approximates: clear() on an already-empty
+    // sheet, upsert() of byte-identical content, and bulk reimport-with-
+    // unchanged-data patterns all set the flag without changing the
+    // tree. Tree-hash equality is the canonical git-native truth.
+    // See specs/api/transaction.md#no-op-detection.
+    if (this.#parentCommitHash !== null) {
+      const { stdout: parentTreeStdout } = await exec(
+        'git',
+        ['rev-parse', `${this.#parentCommitHash}^{tree}`],
+        { cwd: gitDir },
+      );
+      const parentTreeHash = parentTreeStdout.trim();
+      if (parentTreeHash === treeHash) {
+        return {
+          value,
+          commitHash: null,
+          treeHash: null,
+          ref: null,
+          parentCommitHash: this.#parentCommitHash,
+        };
+      }
+    }
+
     const message = formatCommitMessage(this.#message, this.#trailers);
 
     let commitHash: string;

--- a/specs/api/sheet.md
+++ b/specs/api/sheet.md
@@ -134,7 +134,11 @@ Returns `Promise<{ blob, path }>` matching `upsert`.
 
 ### `sheet.clear()`
 
-Removes every record from the sheet's tree. Used during full-replace imports.
+Removes every record from the sheet's tree. Used during full-replace imports (snapshot importers, full re-syncs).
+
+**O(1)** regardless of record count — internally points the sheet's subtree at git's canonical empty-tree hash (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`) via hologit's `TreeObject.clearChildren()`. Invalidates the sheet's in-memory indexes. The resulting empty subtree is omitted from the committed tree (hologit's `write()` skips empty subtrees), so consumers querying the committed sheet root after a clear see no entries.
+
+Pairs naturally with `Transaction#finalize`'s no-op detection (see [transaction.md](transaction.md)) — a `clear()` + re-upsert of byte-identical data produces no commit.
 
 ### `sheet.clone()`
 

--- a/specs/api/transaction.md
+++ b/specs/api/transaction.md
@@ -82,6 +82,32 @@ In **strict mode** (`repo.requireExplicitTransactions()`), mutations outside `re
 
 If the parent ref moves between transaction open and commit (a separate process committed), the transaction throws `TransactionError` (`parent_moved`). The handler's tree changes are discarded.
 
+## No-op detection
+
+`finalize` skips the commit entirely when the resulting tree-hash matches the parent commit's tree-hash:
+
+```text
+new_tree_hash := await workspace.root.write()
+if parentCommitHash !== null and (parentCommitHash^{tree}) === new_tree_hash:
+    return { value, commitHash: null, treeHash: null, ref: null, parentCommitHash }
+```
+
+Two conditions must both hold to detect the no-op:
+
+1. **A parent commit exists.** On a fresh repo (`parentCommitHash === null`), an initial commit IS produced even if the tree is empty — there's no parent tree to compare against. This is intentional: an initial commit is a meaningful event the consumer asked for.
+2. **The resulting tree hash equals the parent's tree hash.** This is the canonical git-native "did anything actually change?" check, computed in O(tree-depth) by `git rev-parse <commit>^{tree}`.
+
+When both conditions hold, the return shape matches the existing `!anyMutation` short-circuit (`commitHash: null`, `treeHash: null`, `ref: null`). Consumers detect a no-op via `result.commitHash === null`.
+
+**This means the following all produce no commit:**
+
+- `upsert(record)` where the record's canonical bytes match the existing blob
+- `clear()` + re-`upsert` from a snapshot whose data is unchanged from the parent's
+- `delete(path)` + `upsert` of an identical record at the same path
+- An explicit `tx.markMutated()` call that isn't accompanied by an actual tree mutation
+
+The last bullet is a behavior change from v1.3.0, where `markMutated()` alone forced a commit. Real consumers of `markMutated` (internal callers like `upsert`/`delete`/`setAttachments`) always pair it with an actual mutation, so this isn't expected to break anyone. Consumers who genuinely want empty commits should use `git commit --allow-empty` outside the library.
+
 ## Permissive mode
 
 Standalone mutations (mutations called without an enclosing `repo.transact`) auto-open a transaction with a generated message:

--- a/specs/behaviors/transactions.md
+++ b/specs/behaviors/transactions.md
@@ -26,13 +26,17 @@ Multi-process / multi-host writers are explicitly out of scope. If another proce
 ## Commit-on-success-only
 
 ```text
-handler resolves successfully + tree has at least one staged change
-  → finalize: validate the staged tree, commit, update ref
+handler resolves successfully + resulting tree differs from parent's tree
+  → finalize: write tree, commit, update ref
   → resolve { value, commitHash, treeHash, ref, parentCommitHash }
 
-handler resolves successfully but no mutations occurred
-  → permissive mode: no commit, resolves with { value, commitHash: null, ... }
-  → explicit `repo.transact`: same — empty transactions don't commit
+handler resolves successfully but resulting tree matches parent's tree
+  → no commit produced (tree-hash equality check)
+  → resolve { value, commitHash: null, treeHash: null, ref: null, parentCommitHash }
+
+handler resolves successfully but no mutating methods were called
+  → no commit produced (anyMutation flag short-circuit)
+  → resolve { value, commitHash: null, treeHash: null, ref: null, parentCommitHash }
 
 handler throws
   → tree discarded, no commit, no ref movement
@@ -41,6 +45,8 @@ handler throws
 ```
 
 This differs from the [pre-v1.0 PR #38 prototype](https://github.com/JarvusInnovations/gitsheets/pull/38), which committed unconditionally when `save()` was called. The commit-on-success-only rule is a hard requirement for production use — a half-applied mutation in the log is worse than no log entry.
+
+**Two short-circuit paths, same return shape.** The library tracks an `anyMutation` flag as a cheap heuristic (set by `upsert`/`delete`/`clear`/etc.), but that flag is an over-approximation. The authoritative no-op signal is tree-hash equality with the parent: after `workspace.root.write()` produces the resulting tree hash, it's compared to `parentCommitHash^{tree}`. A match means semantically nothing changed, and the same `{ commitHash: null, ... }` return path fires. See [api/transaction.md#no-op-detection](../api/transaction.md#no-op-detection) for examples (re-upsert of byte-identical record; `clear()` + re-upsert of unchanged snapshot data; etc.). On a fresh repo (no parent), no tree-hash comparison is possible — an initial commit IS produced even when the tree is empty.
 
 ## Commit message format
 


### PR DESCRIPTION
## Summary

Two fixes for the snapshot-importer pattern reported against laddr's reimport flow ([#178](https://github.com/JarvusInnovations/gitsheets/issues/178), [#179](https://github.com/JarvusInnovations/gitsheets/issues/179)).

Closes #178, closes #179.

## Changes

### `Sheet#clear()` is now O(1) (#178)

Was: walked the sheet's subtree and called `deleteChild` for every entry — ~N tree mutations to produce a state that's semantically just "this subtree is empty." 31k records on the laddr import was paying for that.

Now: `await sheetTree.clearChildren()` (hologit 0.50.1+). Constant-time regardless of record count, points the subtree at git's empty-tree hash. Hologit's `write()` already skips empty subtrees, so the observable committed-tree behavior is identical.

Also fixes a quietly-missing `#invalidateIndexes()` call — pre-fix, an in-memory index could return stale entries from before a `clear()`.

### Transaction#finalize: no-op commit detection (#179)

Was: any mutating method call (`upsert`, `delete`, `clear`, even explicit `markMutated()`) flipped `#anyMutation` and produced a commit. The flag was an over-approximation.

Now: after `workspace.root.write()` produces the resulting tree-hash, compare to `parentCommitHash^{tree}`. If equal, short-circuit to the same `{commitHash: null, treeHash: null, ref: null, parentCommitHash}` shape the `!#anyMutation` path already returns.

**Consequences:**
- `upsert(record)` where canonical bytes match disk → no commit
- `clear()` + re-upsert from byte-identical snapshot → no commit
- `delete(path)` + re-`upsert` of identical record at same path → no commit
- Initial commits on fresh repos still produced (no parent to compare against)

**Subtle behavior change:** `tx.markMutated()` alone, without an actual tree mutation, no longer produces a commit. Documented in the migration guide.

## Hologit dependency

Bumps `hologit` from `^0.49.1` to `^0.50.1` to pick up `TreeObject.clearChildren()`. The matching d.ts declaration is in JarvusInnovations/hologit#457 → 0.50.2; until then this PR carries a 4-line local type augmentation in `src/sheet.ts`. **Before merge**, one more commit will bump to `^0.50.2` and remove the augmentation.

## Tests

| File | Specs |
|---|---|
| `src/sheet-clear.test.ts` | 6 |
| `src/transaction-no-op.test.ts` | 7 |

**287 library tests (+13) + 63 AXI tests = 350 green.**

## Spec + docs

- `specs/api/sheet.md` — `clear()` O(1) guarantee + empty-tree-hash invariant
- `specs/api/transaction.md` — new "No-op detection" section
- `specs/behaviors/transactions.md` — commit-on-success-only diagram updated
- `docs/migration-guide.md` — v1.3.0 → v1.3.1 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)