### PR TITLE
perf(toml): parse with smol-toml, keep @iarna for serialize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The active work scope is [the 1.0.0 milestone](https://github.com/JarvusInnovati
 - **Language** — TypeScript (strict). ESM-only.
 - **Runtime** — Node.js ≥ 20 or Bun ≥ 1.
 - **Tree primitives** — hologit (JS) for v1.0; holo-tree (Rust via napi-rs) for v1.1.
-- **TOML** — `@iarna/toml` (preserves Date types).
+- **TOML** — `smol-toml` for parse (lean memory), `@iarna/toml` for serialize (byte-stable canonical form). Date types preserved (`instanceof Date`). See [specs/architecture.md](specs/architecture.md).
 - **JSON Schema validation** — `ajv`.
 - **Runtime consumer-validator interface** — [Standard Schema](https://standardschema.dev) (any compliant validator: Zod, Valibot, ArkType, Effect Schema).
 - **JSON Merge Patch** — RFC 7396 via `json-merge-patch`.
@@ -61,7 +61,7 @@ See [specs/architecture.md](specs/architecture.md) for the full stack rationale.
 - TypeScript everywhere. `strict: true`. No `.js` in `packages/gitsheets/src/`.
 - Field naming: `camelCase` in code, in TOML records, and on `Sheet.<field>` config — no casing translation.
 - IDs: consumer's choice (gitsheets doesn't impose UUID/string/numeric). Path templates render whatever the field holds.
-- Timestamps: TOML datetime types preserved by `@iarna/toml`; consumers can also use ISO 8601 strings.
+- Timestamps: TOML datetime types preserved across parse (`smol-toml` → `instanceof Date`) and serialize (`@iarna/toml`); consumers can also use ISO 8601 strings.
 - Use the typed error classes from [specs/api/errors.md](specs/api/errors.md) — never throw plain `Error` from public surfaces.
 - Mutations go through `repo.transact` or via the permissive Sheet methods documented in [specs/behaviors/transactions.md](specs/behaviors/transactions.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2939,6 +2939,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-6.0.0.tgz",
@@ -3517,6 +3529,7 @@
         "hologit": "^0.50.2",
         "markdownlint": "^0.40.0",
         "rfc6902": "^5.2.0",
+        "smol-toml": "^1.7.0",
         "sort-keys": "^6.0.0",
         "yargs": "^18.0.0"
       },

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -49,6 +49,7 @@
     "hologit": "^0.50.2",
     "markdownlint": "^0.40.0",
     "rfc6902": "^5.2.0",
+    "smol-toml": "^1.7.0",
     "sort-keys": "^6.0.0",
     "yargs": "^18.0.0"
   },

--- a/packages/gitsheets/src/toml.ts
+++ b/packages/gitsheets/src/toml.ts
@@ -1,7 +1,30 @@
 // TOML serialization helpers with canonical key sorting.
 // See specs/behaviors/normalization.md for the byte-stable normalization rules.
+//
+// We deliberately use two different TOML libraries, split by direction:
+//
+//   parse     → smol-toml   (reads — the hot, memory-sensitive path)
+//   stringify → @iarna/toml (writes — preserves the byte-stable canonical form)
+//
+// Why: @iarna/toml's parser emits string values as V8 sliced/cons-strings that
+// transitively pin large parser buffers — each parsed record retains ~12x its
+// source size, so a consumer holding a full dataset in memory pays a ~5–6x heap
+// blowup (observed: a 31.8k-record store needed >500 MB of heap for ~25 MB of
+// TOML). smol-toml's parser produces flat strings and retains ~2x source size,
+// eliminating that leak at the root. It is also actively maintained and full
+// TOML 1.0 (vs @iarna's frozen 1.0.0-rc.1).
+//
+// We keep @iarna/toml for stringify because its output is what the on-disk
+// canonical form already is: it preserves human-readable multiline strings
+// (triple-quoted markdown bodies) and literal-quoted strings, where smol-toml
+// would escape both to single-line — a ~32% cosmetic byte-churn across a real
+// corpus, with no data change. Serialization isn't memory-sensitive (one record
+// at a time), so there's no reason to take that churn. Verified: smol parse →
+// @iarna stringify round-trips losslessly, and TOML date types stay
+// `instanceof Date` with identical serialized output.
 
 import * as TOML from '@iarna/toml';
+import { parse as smolParse } from 'smol-toml';
 import sortKeys from 'sort-keys';
 
 import { ConfigError } from './errors.js';
@@ -9,7 +32,8 @@ import { ConfigError } from './errors.js';
 export type RecordLike = Record<string, unknown>;
 
 // The hologit package augments '@iarna/toml' with only `parse`, so the
