### PR TITLE
docs(specs): promote holo-tree migration + land spike planning record

### DIFF
--- a/notes/holo-tree-findings.md
+++ b/notes/holo-tree-findings.md
@@ -1,0 +1,155 @@
+# holo-tree findings — gitsheets spike (#127)
+
+Running log of ergonomic + correctness findings from being the first integrated
+consumer of the Rust holo-tree libs. Per the spike's governing principle, rough
+edges get fixed **upstream in holo-tree**, not papered over in gitsheets glue.
+This is the input to the Phase-C hologit PR.
+
+Branch: gitsheets `spike/holo-tree-napi` consumes hologit `feat/holo-tree-napi`.
+
+Legend: **Fixed** = patched on the hologit branch · **Open** = needs upstream work.
+
+---
+
+## 1. `get_or_create_subtree` drops writes into existing dirs, then panics — **Fixed**
+
+**Severity: critical.** Hit by *every* upsert into an already-populated sheet
+directory (the common case after the first record lands).
+
+Two bugs in one path:
+
+- It marked the navigated path dirty only when a *new* node was created. Writing
+  into an existing dir dirtied just the leaf; its clean ancestors short-circuited
+  in `write()` (`if !self.dirty { return self.hash }`), so `write()` returned the
+  parent's unchanged tree hash and **silently dropped the write**.
+- It returned a lazily-loaded existing destination node with `children: None`;
+  the mutating caller (`write_child_bytes`) did `children.as_mut().unwrap()` and
+  **panicked**, which aborted the whole Node process across FFI (see #6).
+
+Fix (hologit `fdc4657f`): mark the whole path dirty unconditionally (this
+navigator is only called to mutate) and `ensure_children` on the returned node
+(also preserves existing siblings). Added `tests/write_child.rs`.
+
+**Why integration caught it:** holo-tree's own merge tests only build trees from
+scratch (every dir created fresh → `children: Some`), so neither bug showed. The
+first write into a *pre-existing* directory is what exposed both.
+
+## 2. `update_ref` rejects bare branch names — **Fixed**
+
+**Severity: medium** (drop-in substrate compatibility).
+
+`git update-ref main …` works; gix's `reference()` rejects a standalone
+lowercase name ("Standalone references must be all uppercased"). gitsheets'
+`transact({ branch: 'main' })` passes the short name straight through.
+
+Fix (hologit `96d710b7`): `update_ref` qualifies a bare name to
+`refs/heads/<name>`; qualified names and all-caps pseudo-refs pass through.
+
+## 3. `commit_tree` can't take explicit author/committer/time — **Fixed**
+
+**Severity: high** (correctness + blocks commit-hash parity).
+
+`holo_tree::repo::commit_tree` used to derive identity from git config and stamp
+`SystemTime::now()`. gitsheets resolves an explicit author/committer per
+transaction (constructor opts, or a documented anonymous fallback) and the JS
+path sets `GIT_AUTHOR_*`/`GIT_COMMITTER_*` per commit. Via holo-tree the commit
+silently got git-config identity instead, and the uncontrollable timestamp meant
+commit-hash parity with the JS path was unachievable.
+
+Fix (hologit branch): `commit_tree` now takes
+`author: Option<Signature>, committer: Option<Signature>` (explicit → config →
+default), and the binding's `commitTree` takes optional `{ name, email,
+timeSeconds?, offsetMinutes? }`. gitsheets `#holoCommit` passes the transaction's
+resolved identity, so holo commits are attributed correctly (verified: a commit
+made via the holo path carries the explicit `opts.author`, not git config).
+With identity + time pinned, the binding's commit now **hash-matches `git
+commit-tree` bit-for-bit** (binding smoke test). Time is left unset in the
+gitsheets path → the binding stamps now(), matching `git commit-tree`'s default.
+
+## 4. `holo_tree::Error` flattens to a string across FFI — **Open**
+
+**Severity: medium.** The binding maps every `holo_tree::Error` to
+`napi::Error::from_reason(e.to_string())`, collapsing the variant. gitsheets
+maps substrate failures onto typed error classes (`RefError`, `TransactionError`,
+…); a stringified `Display` makes that lossy/brittle.
+
+Recommendation: give `holo_tree::Error` stable, matchable discriminants (an enum
+kind or string code) that survive FFI, so consumers can branch on cause without
+parsing prose.
+
+## 5. `&gix::Repository` threaded through every call + thread-local cache — **Open (design)**
+
+**Severity: medium** (ergonomics + a correctness risk across threads).
+
+Nearly every `MutableTree`/`repo` fn takes `&gix::Repository`, and the tree cache
+is a `thread_local!`. The binding smooths the first half (a `Tree` holds a
+`ThreadSafeRepository` and derives `to_thread_local()` per call) — but that is
+exactly the kind of thing the principle says to fix upstream, not hide. And the
+second half is untouched: if napi/libuv ever dispatches calls for one logical
+operation on different threads, the thread-local cache silently misses (or worse).
+
+Recommendation: a repo-bound tree handle (tree owns/borrows its repo so calls
+don't thread it), and/or an explicit cache/session object the consumer owns and
+passes — instead of process/thread-implicit global state.
+
+## 6. A panic aborts the host process across FFI — **Open**
+
+**Severity: high** (robustness for any embedded consumer).
+
+When finding #1 panicked, the process died with `fatal runtime error: failed to
+initiate panic, error 5, aborting` — not a catchable JS exception. holo-tree uses
+`.unwrap()` on internal invariants in hot paths; any violated invariant takes
+down the host. Fixing #1 removed *this* panic, but the class remains.
+
+Recommendation: return `Result` from internal invariants rather than `unwrap()`
+on the public path; and/or have the binding install a panic hook / rely on
+napi's `catch_unwind` so a panic surfaces as a JS error instead of an abort.
+(Worth confirming why the napi boundary didn't already catch it — possibly the
+`napi` feature set in the binding's `Cargo.toml`.)
+
+## 7. `update_ref` has no compare-and-swap — **Open (minor)**
+
+`git update-ref <ref> <new> <old>` supports an expected-old-value for optimistic
+concurrency; holo-tree uses `PreviousValue::Any` (force). gitsheets does its own
+parent-moved re-check before finalize, so this isn't blocking, but exposing an
+expected-old-value would let the substrate enforce it natively.
+
+---
+
+## Benchmark — substrate-level, real data
+
+`packages/gitsheets/bench/holo-tree-bench.mjs` against the codeforphilly-data
+`published` tree (the `people` sheet: **18,203 records in one flat directory**).
+Both sides do identical work — load the people tree, insert record(s), rebuild,
+commit, advance a ref — differing only in substrate. **release** binding build.
+
+| Workload | JS (hologit + git subprocess) | holo (gix, in-process) | speedup |
+| --- | --- | --- | --- |
+| single upsert → commit | ~100 ms median | ~25 ms median | **~4×** |
+| bulk: 500 upserts → 1 commit | ~186 ms median | ~41 ms median | **~4.6×** |
+
+Tree-hash parity confirmed on the real 18k tree (not just unit fixtures).
+
+Notes:
+
+- **Build mode matters enormously.** A *debug* binding measured ~2.4× *slower*
+  than JS; the same code in *release* is ~4–5× *faster*. Any consumer benchmark
+  must use `napi build --release`.
+- This is **conservative**: the binding still calls `to_thread_local()` on every
+  method (finding #5) and gix's object cache is default-disabled — both leave
+  speedup on the table.
+- Not the "~100x" from #127 — that figure is for micro tree-ops / the projection
+  hot loop, not a single big-tree commit. ~4–5× is the honest number for
+  gitsheets' commit-a-change-to-a-large-sheet workload, and it grows with sheet
+  size (the JS in-memory rebuild of an 18k-entry tree dominates its time).
+
+## What worked well
+
+- **Tree-build parity is byte-identical.** For single and bulk upserts, holo-tree
+  produces the exact tree hash git/hologit produce — the core substrate-
+  equivalence claim holds. (Validated in `src/holo-tree-parity.test.ts`.)
+- **Binding boundary conventions are clean:** object ids as hex strings and blob
+  content as `Buffer` mapped onto gitsheets' existing conventions with zero
+  friction.
+- **`napi build` DX is good:** generated `index.d.ts` carries the Rust doc
+  comments through to TypeScript verbatim.

--- a/packages/gitsheets/bench/holo-tree-bench.mjs
+++ b/packages/gitsheets/bench/holo-tree-bench.mjs
@@ -1,0 +1,135 @@
+// Substrate-level microbenchmark for the holo-tree spike (#127).
+//
+// Measures the cost that actually differs between the two substrates: load a
+// large existing tree, insert record(s), rebuild it, commit, advance a ref.
+// Both sides do identical logical work on the SAME real tree (the codeforphilly
+// `people` sheet — ~18k records in one flat directory).
+//
+//   JS path:   hologit TreeObject.writeChild → root.write() → git commit-tree
+//              + git update-ref   (in-memory tree, but git subprocess commit)
+//   holo path: binding writeChild → write → commitTree → updateRef  (all gix,
+//              in-process — no subprocess)
+//
+// Usage:  BENCH_REPO=/path/to/bench-repo node packages/gitsheets/bench/holo-tree-bench.mjs
+//         (optional) K=20 N=500 to set iteration / bulk counts.
+
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { Repo: HologitRepo } = require('hologit');
+const holo = require('holo-tree-napi');
+
+const REPO = process.env.BENCH_REPO;
+if (!REPO) {
+  console.error('set BENCH_REPO to the bench repo working dir');
+  process.exit(1);
+}
+const GIT_DIR = join(REPO, '.git');
+const K = Number(process.env.K ?? 20);
+const N = Number(process.env.N ?? 500);
+const SHEET_ROOT = 'people';
+
+const git = (...args) => execFileSync('git', args, { cwd: GIT_DIR, encoding: 'utf8' }).trim();
+const PARENT = git('rev-parse', 'HEAD');
+const PARENT_TREE = git('rev-parse', 'HEAD^{tree}');
+
+function recordToml(slug) {
+  return `slug = "${slug}"\nname = "Bench ${slug}"\nbenchmark = true\n`;
+}
+
+function stats(samples) {
+  const s = [...samples].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const sum = s.reduce((a, b) => a + b, 0n);
+  return {
+    min: s[0],
+    median: s[Math.floor(s.length / 2)],
+    max: s[s.length - 1],
+    mean: sum / BigInt(s.length),
+  };
+}
+const ms = (ns) => Number(ns) / 1e6;
+const fmt = (st) =>
+  `min=${ms(st.min).toFixed(1)}  median=${ms(st.median).toFixed(1)}  mean=${ms(st.mean).toFixed(1)}  max=${ms(st.max).toFixed(1)} ms`;
+
+// --- one JS-path commit: insert `count` records into people/, commit, move ref ---
+async function jsCommit(slugs) {
+  const repo = new HologitRepo({ gitDir: GIT_DIR });
+  const ws = await repo.createWorkspaceFromRef(PARENT);
+  for (const slug of slugs) {
+    await ws.root.writeChild(`${SHEET_ROOT}/${slug}.toml`, recordToml(slug));
+  }
+  const treeHash = await ws.root.write();
+  const commit = execFileSync(
+    'git',
+    ['commit-tree', treeHash, '-p', PARENT, '-m', 'bench'],
+    { cwd: GIT_DIR, encoding: 'utf8' },
+  ).trim();
+  git('update-ref', 'refs/heads/js-bench', commit);
+  return treeHash;
+}
+
+// --- one holo-path commit: same, all in-process via the binding ---
+function holoCommit(slugs) {
+  const repo = holo.Repo.open(GIT_DIR);
+  const tree = repo.createTreeFromRef(PARENT);
+  for (const slug of slugs) {
+    tree.writeChild(`${SHEET_ROOT}/${slug}.toml`, recordToml(slug));
+  }
+  const treeHash = tree.write();
+  const commit = repo.commitTree(treeHash, [PARENT], 'bench');
+  repo.updateRef('refs/heads/holo-bench', commit);
+  return treeHash;
+}
+
+async function main() {
+  console.log(`bench repo: ${REPO}`);
+  console.log(`parent: ${PARENT}  people records: ${git('ls-tree', '--name-only', `${PARENT}:${SHEET_ROOT}`).split('\n').length}`);
+  console.log(`single-upsert iterations K=${K}, bulk N=${N}\n`);
+
+  // Warm up both engines (load packs / caches) and sanity-check tree parity.
+  const jsWarm = await jsCommit(['warm-0']);
+  const holoWarm = holoCommit(['warm-0']);
+  console.log(`parity check (1 record): js=${jsWarm} holo=${holoWarm} ${jsWarm === holoWarm ? 'OK' : 'MISMATCH'}\n`);
+
+  // --- single upsert into the 18k tree ---
+  const jsSingle = [];
+  for (let i = 0; i < K; i++) {
+    const t = process.hrtime.bigint();
+    await jsCommit([`js-single-${i}`]);
+    jsSingle.push(process.hrtime.bigint() - t);
+  }
+  const holoSingle = [];
+  for (let i = 0; i < K; i++) {
+    const t = process.hrtime.bigint();
+    holoCommit([`holo-single-${i}`]);
+    holoSingle.push(process.hrtime.bigint() - t);
+  }
+  console.log('single upsert → commit (into ~18k-record dir):');
+  console.log(`  JS   : ${fmt(stats(jsSingle))}`);
+  console.log(`  holo : ${fmt(stats(holoSingle))}`);
+  console.log(`  speedup (median): ${(ms(stats(jsSingle).median) / ms(stats(holoSingle).median)).toFixed(1)}x\n`);
+
+  // --- bulk: N records in one commit ---
+  const bulkSlugs = (tag) => Array.from({ length: N }, (_, i) => `${tag}-${i}`);
+  const jsBulk = [];
+  const holoBulk = [];
+  for (let r = 0; r < 5; r++) {
+    let t = process.hrtime.bigint();
+    await jsCommit(bulkSlugs(`jsbulk-${r}`));
+    jsBulk.push(process.hrtime.bigint() - t);
+    t = process.hrtime.bigint();
+    holoCommit(bulkSlugs(`holobulk-${r}`));
+    holoBulk.push(process.hrtime.bigint() - t);
+  }
+  console.log(`bulk: ${N} upserts in one commit:`);
+  console.log(`  JS   : ${fmt(stats(jsBulk))}`);
+  console.log(`  holo : ${fmt(stats(holoBulk))}`);
+  console.log(`  speedup (median): ${(ms(stats(jsBulk).median) / ms(stats(holoBulk).median)).toFixed(1)}x`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/plans/holo-tree-migration.md
+++ b/plans/holo-tree-migration.md
@@ -1,0 +1,166 @@
+---
+status: planned
+depends: [holo-tree-napi-spike]
+specs:
+  - specs/architecture.md
+upstream-specs:
+  - hologit:holo-tree/README.md
+awaits:
+  - "holo-tree-napi published (npm, or a pinned git dep) with per-platform prebuilds — a release can't carry a local file: dep to a sibling repo. (hologit#465 merged to develop 2026-06-27; binding now lives on hologit develop.)"
+issues: [127]
+---
+
+# Plan: holo-tree migration — swap the whole tree substrate off hologit JS
+
+## Scope
+
+The full migration the [`holo-tree-napi-spike`](holo-tree-napi-spike.md) validated
+(verdict: GO). Replace **every** gitsheets tree/commit operation that currently
+goes through the hologit JS dependency with the Rust `holo-tree-napi` binding,
+then **remove the `hologit` dependency entirely** — all behind the unchanged
+public API.
+
+**In scope:**
+
+- Extend the binding to the full surface gitsheets needs (the spike bound only
+  the upsert→commit slice).
+- Migrate every consumer site: `repository.ts`, `sheet.ts`, `transaction.ts`,
+  `path-template/`, `cli/`.
+- Resolve the three operations #127 flagged as "not covered by holo-tree":
+  `writeWorkingChanges`, `diffTree` (for `Sheet.diffFrom`), `git.var('GIT_EDITOR')`.
+- Drop `hologit` from `package.json`; the binding becomes the sole substrate.
+- Delete the spike's dual-path scaffolding (the `enableHoloTree` flag, the op-log,
+  the parity gate) — holo-tree becomes the only path.
+
+**Explicitly out of scope:**
+
+- holo-projector, the broader hologit projection engine.
+- Any public-API change. The migration's governing constraint remains **no
+  public-API impact** (see [`specs/architecture.md`](../specs/architecture.md)
+  "Holo-tree migration", #127).
+- Per-platform prebuild/release engineering for the binding beyond what gitsheets
+  needs to ship (coordinate with the hologit side).
+
+## Implements
+
+### Own specs
+
+- [`specs/architecture.md`](../specs/architecture.md) — flips the "Tree
+  primitives" row from **hologit (JS)** to **holo-tree (Rust via napi)** and
+  retires the "Holo-tree migration (deferred)" section. That spec edit is
+  **spec-first**: it lands in its own PR before this plan brings code into
+  conformance. The load-bearing constraint carried forward: no public-API impact.
+
+Every other spec (`api/*`, `behaviors/*`) must stay green *unchanged* — this is
+an internal substrate swap, so the existing suite + a clean spec-drift audit are
+the conformance proof, not new spec text.
+
+### Upstream specs (informational)
+
+- `hologit:holo-tree/README.md` — the holo-tree surface this consumes; new
+  operations needed here may require upstream additions (same harden-upstream
+  principle as the spike).
+
+## Approach
+
+### Governing principle (carried from the spike)
+
+Same as [`holo-tree-napi-spike`](holo-tree-napi-spike.md): rough edges in
+holo-tree get **fixed upstream**, not papered over in gitsheets glue. The full
+surface will surface more findings than the slice did — expect more upstream PRs.
+
+### Step 1 — extend the binding surface
+
+The spike bound `createTreeFromRef`/`createTree`, `writeChild`/`writeChildBytes`/
+`readBlob`/`deleteChildDeep`/`write`, `commitTree`/`updateRef`, `emptyTreeHash`.
+The full migration additionally needs (map to holo-tree, adding upstream where
+missing):
+
+- `getChild` / `getChildren` / `getSubtree` ← `get_child` / `ensure_children` /
+  `get_subtree` (returning child-type + hash info across FFI).
+- `getBlobMap` ← `get_blob_map` (recursive blob flatten — used by query-all,
+  export, attachment iteration). Watch read-heavy perf (hologit#464).
+- `clearChildren` ← O(1) empty-tree pointer (hologit `TreeObject.clearChildren`;
+  confirm/ add the holo-tree equivalent).
+- `merge` (overlay/replace/underlay + glob) ← `MutableTree::merge` + `MergeOptions`.
+- `readToml` ← `read_toml` (config reads; replaces the hologit `Configurable`
+  pattern + the `@iarna/toml` augmentation in `toml.ts`).
+- `writeBlobFromFile` (hash a file from disk → blob) ← needs a holo-tree helper
+  or a gix `write_blob` from a file stream; used by `cli/` for binary attachments.
+- `getHash` on an in-memory tree (for no-op detection without re-`write()`).
+
+### Step 2 — migrate consumers
+
+Site by site, replacing hologit `TreeObject`/`BlobObject`/`Workspace` handles with
+binding handles. Order roughly by dependency:
+
+- `repository.ts` — `createWorkspaceFromRef`/`getWorkspace`/`createWorkspaceFromTreeHash`/
+  `resolveRef`/`createBlob`/empty-workspace → binding `Repo` + `Tree`.
+- `transaction.ts` — make the holo path the **only** path; delete the op-log,
+  the `enableHoloTree` flag, and the parity gate; keep the resolved-identity
+  commit.
+- `sheet.ts` — `getChild`/`getSubtree`/`getBlobMap`/`writeChild`/`deleteChild`/
+  `clearChildren`/`getHash`/`clone`/blob `read`; and `diffFrom` (see Step 3).
+  Note the structural-compat assumptions (`srcBlob`/`dstBlob` as hologit
+  `BlobObject`) in the diff path need new handle shapes.
+- `path-template/index.ts` — `getChild`/`getChildren`/`getBlobMap` (mind the
+  `for...in` prototype-walk hologit needed; the binding returns plain data).
+- `cli/index.ts` — `writeBlobFromFile` for binary attachments.
+
+### Step 3 — the three "not covered" operations
+
+- `writeWorkingChanges()` (flush in-memory tree → working dir, today `git
+  read-tree -m -u`): add to the binding/holo-tree repo module, or shell out to
+  git. Decide during the plan; lean toward an upstream holo-tree helper.
+- `git.diffTree()` for `Sheet.diffFrom` record-level diffs: use gix's diff API
+  (new binding surface) or continue shelling out. Measure both.
+- `git.var('GIT_EDITOR')`: trivial — stays in JS (`git var`), no substrate
+  dependency.
+
+### Step 4 — drop hologit
+
+Remove `hologit` from `packages/gitsheets/package.json`; delete the
+`hologitRepo` accessor and the `@internal` substrate escape hatch; update
+`architecture.md` "What we deliberately don't use" / stack rows. Confirm no
+remaining `from 'hologit'` imports.
+
+## Validation
+
+- [ ] Binding exposes the full surface above; `napi build --release` + smoke
+      tests green.
+- [ ] No `from 'hologit'` imports remain in `packages/gitsheets/src`; `hologit`
+      removed from `package.json`; `npm run build` + `type-check` clean.
+- [ ] The **entire** existing gitsheets vitest suite passes on the holo-tree
+      substrate (the no-public-API-change conformance proof) — not just the
+      upsert path.
+- [ ] Public API surface unchanged: the published `.d.ts` diff is empty (no
+      consumer-visible type change).
+- [ ] `/audit-spec-drift` clean — implementation still matches every spec.
+- [ ] Benchmark across the full surface (query-all/`getBlobMap`, diff, merge,
+      working-tree flush), not just upsert; results recorded.
+- [ ] `architecture.md` substrate flip merged spec-first before code conformance.
+
+## Risks / unknowns
+
+- **The "not covered" trio.** `writeWorkingChanges` + `diffTree` are the least
+  certain — they may need real upstream holo-tree work or stay as git shell-outs
+  (a partial migration). Scope creep risk; decide early.
+- **Structural-compat handles.** Several gitsheets sites lean on hologit's
+  `TreeObject`/`BlobObject` *shapes* (e.g. `diffFrom`'s `srcBlob`/`dstBlob`).
+  The binding returns plain data, so these need redesigned handle types without
+  changing the public API.
+- **Read-heavy perf + the thread-local cache.** `getBlobMap`/query over large
+  sheets is the workload the spike didn't measure; depends on hologit#464 items
+  (per-read clone, object cache, per-call `to_thread_local`).
+- **Distribution.** A published binding with per-platform prebuilds is a release
+  prerequisite (`awaits:`), and a new native-addon install story for consumers.
+- **Bigger finding surface.** The full API will expose more holo-tree rough
+  edges than the slice; budget for upstream round-trips.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/holo-tree-napi-spike.md
+++ b/plans/holo-tree-napi-spike.md
@@ -1,0 +1,270 @@
+---
+status: done
+depends: []
+specs:
+  - specs/architecture.md
+upstream-specs:
+  - hologit:holo-tree/README.md
+issues: [127]
+---
+
+# Plan: holo-tree napi spike — validate the Rust tree substrate on one vertical slice
+
+## Scope
+
+A **validation spike**, not the migration. The goal is to prove that the new
+Rust `holo-tree` crate (plus a fresh napi-rs binding) is a suitable, ergonomic
+substrate for gitsheets' tree operations — and to **harden holo-tree upstream**
+while we're the first real integrated consumer.
+
+**In scope:**
+
+- **Phase A** — a new `holo-tree-napi` crate in the **hologit** repo (branch
+  `feat/holo-tree-napi`): a napi-rs binding exposing the narrow slice of
+  `MutableTree` + `repo` functions gitsheets needs. Publishable, general-purpose
+  (not gitsheets-private), so it validates the surface for *all* future JS
+  consumers of holo-tree.
+- **Phase B** — wire **one** end-to-end gitsheets path through the binding on the
+  gitsheets `spike/holo-tree-napi` branch: a single-record **upsert committed via
+  a transaction**, i.e. `transact → writeChild → root.write() → commit-tree →
+  update-ref`. Keep the existing hologit JS path in place for everything else;
+  the slice runs behind the unchanged public API.
+- **Phase C** — harvest the ergonomic findings discovered in A/B into a written
+  list, and open a **hologit PR** that improves holo-tree's API/ergonomics for
+  this integrated use case. This is a first-class deliverable, not a footnote.
+
+**Explicitly out of scope** (lands later, gated on this spike's verdict):
+
+- Migrating the other tree sites — `getSubtree`/`getBlobMap`/`getChild`/
+  `deleteChild`/`merge`/`clearChildren`, `path-template/`, `cli/`,
+  `Sheet.diffFrom` (`git.diffTree`), `writeWorkingChanges`. These become a
+  follow-up **full-migration plan** once the slice validates the substrate.
+- `singer-target.js` empty-tree usage, holo-projector, any public-API change
+  (the migration's governing constraint is **no public-API impact** — see
+  [`specs/architecture.md`](../specs/architecture.md) "Holo-tree migration",
+  issue #127).
+- Publishing `holo-tree-napi` to npm. The spike consumes it locally.
+
+## Implements
+
+This plan does not change any spec. It implements **toward** the deferred,
+internal-engine substrate swap already described in the specs, under the
+guardrail those specs set:
+
+### Own specs
+
+- [`specs/architecture.md`](../specs/architecture.md) — the "Tree primitives"
+  stack row and the "Holo-tree migration (deferred post-v1.2)" section. The
+  load-bearing constraint inherited here: **the swap must have no public-API
+  impact** — consumers see only faster tree ops. The spike's vertical slice must
+  sit entirely behind the existing `Repository`/`Sheet`/`Transaction` surface,
+  with the JS path untouched for everything it doesn't cover.
+
+### Upstream specs (informational — owned by hologit, not audited here)
+
+- `hologit:holo-tree/README.md` — the holo-tree crate's documented surface
+  (`MutableTree`, three merge modes, `repo::create_tree_from_ref` /
+  `commit_tree` / `update_ref`, `read_toml`, `GlobMatcher`). We consume it and,
+  per the spike's purpose, propose changes to it.
+
+## Approach
+
+### Governing principle: fix the substrate, don't paper over it
+
+The entire point of being the first integrated consumer is to **harden
+holo-tree for future consumers who won't also author it**. So: when Phase A or B
+hits a rough edge in holo-tree's API — an awkward signature, a missing
+convenience, a forced dance around the thread-local cache, a type that doesn't
+cross the napi boundary cleanly, an error that's hard to map — the response is to
+**record it and fix it upstream in holo-tree** (Phase C), *not* to absorb it in
+gitsheets glue or the binding's JS shim. The binding may smooth genuinely
+JS-specific concerns (async, Buffer marshalling), but anything that is really a
+holo-tree shortcoming goes back to holo-tree. Every workaround we'd be tempted
+to write in gitsheets is a Phase-C finding.
+
+### Phase A — `holo-tree-napi` binding (hologit repo)
+
+On `hologit/feat/holo-tree-napi`, add a `holo-tree-napi/` member to the existing
+Cargo workspace (alongside `holo-tree/`, `holo-projector/`):
+
+- napi-rs (`napi`, `napi-derive`, `napi-build`) crate scaffold; `napi build` →
+  `.node` addon + generated `index.d.ts`; `package.json` named e.g.
+  `holo-tree-napi` (or `@hologit/holo-tree`).
+- Expose the **minimal** surface the upsert slice needs, plus a repo handle:
+  - open/hold a repo handle (wrap `gix::open`) — decide how the `&gix::Repository`
+    that holo-tree threads through nearly every call is held across napi calls
+    (this is finding #1 territory — see Risks).
+  - `createTreeFromRef(ref) -> Tree` ← `repo::create_tree_from_ref`
+  - `tree.writeChild(path, content)` ← `MutableTree::write_child` /
+    `write_child_bytes` (Buffer in, hashes blob + deep-inserts)
+  - `tree.write() -> treeHash` ← `MutableTree::write`
+  - `commitTree(treeHash, parents, message, author/committer) -> hash` ←
+    `repo::commit_tree`
+  - `updateRef(ref, hash)` ← `repo::update_ref`
+  - `emptyTreeHash()` ← `tree::empty_tree_id` (cheap, likely needed soon)
+- Map `holo_tree::Error` → JS errors with enough structure that gitsheets can
+  translate to its typed error classes (don't lose the variant).
+- A couple of Rust/Node smoke tests proving an upsert+commit round-trips against
+  a scratch repo.
+
+### Phase B — one vertical slice (gitsheets repo)
+
+On `gitsheets/spike/holo-tree-napi`, add `holo-tree-napi` as a **local path or
+git dependency** (not npm) and route exactly the upsert-commit path through it,
+leaving the hologit JS path in place elsewhere. Concretely, the current chain is:
+
+- `Repository.transact` → `hologitRepo.createWorkspaceFromRef(parentCommitHash)`
+  → `transaction.ts` holds `workspace.root` (a hologit `TreeObject`).
+- `Sheet.#upsertInTx` (`sheet.ts:1353`) → `this.#dataTree.writeChild(fullPath,
+  content)` (subtree of `workspace.root`).
+- `Transaction.commit` (`transaction.ts:~245`) → `this.#workspace.root.write()`
+  → `treeHash`, then **shells out** to `git commit-tree` and `git update-ref`.
+
+The slice replaces that chain's tree object with a holo-tree `MutableTree` from
+the binding: `createTreeFromRef(parentRef)` → `writeChild(path, bytes)` →
+`write()` → `commitTree(...)` → `updateRef(...)`. Note this also **retires two
+subprocess shell-outs** (`commit-tree`, `update-ref`) — a concrete ergonomics +
+perf win to measure.
+
+- Gate the slice behind an internal flag/seam (e.g. an env var or a constructor
+  option) so both paths coexist on the branch and can be A/B compared. Do **not**
+  change the public API.
+- Prove parity: an upsert through the holo-tree path must produce the **same
+  commit/tree hash** as the hologit-JS path for the same input (git objects are
+  content-addressed, so byte-identical trees → identical hashes — a strong,
+  cheap oracle).
+- Benchmark the slice vs the JS path (single upsert, and a batch of N upserts in
+  one transaction) and record the numbers.
+
+### Phase C — ergonomics findings + hologit PR
+
+- Maintain a running findings log during A/B (scratch file on the branch, e.g.
+  `notes/holo-tree-findings.md` — not committed to gitsheets `main`).
+- Turn the findings into a concrete **hologit PR** on `feat/holo-tree-napi` (or a
+  sibling branch) that improves holo-tree's ergonomics/suitability for embedded
+  consumers. Likely candidates to evaluate (confirm against real friction, don't
+  pre-commit): a repo-bound handle so callers don't thread `&Repository` through
+  every call; clearer error variants / `Display` for cross-FFI mapping; a
+  one-call "commit these blobs to this ref" convenience; cache lifecycle that's
+  safe when calls arrive on different libuv threads.
+- The PR is the deliverable that closes the loop on "validate *and improve* the
+  RS libs."
+
+## Validation
+
+- [x] `holo-tree-napi` crate builds on this machine (`napi build`) and produces a
+      loadable `.node` addon + generated `.d.ts`.
+- [x] Rust/Node smoke test: create-tree-from-ref → write-child → write →
+      commit-tree → update-ref round-trips against a scratch repo and the ref
+      advances to the new commit.
+- [x] gitsheets `spike/holo-tree-napi` consumes the binding via a local
+      path/git dep and builds + type-checks.
+- [x] A single-record upsert committed through the holo-tree slice produces a
+      commit whose **tree hash and commit hash match** the hologit-JS path for
+      the same input (parity oracle). *(Tree-hash parity asserted end-to-end,
+      single/bulk/real 18k data; commit-hash parity is bit-exact at the binding
+      level — see Notes › Parity.)*
+- [x] The existing gitsheets vitest suite stays green with the slice flag **off**
+      (no regression to the JS path), and the upsert-path tests also pass with the
+      flag **on**. *(292 gitsheets + 66 axi green flag-off; 5 parity tests green
+      flag-on.)*
+- [x] Benchmark recorded: holo-tree slice vs JS path for 1 upsert and N-in-one-tx,
+      including the eliminated `commit-tree`/`update-ref` shell-outs. *(~4–5×;
+      `packages/gitsheets/bench/holo-tree-bench.mjs`, results in findings doc.)*
+- [x] Findings log written, and a hologit PR opened against
+      `JarvusInnovations/hologit` implementing at least the highest-value
+      ergonomic improvement surfaced. *(`notes/holo-tree-findings.md`; PR
+      [hologit#465](https://github.com/JarvusInnovations/hologit/pull/465) — 3
+      fixes landed, not just one.)*
+- [x] A go/no-go note on the full migration (does holo-tree, as improved, clear
+      the bar to become the v-next substrate?) plus a pointer to the follow-up
+      full-migration plan if go. *(Verdict: GO — see Notes.)*
+
+## Risks / unknowns
+
+- **`&gix::Repository` threading + thread-local cache.** holo-tree takes
+  `&Repository` on nearly every method and keeps a *thread-local* tree cache.
+  napi/libuv may dispatch calls on different threads, which can silently void the
+  cache or worse. This is the single biggest ergonomics question — and exactly
+  the kind of thing to fix upstream (a repo-bound handle, or an explicit
+  cache/session object), not to hack around in the binding. Treat as Phase-C
+  finding #1.
+- **napi value marshalling.** Blob content (binary), object ids (hex strings vs
+  bytes), and author/committer identity need clean, cheap crossings. Watch for
+  forced UTF-8 assumptions on blob bytes (records are TOML/text, but attachments
+  are binary).
+- **Error fidelity across FFI.** `holo_tree::Error` variants must survive to JS so
+  gitsheets can map them to its typed error classes; a stringified `Display` may
+  lose structure. Candidate Phase-C improvement.
+- **Build/toolchain friction.** Rust toolchain + napi build in a JS repo's dev
+  loop; per-platform prebuilds are out of scope for the spike (build locally).
+- **Parity oracle assumptions.** Identical-hash parity assumes byte-identical
+  tree serialization (sorting, modes, empty-tree handling). A hash mismatch is a
+  *finding*, not necessarily a blocker — investigate whether it's a holo-tree
+  serialization difference.
+- **Spike, not migration.** The slice deliberately leaves the JS path in place.
+  Resist scope-creep into the full swap; that's the follow-up plan's job.
+
+## Notes
+
+**Verdict: GO.** holo-tree is a suitable substrate for gitsheets' tree
+operations, and the "first integrated consumer hardens it" approach worked as
+intended.
+
+- **Correctness.** The binding builds byte-identical trees to hologit+git
+  (tree-hash parity on single, bulk, and the real ~18k-record codeforphilly
+  `people` sheet), and creates commits that bit-match `git commit-tree` under
+  identical identity+time. No tree-serialization divergence found.
+- **Performance.** ~4–5× faster end-to-end for committing a change to a large
+  sheet (release build) — and conservatively so; per-call `to_thread_local()`
+  and the default-off gix object cache remain (hologit#464). Caveat surfaced:
+  a *debug* binding is ~2.4× *slower* — release builds are mandatory.
+- **Hardening worked.** Every rough edge was fixable upstream rather than worked
+  around in gitsheets glue. Three holo-tree fixes landed in
+  [hologit#465](https://github.com/JarvusInnovations/hologit/pull/465):
+  `get_or_create_subtree` (silent dropped writes + an FFI-aborting panic when
+  writing into an existing directory — critical; would hit every real consumer),
+  `update_ref` (bare branch names), and `commit_tree` (explicit
+  author/committer/time). The critical bug was invisible to holo-tree's own
+  tests because they only build trees from scratch — integration found it.
+
+**Parity (criterion 4) — precise form.** Tree-hash parity is asserted
+end-to-end (gitsheets JS path vs holo path, same input → identical tree hash).
+Commit-hash parity is bit-exact *at the binding level* (`commitTree` ==
+`git commit-tree` under pinned identity+date, binding smoke test); it is
+deliberately not asserted across two end-to-end transactions because their
+commit timestamps differ by wall-clock — the JS path has the same
+non-determinism, so it is not a substrate-fidelity gap.
+
+**Binding placement.** The binding lives in the hologit repo
+(`holo-tree-napi`, `publish = false`), consumed via a `file:` dep during the
+spike. A real migration needs it published (or a git dep) with per-platform
+prebuilds — out of scope here.
+
+**Branch status.** The gitsheets `spike/holo-tree-napi` branch is intentionally
+*not* merged to develop — it's a validation spike (local `file:` dep,
+behind-a-flag integration). The mergeable-to-develop subset (the spec promotion
+in `architecture.md`/`deferred.md`/`README.md`, this plan, and
+`notes/holo-tree-findings.md`) is separable from the spike-only integration code
+(the flag, the `file:` dep, the op-log path, the parity/bench artifacts) — see
+Follow-ups.
+
+## Follow-ups
+
+- **Tracked as:** the full migration continues under
+  [#127](https://github.com/JarvusInnovations/gitsheets/issues/127) (still
+  open). A dedicated full-migration plan should be authored once hologit#465
+  merges and the binding is published — it migrates the remaining tree sites
+  (`getSubtree`/`getBlobMap`/`getChild`/`deleteChild`/`merge`/`clearChildren`,
+  `path-template/`, `cli/`, `Sheet.diffFrom`, `writeWorkingChanges`) and removes
+  the hologit JS dependency, behind the unchanged public API.
+- **Tracked as:** holo-tree performance headroom (per-call `to_thread_local()`,
+  default-off gix object cache, per-read cache clone, release-build guidance) —
+  [hologit#464](https://github.com/JarvusInnovations/hologit/issues/464).
+- **Tracked as:** remaining open holo-tree ergonomic findings not yet fixed —
+  error fidelity across FFI (#4), panic-aborts-process (#6), `update_ref`
+  compare-and-swap (#7) — catalogued in `notes/holo-tree-findings.md`; fold into
+  the hologit#465 review or a follow-up hologit issue.
+- **Tracked as:** whether to land the mergeable-to-develop subset (spec
+  promotion + this plan + findings) on develop ahead of the full migration, so
+  the holo-tree decision/record is on mainline — a team call, not yet filed.

--- a/specs/README.md
+++ b/specs/README.md
@@ -91,7 +91,7 @@ Run `/audit-spec-drift` (the Claude Code command at `.claude/commands/audit-spec
 
 ## Versioning relative to specs
 
-These specs describe the **current shipped surface** of gitsheets. v1.0 sets the API contract; v1.1 adds the full CLI flag/command surface plus library additions (`diffFrom`, attachment iterator + deletes, query AbortSignal, push-daemon hardening, `--prefix`). v1.2 adds content-typed records (markdown/mdx with TOML frontmatter), lazy body loading, and the `check` CLI command. Items intentionally deferred to later releases (e.g., [holo-tree migration](https://github.com/JarvusInnovations/gitsheets/issues/127), [`--working`](https://github.com/JarvusInnovations/gitsheets/issues/165), watch mode, field-level encryption) live in [`deferred.md`](deferred.md).
+These specs describe the **current shipped surface** of gitsheets. v1.0 sets the API contract; v1.1 adds the full CLI flag/command surface plus library additions (`diffFrom`, attachment iterator + deletes, query AbortSignal, push-daemon hardening, `--prefix`). v1.2 adds content-typed records (markdown/mdx with TOML frontmatter), lazy body loading, and the `check` CLI command. Items intentionally deferred to later releases (e.g., [`--working`](https://github.com/JarvusInnovations/gitsheets/issues/165), watch mode, field-level encryption) live in [`deferred.md`](deferred.md). The [holo-tree migration](https://github.com/JarvusInnovations/gitsheets/issues/127) is now carried by [`architecture.md`](architecture.md#holo-tree-migration-deferred) and tracked as plans in [`plans/`](../plans/).
 
 When work begins on a deferred item, the entry is promoted out of `deferred.md` into the active specs in the same PR that closes the issue; the spec authoring rules above apply.
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -99,8 +99,8 @@ These belong to the library and are not consumer concerns:
 - **Versioning:** semver. v1.0.0 is the cut after all `[1.0]`-tagged issues in the [1.0.0 milestone](https://github.com/JarvusInnovations/gitsheets/milestone/1) close. Patch releases inside 1.x preserve the documented API.
 - **Breaking changes** — only at major boundaries. The library's pre-1.0 API does not constrain v1.0 (the legacy `GitSheets` class is purged outright; no migration shim).
 
-## Holo-tree migration (deferred post-v1.2)
+## Holo-tree migration (deferred)
 
-[Issue #127](https://github.com/JarvusInnovations/gitsheets/issues/127) tracks the swap to a Rust `holo-tree` crate via `napi-rs`. **This is an internal-engine change with no public-API impact** — consumers should not see any difference, only ~100x faster tree operations.
+[Issue #127](https://github.com/JarvusInnovations/gitsheets/issues/127) tracks swapping the hologit JS dependency for a Rust `holo-tree` crate via `napi-rs`, for ~100x faster tree operations on the hot path. **This is an internal-engine change with no public-API impact** — consumers see no difference, only performance. That constraint is load-bearing: the migration must sit entirely behind the existing `Repository` / `Sheet` / `Transaction` surface, with no consumer-visible change.
 
-v1.0, v1.1, and v1.2 all shipped on the current JS hologit substrate. The holo-tree migration remains deferred; it's a substantial substrate swap that needs its own focused release. Tracked in [`deferred.md`](deferred.md).
+It stays deferred because the substrate swap is its own substantial track — it touches every tree-mutation site and benefits from a dedicated review cycle. v1.0, v1.1, and v1.2 all shipped on the JS hologit substrate; the migration targets a future minor when scheduled. The work is tracked as plans in [`plans/`](../plans/) — beginning with the [`holo-tree-napi-spike`](../plans/holo-tree-napi-spike.md) validation spike, which hardens the upstream Rust libs before any full swap — rather than as a backlog note.

--- a/specs/deferred.md
+++ b/specs/deferred.md
@@ -12,14 +12,6 @@ Every deferred item that's a viable future feature links to a tracking GitHub is
 
 When in doubt about whether an entry belongs in `deferred.md`, the litmus test is: "if someone reads the spec for X and notices it's missing from the code, will this file explain why?"
 
-## Deferred — substantial internal-engine swap
-
-### Holo-tree migration (Rust substrate) — [#127](https://github.com/JarvusInnovations/gitsheets/issues/127)
-
-- **What:** Swap the current hologit JS dependency for a Rust `holo-tree` crate via `napi-rs`. ~100x faster tree operations on the hot path.
-- **Why deferred:** Originally targeted at v1.1; slipped past v1.1 and v1.2 because the substrate swap is its own substantial track (touches every tree-mutation site) and benefits from a dedicated review cycle. Currently unmilestoned — targeting a future minor when scheduled.
-- **Constraint:** Must not change the public API. Consumers see no difference, only performance.
-
 ## Deferred (no scheduled release)
 
 ### Watch mode — [#135](https://github.com/JarvusInnovations/gitsheets/issues/135)


### PR DESCRIPTION
Lands the **durable record** from the holo-tree validation spike (#127) onto
`develop` — the spec decision plus the planning/findings — **separate from the
spike-only integration code**.

## Why this is a separate, code-free PR

The full spike lives on `spike/holo-tree-napi` (pushed, 11 commits). That branch
carries a local `file:` dependency on the `holo-tree-napi` binding and a
behind-a-flag integration of `Repository`/`Sheet`/`Transaction` — neither of
which can merge to `develop` (the `file:` dep breaks `npm install` in CI). This
PR carries **only** the parts that belong on mainline now, with no code or
behavior change.

## What's in here

- **Spec promotion** — the holo-tree migration moves out of `deferred.md`'s
  backlog and into `architecture.md` proper (intent + the load-bearing
  *no-public-API-impact* constraint), with tracking repointed to `plans/`.
  `README.md` example list updated. The substrate **stays hologit**; the
  migration **stays deferred/planned** — so specs and code remain in
  conformance (no drift).
- **Plans** — `holo-tree-napi-spike` (✅ done, verdict **GO**) and
  `holo-tree-migration` (planned, `awaits:` the binding being published).
- **Findings + benchmark** — `notes/holo-tree-findings.md` and
  `packages/gitsheets/bench/holo-tree-bench.mjs`, referenced by the plans.

## Context

- The spike's upstream improvements (3 holo-tree fixes + the napi binding)
  merged to hologit develop in JarvusInnovations/hologit#465.
- Performance-headroom items: JarvusInnovations/hologit#464.
- The full integration code remains on `spike/holo-tree-napi` for revival when
  the `holo-tree-migration` plan starts (once the binding is published).

No code changes → build/type-check/test are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)