### PR TITLE
docs(skill): recommend gitsheets-axi for post-edit hook + JSON config example

### DIFF
--- a/skills/gitsheets/SKILL.md
+++ b/skills/gitsheets/SKILL.md
@@ -58,9 +58,11 @@ If the user is heading toward one of these, gently steer them back:
 
 ## Editing record files directly (post-edit hook)
 
-If you're going to edit gitsheets record files (`.toml` or `.md`) directly on disk rather than through the API, install a post-edit hook that runs `gitsheets check <sheet> $FILE --fix` after each edit. This re-canonicalizes the file (deep-sorted keys, normalized markdown body) and validates against the sheet's schema, catching mistakes immediately rather than at the next git commit. Hook examples in `references/cli.md` under the `check` command.
+If you're going to edit gitsheets record files (`.toml` or `.md`) directly on disk rather than through the API, install a post-edit hook that runs `gitsheets-axi check <sheet> $FILE --fix` after each edit. This re-canonicalizes the file (deep-sorted keys, normalized markdown body) and validates against the sheet's schema, catching mistakes immediately rather than at the next git commit. Hook examples in `references/axi.md`.
 
-For CI / pre-commit verification, drop the `--fix`: `gitsheets check <sheet> $FILE` exits non-zero if the file isn't already canonical, without touching it.
+`gitsheets-axi` is preferred for hook use because its output is TOON on stdout with stable error codes (`VALIDATION_FAILED`, `CONFIG_INVALID`, `NOT_CANONICAL`, etc.) — an agent reading the hook's stdout can switch on the outcome. The human `gitsheets check` works too and is documented in `references/cli.md`; pick it when `gitsheets-axi` isn't installed in the environment.
+
+For CI / pre-commit verification, drop the `--fix`: `gitsheets-axi check <sheet> $FILE` exits non-zero if the file isn't already canonical, without touching it.
 
 ## When you genuinely don't know
 

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -159,6 +159,29 @@ Outputs:
 - `CONFIG_INVALID` when the file fails to parse as the sheet's format
 - `NOT_FOUND` when the target file doesn't exist
 
+#### Claude Code post-edit hook
+
+Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (user-wide):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "command": "gitsheets-axi check ${SHEET} \"$FILE\" --fix"
+      }
+    ]
+  }
+}
+```
+
+Substitute `${SHEET}` with the sheet name. For multi-sheet repos, point the hook at a wrapper script that infers the sheet from `$FILE`'s path (e.g. `users/jane.toml` → `users`).
+
+#### Pre-commit verification
+
+Drop `--fix` for a non-destructive verification — exits non-zero (with structured `NOT_CANONICAL` / `VALIDATION_FAILED` on stdout) when the file isn't already canonical. Suitable for a git pre-commit hook or a CI step that runs over staged record files.
+
 ### `gitsheets-axi diff <sheet> [<src-ref>] [--patches]`
 
 TOON change summary between a source ref and the current tree. With no `<src-ref>`, compares against the empty tree — every current record shows as `added`, useful for one-shot snapshots.


### PR DESCRIPTION
## Summary

Two small skill fixes. Both follow naturally from #170 (gitsheets-axi) landing in v1.3.0 but were missed in the skill docs at the time.

### `SKILL.md` — post-edit hook recommendation

The "Editing record files directly (post-edit hook)" section was written before `gitsheets-axi` existed and recommended \`gitsheets check\` (the human CLI). For agents reading the skill, \`gitsheets-axi check\` is the right call:

- TOON output on stdout (agent can parse the result)
- Stable error codes — \`NOT_CANONICAL\` / \`VALIDATION_FAILED\` / \`CONFIG_INVALID\` / \`NOT_FOUND\` — agents can switch on the outcome
- Designed for hook use; \`gitsheets check\` puts errors on stderr which agents typically don't read

The section now leads with \`gitsheets-axi check\` and keeps \`gitsheets check\` as the fallback when AXI isn't installed.

### \`references/axi.md\` — concrete hook config example

\`axi.md\` mentioned the post-edit-hook use case but didn't have a Claude Code \`PostToolUse\` config JSON example like \`cli.md\` does. Added one matching the convention an agent will recognize, plus a note on dropping \`--fix\` for pre-commit verification.

## Test plan

- [x] Skill-only diff, no code changes
- [x] No spec changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)