### PR TITLE
feat(gitsheets-axi): add `setup hooks` command for session-hook install

### DIFF
--- a/docs/axi.md
+++ b/docs/axi.md
@@ -1,6 +1,6 @@
 # gitsheets-axi
 
-`gitsheets-axi` is the agent-facing companion to `gitsheets`. Same library underneath, different ergonomics: TOON output by default, errors on stdout, idempotent mutations, format-aware schemas, self-installing session hooks.
+`gitsheets-axi` is the agent-facing companion to `gitsheets`. Same library underneath, different ergonomics: TOON output by default, errors on stdout, idempotent mutations, format-aware schemas, and opt-in session hooks installed via `gitsheets-axi setup hooks`.
 
 ```bash
 npm install -g gitsheets-axi
@@ -36,7 +36,7 @@ Every difference is in service of agents talking to the CLI through shell execut
 | Default output | JSON / pretty per `--format` | **TOON** (~40% fewer tokens), `--format=json` opt-out |
 | Default schema | every field a human might want | **minimal**, `--fields` opts in to more |
 | `--help` | full manual per command | concise reference + 2-3 examples |
-| Session-hook install | doesn't touch agent config | **self-installs** SessionStart hooks |
+| Session-hook install | doesn't touch agent config | **opt-in** SessionStart hooks via `setup hooks` |
 
 ## Output: TOON
 
@@ -77,14 +77,19 @@ Under the hood, mutations use the library's [`Sheet.willChange()`](api.md) (adde
 
 ## Session hooks
 
-On first invocation, `gitsheets-axi` self-installs `SessionStart` hooks into:
+Hooks are **opt-in** (AXI principle 7 — explicit consent, never implicit). Nothing is installed until you run the explicit installer:
+
+```bash
+gitsheets-axi setup hooks
+```
+
+This installs `SessionStart` hooks into:
 
 - **Claude Code** — `~/.claude/settings.json`
 - **Codex** — `~/.codex/hooks.json` + `[features].hooks = true` in `config.toml`
+- **OpenCode**
 
-The hook runs the bare home view at every session start, so the agent's initial context already includes a compact view of the current repo's sheets. The install is **self-healing** — every invocation re-checks the hook's binary path and updates it if the executable moved (reinstall, asdf version change, etc.).
-
-Set `GITSHEETS_AXI_DISABLE_HOOKS=1` to suppress installation.
+The hook runs the bare home view at every session start, so the agent's initial context already includes a compact view of the current repo's sheets. `setup hooks` is **idempotent and self-repairing** — re-running re-checks each hook's binary path and updates it if the executable moved (reinstall, asdf version change, etc.). Restart your agent session afterward to pick up the ambient context.
 
 ## Commands
 
@@ -104,6 +109,7 @@ gitsheets-axi infer <sheet>              # observe records → schema
 gitsheets-axi migrate-config <sheet>     # pre-v1.0 [fields] → [schema]
 gitsheets-axi attachment <list|get|set|delete> <sheet> <path> [<name>]
 gitsheets-axi push                       # one-shot git push
+gitsheets-axi setup hooks                # install opt-in SessionStart hooks
 ```
 
 Every command supports `--help` with its specific flags and 2-3 examples.

--- a/packages/gitsheets-axi/README.md
+++ b/packages/gitsheets-axi/README.md
@@ -7,7 +7,7 @@ Same underlying library as the human `gitsheets` CLI, different ergonomics:
 - **TOON output** by default — ~40% fewer tokens than equivalent JSON
 - **Idempotent mutations** — re-running with unchanged state returns `result: "no-op"`, no commit
 - **Errors on stdout** with stable codes and actionable hints
-- **Self-installing session hooks** for Claude Code and Codex
+- **Opt-in session hooks** for Claude Code, Codex, and OpenCode (`gitsheets-axi setup hooks`)
 
 ```bash
 npm install -g gitsheets-axi
@@ -44,6 +44,7 @@ gitsheets-axi infer <sheet>
 gitsheets-axi migrate-config <sheet>
 gitsheets-axi attachment <list|get|set|delete> <sheet> <path> [<name>]
 gitsheets-axi push [--remote r] [--branch b]
+gitsheets-axi setup hooks
 ```
 
 Run any command with `--help` for its flags + examples. Every command runs `--help` against itself, not the top-level manual.