-// `stringify` export isn't seen by tsc. Wrap once here.
+// `stringify` export isn't seen by tsc. Wrap once here. (We only use its
+// `stringify`; parsing goes through smol-toml — see the module header.)
 interface TomlModule {
   parse: (content: string) => Record<string, unknown>;
   stringify: (obj: Record<string, unknown>) => string;
@@ -28,7 +52,9 @@ export function stringifyRecord(record: RecordLike): string {
 }
 
 export function parseToml(content: string): RecordLike {
-  return toml.parse(content);
+  // `integersAsBigInt: 'asNeeded'` mirrors @iarna's behavior: integers within
+  // the safe range stay `number`, larger ones become `BigInt` (lossless).
+  return smolParse(content, { integersAsBigInt: 'asNeeded' }) as RecordLike;
 }
 
 export function parseConfigToml(content: string, sourcePath: string): RecordLike {

--- a/specs/README.md
+++ b/specs/README.md
@@ -83,7 +83,7 @@ Specs declare *what* must be true, not *how* to implement it.
 > "Patch updates a record by merging in changes."
 
 **Too detailed** — duplicates the code:
-> "Open the record blob, parse with `iarna/toml`, deepclone the object, walk the patch tree with a recursive merge function, then…"
+> "Open the record blob, parse with `smol-toml`, deepclone the object, walk the patch tree with a recursive merge function, then…"
 
 ## Spec drift auditing
 

--- a/specs/api/conventions.md
+++ b/specs/api/conventions.md
@@ -128,5 +128,5 @@ When a root isn't specified:
 ## I/O
 
 - All file paths inside the data repo are POSIX-style (`/` separators) regardless of host OS.
-- TOML reads use `@iarna/toml` to preserve Date types.
-- TOML writes serialize sorted keys (deep) for byte-stable normalization.
+- TOML reads use `smol-toml` (lean parse — see [architecture.md](../architecture.md)); Date types still read back as `instanceof Date`.
+- TOML writes serialize via `@iarna/toml` with sorted keys (deep) for byte-stable normalization.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -16,7 +16,8 @@ Concrete v1.0 ship list lives across [GitHub issues #128–#141 in the 1.0.0 mil
 | Module format | **ESM-only** | Modern Node + Bun + edge runtimes all handle ESM. Dual CJS/ESM build deferred until a concrete consumer needs it. |
 | Runtime | **Node.js ≥ 20**, **Bun ≥ 1** | Both have native ESM, both can host the CLI. No Deno target in v1.0. |
 | Tree primitives | **hologit (JS)** | Provides `TreeObject`, `BlobObject`, repo discovery, in-memory mutable trees, packfile access via the `git` CLI. v1.0–v1.2 stay on the JS substrate; the Rust [holo-tree migration](https://github.com/JarvusInnovations/gitsheets/issues/127) is deferred. |
-| TOML | **`@iarna/toml`** | Preserves date types; canonical-sorted keys for byte-stable normalization. |
+| TOML parse | **`smol-toml`** | Reads — the hot, memory-sensitive path. `@iarna/toml`'s parser pins large parser buffers in each value (~12× source retained per record); `smol-toml` produces flat strings (~2× retained), eliminating a ~5–6× heap blowup for in-memory consumers. Actively maintained, full TOML 1.0. Date types stay `instanceof Date`. |
+| TOML serialize | **`@iarna/toml`** | Writes — preserves the byte-stable canonical form: human-readable triple-quoted multiline strings and literal-quoted strings. (`smol-toml` would escape both to single-line — cosmetic churn, no data change.) Serialization isn't memory-sensitive. |
 | Canonical key sort | **`sort-keys`** | Deep alphabetical key sorting on every write for byte-stable normalization. |
 | JSON Schema validation | **`ajv`** + **`ajv-formats`** | Industry-standard, well-maintained, fast. Used for the persisted shape contract per [behaviors/validation.md](behaviors/validation.md). `ajv-formats` carries `date-time`, `email`, etc. |
 | Runtime validator (consumer-supplied) | Any **[Standard Schema](https://standardschema.dev)** implementation | Consumer chooses Zod / Valibot / ArkType / Effect Schema. Gitsheets calls `~standard.validate`. |

--- a/specs/behaviors/normalization.md
+++ b/specs/behaviors/normalization.md
@@ -100,8 +100,8 @@ Sorts an array of strings using locale-aware comparison (`localeCompare` with `s
 
 ### TOML serialization details
 
-- The library uses `@iarna/toml` for serialization. Dates, datetimes, and date-times round-trip correctly (a Date in the record becomes the matching TOML date type).
-- Multi-line string formatting follows `@iarna/toml`'s defaults — strings with newlines emit as triple-quoted; the library doesn't impose its own length threshold.
+- The library **parses** with `smol-toml` and **serializes** with `@iarna/toml` (see [architecture.md](../architecture.md) for why the two directions use different libraries). Dates, datetimes, and date-times round-trip correctly: `smol-toml` parses them to `TomlDate` (an `instanceof Date` subclass) and `@iarna/toml` serializes those back to the matching TOML date type, byte-identically.
+- Multi-line string formatting follows `@iarna/toml`'s serializer defaults — strings with newlines emit as triple-quoted; the library doesn't impose its own length threshold.
 - Null values are *omitted* from the output. TOML can't represent `null`; absent fields read back as `undefined` and are treated as null by validation.
 - Empty arrays and empty objects are preserved (they have semantic meaning distinct from absent).
 

--- a/specs/behaviors/patch-semantics.md
+++ b/specs/behaviors/patch-semantics.md
@@ -131,7 +131,7 @@ await sheet.upsert(merged);
 
 ## Implementation note
 
-The library uses an inline RFC 7396 implementation in `packages/gitsheets/src/patch.ts` — about 40 lines, no external dependency. Inline-ness is deliberate: @iarna/toml's custom Date subclasses and other class instances need to flow through the merge as opaque values rather than being recursively merged, and an off-the-shelf merge package's `isPlainObject` heuristic isn't tailored to that. The `deepmerge` package is removed from `package.json` during the [#128 purge](https://github.com/JarvusInnovations/gitsheets/issues/128).
+The library uses an inline RFC 7396 implementation in `packages/gitsheets/src/patch.ts` — about 40 lines, no external dependency. Inline-ness is deliberate: the TOML parser's custom Date subclasses (`smol-toml`'s `TomlDate`, an `instanceof Date`) and other class instances need to flow through the merge as opaque values rather than being recursively merged, and an off-the-shelf merge package's `isPlainObject` heuristic isn't tailored to that. The `deepmerge` package is removed from `package.json` during the [#128 purge](https://github.com/JarvusInnovations/gitsheets/issues/128).
 
 ## Conformance
 


### PR DESCRIPTION
## Summary

Switch the record **parser** from `@iarna/toml` to `smol-toml`; keep `@iarna/toml` for **serialization**. Splitting the two directions fixes a significant memory leak on the read path while preserving the byte-stable, human-readable canonical on-disk form.

## Why

`@iarna/toml`'s parser emits string values as V8 sliced/cons-strings that transitively pin large parser buffers — **each parsed record retains ~12× its source size**. A consumer holding a full dataset in memory pays a ~5–6× heap blowup. Root-caused in a downstream consumer (CodeForPhilly/codeforphilly-ng#132) where a **31.8k-record store needed >500 MB of heap for ~25 MB of TOML**.

`smol-toml`'s parser produces flat strings (~2× retained), eliminating the leak at the root. It's also actively maintained and full TOML 1.0 (vs `@iarna`'s frozen 1.0.0-rc.1).

**End-to-end on the real 31.8k-record dataset** (via the consumer's boot path):

| Metric | `@iarna` parse | `smol-toml` parse | |
|---|---|---|---|
| Retained heap | 581 MB | **88 MB** | 6.6× |
| Transient boot peak | 532 MB | **71 MB** | 7.5× |
| RSS | 806 MB | 292 MB | 2.8× |

## Why keep `@iarna` for serialize

`@iarna`'s output **is** the current canonical form — readable triple-quoted multiline strings and literal-quoted strings. `smol-toml`'s serializer escapes both to single-line (~32% cosmetic byte-churn across a real corpus, no data change). Serialization isn't memory-sensitive (one record at a time), so there's no reason to take that churn. See #196 for the serialization-format analysis and guidance for the eventual Rust core.

## Safety / verification

- **Lossless** on a 4,310-record real corpus: `smol` parse → `@iarna` stringify round-trips identically; `smol` parse agrees with `@iarna` parse on every record.
- **Dates preserved**: `smol-toml` parses TOML datetimes to `TomlDate` (an `instanceof Date` subclass), and `@iarna` serializes those byte-identically for all four TOML date types (offset/local datetime, date, time). All `instanceof Date` call sites keep working.
- `integersAsBigInt: 'asNeeded'` mirrors `@iarna`'s safe-int/BigInt split.
- **Full suite green: 353/353**, type-check clean.
- Specs updated (`architecture.md`, `api/conventions.md`, `behaviors/normalization.md`, `behaviors/patch-semantics.md`, `README.md`) + `CLAUDE.md`.

## Follow-up

- #196 — when the [holo-tree Rust migration](https://github.com/JarvusInnovations/gitsheets/issues/127) absorbs TOML, prefer the Rust `toml`/`toml_edit` stack (format-compatible with today's canonical form) and retire the JS split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)