@@ -67,14 +68,19 @@ path: jane
 
 ## Session hooks
 
-On first invocation, `gitsheets-axi` installs `SessionStart` hooks into:
+Hooks are **opt-in** — nothing is installed implicitly. Run the explicit installer once:
+
+```bash
+gitsheets-axi setup hooks
+```
+
+This installs `SessionStart` hooks into:
 
 - **Claude Code** — `~/.claude/settings.json`
 - **Codex** — `~/.codex/hooks.json` + `[features].hooks = true` in `config.toml`
+- **OpenCode**
 
-The hook runs the bare home view at every session start, so the agent sees the current repo's sheets in its initial context. The install **self-heals** — every invocation re-checks the hook's binary path and updates it if the executable moved.
-
-Set `GITSHEETS_AXI_DISABLE_HOOKS=1` to suppress installation.
+The hook runs the bare home view at every session start, so the agent sees the current repo's sheets in its initial context. `setup hooks` is **idempotent and self-repairing** — re-running re-checks each hook's binary path and updates it if the executable moved (reinstall, asdf version change, etc.). Restart your agent session after installing to pick up the ambient context.
 
 ## Output: TOON
 

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -19,6 +19,7 @@ import { inferCommand, INFER_HELP } from './commands/infer.js';
 import { migrateConfigCommand, MIGRATE_CONFIG_HELP } from './commands/migrate-config.js';
 import { attachmentCommand, ATTACHMENT_HELP } from './commands/attachment.js';
 import { pushCommand, PUSH_HELP } from './commands/push.js';
+import { setupCommand, SETUP_HELP } from './commands/setup.js';
 
 const DESCRIPTION =
   'gitsheets — agent-facing interface for the git-backed document store. ' +
@@ -27,12 +28,12 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[15]:
+commands[16]:
   (none)=home, sheets, query, read,
   upsert, patch, delete,
   check, diff, normalize,
   init, infer, migrate-config,
-  attachment, push
+  attachment, push, setup
 flags[2]:
   --help, -v/-V/--version
 examples:
@@ -47,6 +48,7 @@ examples:
   gitsheets-axi infer users
   gitsheets-axi attachment list users jane
   gitsheets-axi push
+  gitsheets-axi setup hooks
 `;
 
 const COMMAND_HELP: Record<string, string> = {
@@ -64,6 +66,7 @@ const COMMAND_HELP: Record<string, string> = {
   'migrate-config': MIGRATE_CONFIG_HELP,
   attachment: ATTACHMENT_HELP,
   push: PUSH_HELP,
+  setup: SETUP_HELP,
 };
 
 type CommandFn = (args: string[], ctx: GitsheetsContext) => Promise<string | Record<string, unknown>>;
@@ -83,6 +86,7 @@ const COMMANDS: Record<string, CommandFn> = {
   'migrate-config': migrateConfigCommand,
   attachment: attachmentCommand,
   push: pushCommand,
+  setup: setupCommand,
 };
 
 export async function main(): Promise<void> {
@@ -90,7 +94,6 @@ export async function main(): Promise<void> {
     description: DESCRIPTION,
     version: VERSION,
     topLevelHelp: TOP_HELP,
-    ...(process.env.GITSHEETS_AXI_DISABLE_HOOKS === '1' ? { hooks: false as const } : {}),
     resolveContext: () => createContext(),
     home: (_args, ctx) => homeCommand(ctx as GitsheetsContext),
     commands: COMMANDS as Record<

--- a/packages/gitsheets-axi/src/commands/setup.ts
+++ b/packages/gitsheets-axi/src/commands/setup.ts
@@ -1,0 +1,44 @@
+import { AxiError, installSessionStartHooks } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
+
+export const SETUP_HELP = `usage: gitsheets-axi setup hooks
+Install or repair agent SessionStart hooks so each session starts with gitsheets-axi's
+home view (the current repo's sheets) as ambient context. Idempotent; repairs a stale
+executable path.
+examples:
+  gitsheets-axi setup hooks`;
+
+export async function setupCommand(
+  args: string[],
+  _ctx?: GitsheetsContext,
+): Promise<string> {
+  if (args.includes('--help')) return SETUP_HELP;
+  if (args[0] !== 'hooks') {
+    throw new AxiError(`Unknown setup action: ${args[0] ?? '(none)'}`, 'VALIDATION_ERROR', [
+      'Run `gitsheets-axi setup hooks`',
+    ]);
+  }
+
+  const errors: string[] = [];
+  installSessionStartHooks({
+    marker: 'gitsheets-axi',
+    timeoutSeconds: 10,
+    onError: (m) => errors.push(m),
+  });
+  if (errors.length > 0) {
+    throw new AxiError('Hook installation reported problems', 'HOOK_INSTALL_FAILED', errors);
+  }
+
+  return joinBlocks(
+    renderObject({
+      hooks: {
+        status: 'installed',
+        integrations: 'Claude Code, Codex, OpenCode',
+        marker: 'gitsheets-axi',
+      },
+    }),
+    renderHelp(['Restart your agent session to receive gitsheets-axi ambient context']),
+  );
+}

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -25,6 +25,7 @@ import {
 } from '../src/commands/migrate-config.js';
 import { attachmentCommand, ATTACHMENT_HELP } from '../src/commands/attachment.js';
 import { pushCommand, PUSH_HELP } from '../src/commands/push.js';
+import { setupCommand, SETUP_HELP } from '../src/commands/setup.js';
 
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
@@ -41,6 +42,7 @@ const COMMAND_HELP: Record<string, string> = {
   'migrate-config': MIGRATE_CONFIG_HELP,
   attachment: ATTACHMENT_HELP,
   push: PUSH_HELP,
+  setup: SETUP_HELP,
 };
 
 const COMMANDS = {
@@ -58,6 +60,7 @@ const COMMANDS = {
   'migrate-config': migrateConfigCommand,
   attachment: attachmentCommand,
   push: pushCommand,
+  setup: setupCommand,
 } as Record<
   string,
   (args: string[], ctx: GitsheetsContext | undefined) => Promise<string | Record<string, unknown>>

--- a/packages/gitsheets-axi/test/setup.test.ts
+++ b/packages/gitsheets-axi/test/setup.test.ts
@@ -1,0 +1,29 @@
+// `setup hooks` command surface. The actual hook install writes to the real
+// ~/.claude (os.homedir ignores $HOME), so we only cover the dispatcher-level
+// argument handling here — `--help`, the unknown-action guard, and that the
+// command is registered in the surface. The install path is exercised by the
+// SDK's own tests.
+
+import { describe, expect, it } from 'vitest';
+
+import { SETUP_HELP, setupCommand } from '../src/commands/setup.js';
+
+describe('setup', () => {
+  it('returns help for --help', async () => {
+    const out = await setupCommand(['--help']);
+    expect(out).toBe(SETUP_HELP);
+    expect(out).toContain('gitsheets-axi setup hooks');
+  });
+
+  it('rejects an unknown action with VALIDATION_ERROR', async () => {
+    await expect(setupCommand(['frobnicate'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+  });
+
+  it('rejects a missing action with VALIDATION_ERROR', async () => {
+    await expect(setupCommand([])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+  });
+});

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -1,6 +1,6 @@
 # gitsheets-axi reference
 
-`gitsheets-axi` is the **agent-facing** companion to `gitsheets`. Same underlying library, different ergonomics: TOON output by default, errors on stdout, idempotent mutations, format-aware schemas, self-installing session hooks.
+`gitsheets-axi` is the **agent-facing** companion to `gitsheets`. Same underlying library, different ergonomics: TOON output by default, errors on stdout, idempotent mutations, format-aware schemas, and opt-in session hooks installed via `gitsheets-axi setup hooks`.
 
 **Use `gitsheets-axi` when an agent is reading or mutating gitsheets data via shell execution.** Use the `gitsheets` library (TypeScript imports) when authoring code that runs inside an application.
 
@@ -9,7 +9,7 @@ npm install -g gitsheets-axi    # one-time global install
 gitsheets-axi                   # session-aware home view
 ```
 
-`gitsheets-axi` shares the gitsheets minor version (1.3.x ↔ 1.3.x). Major and minor stay in lockstep; patch versions are independent. The binary self-installs `SessionStart` hooks for Claude Code and Codex on first invocation — once installed, every new agent session sees a TOON home view of the current repo's sheets.
+`gitsheets-axi` shares the gitsheets minor version (1.3.x ↔ 1.3.x). Major and minor stay in lockstep; patch versions are independent. Run `gitsheets-axi setup hooks` once to install opt-in `SessionStart` hooks for Claude Code, Codex, and OpenCode — once installed, every new agent session sees a TOON home view of the current repo's sheets.
 
 ## Output: TOON
 
@@ -228,6 +228,10 @@ Errors map to:
 
 This is **not** a daemon lifecycle command — for retry-with-backoff semantics in a long-running consumer, use `Repository.startPushDaemon` from the library.
 
+### `gitsheets-axi setup hooks`
+
+Explicit, opt-in installer for the agent `SessionStart` hooks (see [Hook installation](#hook-installation)). Installs into Claude Code, Codex, and OpenCode. Idempotent and self-repairing — re-running repairs a stale executable path. `--help` prints usage; any action other than `hooks` exits non-zero with a `VALIDATION_ERROR`. Restart the agent session afterward to pick up the ambient context.
+
 ## When to use `gitsheets-axi` vs `gitsheets`
 
 | Scenario | Use |
@@ -243,14 +247,19 @@ When in doubt: `gitsheets-axi` for agent shell invocations; `gitsheets` for ever
 
 ## Hook installation
 
-`gitsheets-axi` self-installs SessionStart hooks on first invocation:
+Hooks are **opt-in** (AXI principle 7 — explicit consent, never implicit). Nothing is installed until you run the explicit installer:
+
+```bash
+gitsheets-axi setup hooks
+```
+
+This installs SessionStart hooks into:
 
 - **Claude Code** — `~/.claude/settings.json` SessionStart entry
 - **Codex** — `~/.codex/hooks.json` SessionStart entry + `[features].hooks = true` in `config.toml`
+- **OpenCode**
 
-The hook runs `gitsheets-axi` (the bare home view), so every new session opens with a compact view of the current repo's sheets already in context. The install is **self-healing**: every invocation re-checks the hook's binary path and updates it if the executable moved (reinstall, asdf version change).
-
-Disable hooks for the current invocation with `GITSHEETS_AXI_DISABLE_HOOKS=1`.
+The hook runs `gitsheets-axi` (the bare home view), so every new session opens with a compact view of the current repo's sheets already in context. `setup hooks` is **idempotent and self-repairing**: re-running re-checks each hook's binary path and updates it if the executable moved (reinstall, asdf version change). Restart the agent session afterward to pick up the ambient context.
 
 ## See also
 


### PR DESCRIPTION
## What

Adds the explicit `setup hooks` command so `gitsheets-axi` installs its agent SessionStart hook the same way as the AXI standard (principle 7), the `axi-sdk-js` convention, and the first-party reference tools (`gh-axi`, `chrome-devtools-axi`).

Previously gitsheets-axi had no setup command — the README claimed an auto-install/self-heal on first invocation that the current `axi-sdk-js` no longer performs, leaving a dead `hooks: false` runAxiCli spread and a `GITSHEETS_AXI_DISABLE_HOOKS` toggle behind.

## Changes

- **New `setup hooks` command** — installs/repairs via `installSessionStartHooks({ marker: "gitsheets-axi" })` (Claude Code, Codex, OpenCode); idempotent and self-repairing.
- Registered in `src/cli.ts` (`COMMANDS`, `COMMAND_HELP`, `TOP_HELP`, example) and the test command surface.
- **Removed** the stale `hooks: false` spread and all `GITSHEETS_AXI_DISABLE_HOOKS` references.
- Rewrote the "Session hooks" docs in the package README, `docs/axi.md`, and `skills/gitsheets/references/axi.md`.

## Verification

`npm run build` and `npm run type-check` clean; **gitsheets 287/287 + gitsheets-axi 66/66 tests pass** (+3 new `setup.test.ts`). `setup --help` shows help; `setup <bad>` emits a structured `VALIDATION_ERROR`; `--help` lists `setup`. No `GITSHEETS_AXI_DISABLE_HOOKS` references remain.

> Note: the built bin exits `0` even on error paths (a pre-existing quirk — `main()` runs as a floating promise without honoring `process.exitCode`), independent of this change. The in-process test harness asserts the correct non-zero `process.exitCode`. Flagging for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)