### PR TITLE
specs+plans: Rust-core architecture + full implementation DAG (#127)

### DIFF
--- a/plans/canonical-rebaseline.md
+++ b/plans/canonical-rebaseline.md
@@ -1,0 +1,65 @@
+---
+status: planned
+depends: [toml-canonical-core]
+specs:
+  - specs/rust-core.md
+  - specs/behaviors/normalization.md
+issues: [196]
+---
+
+# Plan: canonical-form re-baseline
+
+## Scope
+
+Execute the **one-time, deliberate** canonical-form change that adopting the Rust
+serializer implies, and update the spec to match. **In:** amend
+`normalization.md` to the new canonical form, provide a re-normalize routine, and
+re-baseline this repo's own fixtures/corpora. **Out:** the serializer itself
+([`toml-canonical-core`](toml-canonical-core.md)) and migrating *external* repos
+(that's each consumer's one-shot, documented here as a recipe).
+
+## Implements
+
+- [`specs/behaviors/normalization.md`](../specs/behaviors/normalization.md) — the
+  canonical form is amended (the integer-underscore change, per #196) as the
+  spec-first step before any re-baseline.
+- [`specs/rust-core.md`](../specs/rust-core.md) — "Canonical-form rebaseline":
+  do it while gitsheets effectively has a single user.
+
+## Approach
+
+- **Spec first.** Amend `normalization.md` to state the new canonical form and why
+  (link #196), in its own commit, before touching any bytes.
+- **Re-normalize routine.** A `git sheet normalize`-style pass (or a one-shot)
+  that reads every record, re-serializes via the core, and writes the new
+  canonical bytes in a single commit per repo. Idempotent: a second run is a no-op.
+- **Re-baseline in-repo.** Apply it to gitsheets' own test fixtures / any sample
+  corpora so the suite reflects the new canonical form.
+- **Consumer recipe.** Document the one-command re-normalize for external repos.
+
+## Validation
+
+- [ ] `normalization.md` describes the new canonical form; the change is its own
+      reviewable commit.
+- [ ] The re-normalize routine is idempotent (second run produces no diff).
+- [ ] After re-baseline, the core serializer is byte-identical to on-disk for the
+      whole corpus (0 diff — the churn is now absorbed).
+- [ ] Documented consumer recipe for re-baselining an existing repo in one commit.
+
+## Risks / unknowns
+
+- **Timing vs adoption.** Decision D in the analysis: bundle into the Node cutover
+  vs an isolated commit first. This plan does the spec + routine; the
+  *cutover-bearing* re-baseline of a live repo is sequenced with
+  [`node-binding-thin`](node-binding-thin.md).
+- **Surprise churn.** If the parity harness in `toml-canonical-core` missed a
+  formatting difference, it shows up here as unexpected diff — fix upstream, not by
+  re-normalizing around it.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/definition-logic-core.md
+++ b/plans/definition-logic-core.md
@@ -1,0 +1,75 @@
+---
+status: planned
+depends: [gitsheets-core-foundation]
+specs:
+  - specs/rust-core.md
+  - specs/behaviors/path-templates.md
+  - specs/behaviors/validation.md
+issues: [127]
+---
+
+# Plan: definition-logic core — path templates, validation, embedded engine
+
+## Scope
+
+Move the behavior that's **derived from a sheet definition** into the core, so it
+produces identical results under every binding. **In:** path-template rendering
+(incl. partition derivations), persisted-shape (JSON Schema) validation, and the
+**embedded JS engine** for the escape-hatch cases (declarative-first). **Out:**
+the consumer-supplied runtime validator (Zod/Pydantic) — that legitimately stays
+in the binding — and record CRUD/query (downstream).
+
+## Implements
+
+- [`specs/rust-core.md`](../specs/rust-core.md) — "Embedded code execution"
+  (declarative-first; JS escape-hatch in an embedded engine *in the core*;
+  engine-as-contract; thread-confinement) and the consumer-validator-vs-
+  definition-embedded distinction.
+- [`specs/behaviors/path-templates.md`](../specs/behaviors/path-templates.md) and
+  [`specs/behaviors/validation.md`](../specs/behaviors/validation.md) — re-implemented
+  in Rust, behavior-preserving.
+
+## Approach
+
+- **Path templates (native).** `${{ field }}` substitution + built-in partition
+  derivations (date-parts, hashing, bucketing) evaluated natively over the core
+  `Value`.
+- **Shape validation (native).** JSON Schema via a Rust validator (e.g.
+  `jsonschema`). **Parity pass vs `ajv`** — formats, coercion, error shapes —
+  because this changes observable validation behavior.
+- **Embedded engine (escape-hatch).** Embed a small JS engine (`rquickjs` for
+  maturity, or `boa_engine` pure-Rust for clean cross-compile — decide here).
+  Compile each definition's snippets **once on sheet-open** into persistent
+  function handles held on the `Sheet`/`Store`; reuse across operations. Pin the
+  engine version (it's part of the canonical-behavior contract). Confine the
+  context to the owning thread.
+- **Parity vs `node:vm`.** The current raw-JS sort rules run via `node:vm`; the
+  embedded engine must produce identical results for the same snippets.
+
+## Validation
+
+- [ ] Path rendering (incl. a partition-derivation case) is identical to the JS
+      implementation across the corpus.
+- [ ] Rust JSON-Schema validation matches `ajv` on a parity fixture set (valid +
+      invalid records, formats, edge cases).
+- [ ] An embedded-JS sort/derivation snippet produces the same result as today's
+      `node:vm` path; the compiled context persists across operations (compiled
+      once per open, not per call).
+- [ ] Engine version is pinned and recorded as a behavior-contract input.
+
+## Risks / unknowns
+
+- **`ajv` parity** is the biggest unknown — format validators and coercion
+  semantics differ between validators. Budget a real parity pass.
+- **Engine choice trade-off.** QuickJS (mature, small C) vs Boa (pure-Rust, easier
+  prebuilds, less complete). Tie the decision to the cross-platform prebuild story.
+- **Thread model.** `!Send` JS context + the napi/pyo3 threading model — confine
+  deliberately (same lesson as holo-tree's thread-local cache).
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/gitsheets-core-foundation.md
+++ b/plans/gitsheets-core-foundation.md
@@ -1,0 +1,71 @@
+---
+status: planned
+depends: [holo-tree-migration]
+specs:
+  - specs/rust-core.md
+issues: [127]
+---
+
+# Plan: gitsheets-core foundation — the crate, the value type, the boundary
+
+## Scope
+
+Stand up the Rust core and its FFI boundary so later plans have somewhere to land
+engine logic. **In:** a `gitsheets-core` crate, the TOML-faithful **core value
+type**, the typed-error surface, and a `gitsheets-napi` binding skeleton that
+marshals records between JS and the core with full type fidelity. **Out:** any
+actual engine behavior (TOML, normalization, validation, query, Sheet) — those
+are downstream plans; this is the substrate they build on.
+
+## Implements
+
+- [`specs/rust-core.md`](../specs/rust-core.md) — "The FFI boundary" (typed core
+  value, not JSON; batch APIs) and the `gitsheets-core` / thin-binding split. This
+  plan delivers the *boundary*, not the engine on either side of it.
+
+## Approach
+
+- **Workspace.** Add a Rust workspace to the gitsheets repo (e.g. `rust/` with
+  `gitsheets-core` + `gitsheets-napi` members). `gitsheets-core` depends on
+  `holo-tree` — via a Cargo git dependency on hologit, or holo-tree published to
+  crates.io (decide here; git dep is fine to start).
+- **Core value type.** A `Value` enum that preserves TOML's type set —
+  string, integer, float, bool, **datetime**, array, table — so nothing is lost
+  crossing the boundary (JSON would flatten datetimes to strings and blur
+  int/float). This is the lingua franca every later plan speaks.
+- **Marshalling (napi).** `Value` ↔ JS object with fidelity rules: TOML datetime
+  ↔ JS `Date`, integer ↔ number (bigint above 2^53?), float ↔ number, table ↔
+  plain object. Round-trip tests are the contract.
+- **Errors.** A `core::Error` enum with stable, matchable variants (the
+  [findings doc](../notes/holo-tree-findings.md) flagged that holo-tree errors
+  flatten to strings across FFI — don't repeat that). The binding maps variants
+  to gitsheets' typed error classes ([`specs/api/errors.md`](../specs/api/errors.md)).
+- **Batch-first signatures.** Even the skeleton APIs take/return arrays, so bulk
+  paths never bake in per-record FFI crossings.
+
+## Validation
+
+- [ ] `gitsheets-core` + `gitsheets-napi` build; the napi addon loads in Node.
+- [ ] A record round-trips JS → `Value` → JS preserving types: a `Date` stays a
+      `Date`, an integer stays integral, a float stays a float, nested tables
+      survive.
+- [ ] A core error surfaces in JS as a structured, matchable cause (not an opaque
+      string), and the binding maps it to the right typed error class.
+- [ ] A batch (array) crosses the boundary in a single call.
+
+## Risks / unknowns
+
+- **holo-tree dependency form.** Git dep vs crates.io publish for holo-tree —
+  affects reproducibility and the gitsheets build. Decide early.
+- **Integer width.** TOML allows 64-bit integers; JS numbers lose precision above
+  2^53. Decide bigint vs number per-field or globally (consumers' IDs may be large).
+- **`Date` fidelity.** TOML local-vs-offset datetimes vs JS `Date` (always UTC
+  instant). The current JS stack preserves `@iarna` `Date`; match that semantics.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/holo-tree-migration.md
+++ b/plans/holo-tree-migration.md
@@ -3,10 +3,9 @@ status: planned
 depends: [holo-tree-napi-spike]
 specs:
   - specs/architecture.md
+  - specs/rust-core.md
 upstream-specs:
   - hologit:holo-tree/README.md
-awaits:
-  - "holo-tree-napi published (npm, or a pinned git dep) with per-platform prebuilds — a release can't carry a local file: dep to a sibling repo. (hologit#465 merged to develop 2026-06-27; binding now lives on hologit develop.)"
 issues: [127]
 ---
 

--- a/plans/node-binding-thin.md
+++ b/plans/node-binding-thin.md
@@ -1,0 +1,67 @@
+---
+status: planned
+depends: [sheet-store-core, canonical-rebaseline]
+specs:
+  - specs/rust-core.md
+  - specs/api/conventions.md
+issues: [127]
+---
+
+# Plan: re-thin the Node binding over the full core (the cutover)
+
+## Scope
+
+Make the published `gitsheets` npm package a **thin marshalling shell** over
+`gitsheets-core`, and retire the JS engine implementation. This is the Node
+**cutover**: the moment consumers run on the Rust core end-to-end. **In:** the
+`gitsheets-napi` surface, the idiomatic JS API preserved unchanged, the consumer
+(Standard Schema) validator hook, error mapping, removal of the now-dead JS
+engine, and the live re-baseline. **Out:** Python (parallel plan).
+
+## Implements
+
+- [`specs/rust-core.md`](../specs/rust-core.md) — the thin-binding half of the
+  split; "no consumer-visible public-API change" except the deliberate, documented
+  bytes re-baseline.
+- [`specs/api/conventions.md`](../specs/api/conventions.md) — the public surface is
+  preserved exactly.
+
+## Approach
+
+- Wire the public `Repository`/`Sheet`/`Transaction`/`Store` classes to call
+  `gitsheets-core` via `gitsheets-napi`, keeping signatures identical.
+- Run the **Standard Schema validator** in the binding (native object), before
+  marshalling to the core — per the documented write order.
+- Map core error variants → the existing typed error classes.
+- **Delete** the JS engine (TOML serialize/parse, normalization, path templates,
+  validation, query, Sheet/Tx) now that the core owns them; drop `smol-toml`,
+  `@iarna`, `ajv` from the JS layer where the core subsumes them.
+- Ship the **canonical re-baseline** as part of the cutover (the one
+  consumer-visible byte change, documented).
+
+## Validation
+
+- [ ] The **entire** existing gitsheets vitest suite passes against the core-backed
+      binding (the no-public-API-change proof).
+- [ ] The published `.d.ts` diff is empty — no consumer-visible type change.
+- [ ] `/audit-spec-drift` clean against the API + behavior specs.
+- [ ] `smol-toml` / `@iarna` / `ajv` removed from the JS layer where superseded;
+      no `from 'hologit'` or JS-engine imports remain.
+- [ ] Bulk upsert/query benchmarked vs the pre-cutover JS path (expect the core's
+      speedup, esp. bulk).
+
+## Risks / unknowns
+
+- **Re-baseline as a consumer-visible change** — the one place the migration breaks
+  byte-stability. Document loudly; provide the one-command re-normalize for
+  existing repos (from [`canonical-rebaseline`](canonical-rebaseline.md)).
+- **The consumer-validator round-trip** (native → core) must not regress validation
+  timing or error semantics.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/python-binding.md
+++ b/plans/python-binding.md
@@ -1,0 +1,67 @@
+---
+status: planned
+depends: [sheet-store-core]
+specs:
+  - specs/rust-core.md
+issues: [127]
+---
+
+# Plan: Python binding (pyo3)
+
+## Scope
+
+The first **second** binding — `gitsheets` for Python over the same
+`gitsheets-core`, proving the thin-binding model and the cross-binding
+byte-consistency the whole architecture is for. **In:** a pyo3 binding,
+Python-idiomatic API, native `dict`/`datetime` marshalling, the consumer-validator
+hook (Pydantic-or-similar), packaging/wheels. **Out:** feature parity beyond the
+core's surface; any core change (if Python needs something the core lacks, that's a
+core plan).
+
+## Implements
+
+- [`specs/rust-core.md`](../specs/rust-core.md) — the multi-binding goal made real;
+  validates that "the bytes-authority lives in the core" actually yields identical
+  bytes across languages.
+
+## Approach
+
+- **pyo3 binding** over `gitsheets-core`; map the core `Value` ↔ Python natives
+  with fidelity (TOML datetime ↔ `datetime.datetime`, int/float, table ↔ `dict`).
+- **Idiomatic surface** in Python conventions (sync first; async if warranted).
+- **Consumer validator** hook runs Python-side (e.g. Pydantic) on the native object
+  before the core takes over — same write order as Node.
+- **Embedded-engine reuse:** definition-embedded JS snippets run in the **core's**
+  engine, so Python gets identical sort/partition/validation results as Node with
+  no Python JS runtime. (This is the payoff of "embed in the core, not the host.")
+- **Packaging:** maturin/abi3 wheels per platform (mirror the holo-tree prebuild +
+  trusted-publishing playbook).
+
+## Validation
+
+- [ ] A record written via **Python** and a record written via **Node** for the
+      same input produce **byte-identical** commits (the cross-binding consistency
+      proof — the architecture's whole point).
+- [ ] A definition-embedded JS snippet yields identical results under Python and
+      Node.
+- [ ] Type fidelity: a `datetime` round-trips Python → core → on-disk → Node as the
+      same instant.
+- [ ] Wheels build + install on the target platforms; a smoke test round-trips
+      upsert→commit.
+
+## Risks / unknowns
+
+- **GIL + the core's thread model** — the embedded-engine thread-confinement and
+  holo-tree's thread-local cache must cooperate with Python's GIL/threading.
+- **Packaging surface** — Python wheels per platform/ABI is its own release track
+  (reuse the trusted-publishing patterns, different ecosystem).
+- **API idiom translation** — keep it Pythonic without diverging the *behavior*
+  from Node (behavior is the core's; only ergonomics differ).
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/record-engine-core.md
+++ b/plans/record-engine-core.md
@@ -1,0 +1,66 @@
+---
+status: planned
+depends: [toml-canonical-core, definition-logic-core]
+specs:
+  - specs/rust-core.md
+  - specs/behaviors/indexing.md
+  - specs/behaviors/patch-semantics.md
+issues: [127]
+---
+
+# Plan: record engine in the core — CRUD, query, index, diff/patch
+
+## Scope
+
+The record-level data engine in `gitsheets-core`, composed from the bytes-authority
+
++ definition-logic layers below it. **In:** record read/write/list, query
+traversal + filtering, secondary indexing, and diff + patch semantics — all over
+the core `Value` and the holo-tree substrate. **Out:** the `Sheet`/`Transaction`/
+`Store` orchestration on top (that's [`sheet-store-core`](sheet-store-core.md)) and
+the bindings.
+
+## Implements
+
++ [`specs/rust-core.md`](../specs/rust-core.md) — "Query traversal + filtering;
+  secondary indexing; diff + patch" in the core.
++ [`specs/behaviors/indexing.md`](../specs/behaviors/indexing.md),
+  [`specs/behaviors/patch-semantics.md`](../specs/behaviors/patch-semantics.md) —
+  re-implemented behavior-preserving in Rust.
+
+## Approach
+
++ **Record CRUD.** read (parse), write (render path + normalize + serialize + tree
+  write), delete, list — over holo-tree blobs and the core `Value`.
++ **Query.** traversal of the data tree + native filtering (declarative predicates
+  in Rust; the embedded-engine escape-hatch for arbitrary predicates). Batch-first
+  (`queryAll` crosses once).
++ **Indexing.** secondary indices built natively; lazy or persisted (the persisted
+  variant is a deferred option — keep the door open).
++ **Diff / patch.** record-level diff (gix diff, replacing `git.diffTree`) and the
+  RFC 7396 / 6902 patch semantics in Rust.
+
+## Validation
+
++ [ ] CRUD round-trips records byte-identically to the (re-baselined) on-disk form.
++ [ ] Query results (and filter semantics, incl. an escape-hatch predicate) match
+      the JS implementation on a fixture corpus.
++ [ ] Indexing produces the same lookups as the JS index.
++ [ ] Diff + patch outputs match the JS `Sheet.diffFrom` / patch behavior.
++ [ ] Bulk query/CRUD over a large corpus (≈18k records) benchmarked vs the JS path.
+
+## Risks / unknowns
+
++ **Scope creep** — this is the largest single core plan; if it grows, split query
+  + index into their own plan before starting (don't restructure mid-flight).
++ **gix diff fidelity** vs `git diffTree` for record-level diffs.
++ **The read-heavy perf headroom** (hologit#464: per-call `to_thread_local`,
+  object cache, per-read clone) lands here — measure and feed back upstream.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/sheet-store-core.md
+++ b/plans/sheet-store-core.md
@@ -1,0 +1,70 @@
+---
+status: planned
+depends: [record-engine-core]
+specs:
+  - specs/rust-core.md
+  - specs/api/sheet.md
+  - specs/api/transaction.md
+  - specs/api/store.md
+  - specs/behaviors/transactions.md
+issues: [127]
+---
+
+# Plan: Sheet / Transaction / Store state machine in the core
+
+## Scope
+
+Lift the orchestration layer — `Sheet`, `Transaction`, `Store` — into
+`gitsheets-core`, on top of the record engine. **In:** the transaction lifecycle
+(parent resolution, optimistic concurrency, commit + ref update), sheet config
+resolution, the Store multi-sheet surface, and the strict/permissive mutation
+rules. **Out:** the binding-level idiomatic surface and the consumer validator
+(those stay per-binding) and the working-tree `--working` path (deferred).
+
+## Implements
+
+- [`specs/rust-core.md`](../specs/rust-core.md) — "The `Sheet` / `Transaction` /
+  `Store` state machine" in the core.
+- [`specs/api/sheet.md`](../specs/api/sheet.md),
+  [`specs/api/transaction.md`](../specs/api/transaction.md),
+  [`specs/api/store.md`](../specs/api/store.md),
+  [`specs/behaviors/transactions.md`](../specs/behaviors/transactions.md) —
+  behavior-preserving (the *contracts* don't change; the implementation moves).
+
+## Approach
+
+- **Transaction.** parent resolution, the in-process mutex / serialization, the
+  optimistic `parent_moved` re-check, no-op detection, commit-tree + update-ref
+  (already in holo-tree's `commit_tree`/`update_ref`, now with explicit identity).
+- **Sheet.** config resolution (`read_toml` for `.gitsheets/<name>.toml`), the
+  upsert/willChange/patch pipeline, strict-vs-permissive mode.
+- **Store.** the typed multi-sheet surface + `Store.transact`.
+- The consumer-validator hook is a **callback into the binding** at the documented
+  point (native object → consumer validator → core), since it runs host-side.
+
+## Validation
+
+- [ ] The full transaction lifecycle (commit, no-op, `parent_moved`, strict mode)
+      matches the JS behavior and the specs.
+- [ ] An upsert through the core produces the same commit/tree as the JS path for
+      the same input (post-rebaseline), incl. correct author/committer identity.
+- [ ] The consumer-validator callback fires at the right point and can reject a
+      write before any bytes are written.
+- [ ] The existing transaction/Sheet/Store test suite passes against the core.
+
+## Risks / unknowns
+
+- **The consumer-validator callback across FFI** is the trickiest seam — a
+  host-language function invoked mid-core-operation. Design the re-entrancy
+  carefully (or validate-then-commit in two phases to avoid calling back into the
+  host while holding core state).
+- **Behavioral parity surface is large** — this is where "no public-API change"
+  is truly tested. Lean on the existing suite as the oracle.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/toml-canonical-core.md
+++ b/plans/toml-canonical-core.md
@@ -1,0 +1,68 @@
+---
+status: planned
+depends: [gitsheets-core-foundation]
+specs:
+  - specs/rust-core.md
+  - specs/behaviors/normalization.md
+issues: [127, 196]
+---
+
+# Plan: TOML + canonical form in the core (the bytes-authority)
+
+## Scope
+
+Move the **authority over on-disk bytes** into `gitsheets-core`: TOML parse +
+serialize and normalization (key sorting → byte-stable canonical form), operating
+on the [core `Value`](gitsheets-core-foundation.md). **In:** parse, serialize,
+normalize, and a parity harness against the current JS canonical bytes. **Out:**
+the actual corpus re-normalization (that's [`canonical-rebaseline`](canonical-rebaseline.md))
+and record-level CRUD (that's [`record-engine-core`](record-engine-core.md)).
+
+## Implements
+
+- [`specs/rust-core.md`](../specs/rust-core.md) — TOML parse+serialize +
+  normalization in the core; the "serialize fresh from an object, expect the
+  integer re-baseline" finding.
+- [`specs/behaviors/normalization.md`](../specs/behaviors/normalization.md) — the
+  canonical-form rules, re-implemented in Rust (the spec text itself changes in
+  the rebaseline plan, not here).
+
+## Approach
+
+- **Parse:** `toml` crate → core `Value`. Drops the `smol-toml` memory workaround
+  (a V8/`@iarna` artifact that doesn't exist natively).
+- **Serialize + normalize:** deep key sort, then serialize via `toml`/`toml_edit`
+  default formatting (triple-quote multiline + literal-quote, per #196). gitsheets
+  serializes *fresh* from a `Value`, so accept the integer-underscore shift
+  (`31_618` → `31618`) rather than hand-mimic `@iarna`.
+- **Parity harness (the gate):** serialize the 4,310-record corpus from #196 both
+  ways; assert the only diffs are the documented, expected normalization (integer
+  underscores). Anything else is a bug to fix before proceeding.
+- Expose batch parse/serialize across the boundary.
+
+## Validation
+
+- [ ] `toml` parse → `Value` → serialize is lossless for the #196 corpus
+      (data-identical).
+- [ ] Serializer output differs from current `@iarna` on-disk bytes **only** by
+      the documented normalization (integer underscores); the diff is enumerated
+      and matches #196's prediction.
+- [ ] Multiline/markdown bodies stay triple-quoted and readable (NOT
+      single-line-escaped — the one outcome #196 says to avoid).
+- [ ] Normalization (key sort) is byte-stable and idempotent.
+
+## Risks / unknowns
+
+- **Hidden formatting divergences** beyond integers (float rendering, table vs
+  inline-table thresholds, key quoting). The corpus parity harness is what
+  surfaces them — treat any non-integer diff as a finding.
+- **`toml` vs `toml_edit` version** alignment with holo-tree's existing `toml`
+  dependency.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,6 +28,7 @@ PRs that change runtime behavior should include a spec change. If they don't, th
 specs/
 ├── README.md             # This file — workflow + layout
 ├── architecture.md       # Tech stack, packaging, foundational decisions
+├── rust-core.md          # v-next target: Rust core + thin language bindings (forward-looking)
 ├── concepts.md           # Vocabulary: Repository, Sheet, Record, Transaction, Store, Index
 ├── deferred.md           # Features intentionally not in scope for v1.0
 ├── api/                  # Per-symbol API contracts

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -105,3 +105,10 @@ These belong to the library and are not consumer concerns:
 [Issue #127](https://github.com/JarvusInnovations/gitsheets/issues/127) tracks swapping the hologit JS dependency for a Rust `holo-tree` crate via `napi-rs`, for ~100x faster tree operations on the hot path. **This is an internal-engine change with no public-API impact** — consumers see no difference, only performance. That constraint is load-bearing: the migration must sit entirely behind the existing `Repository` / `Sheet` / `Transaction` surface, with no consumer-visible change.
 
 It stays deferred because the substrate swap is its own substantial track — it touches every tree-mutation site and benefits from a dedicated review cycle. v1.0, v1.1, and v1.2 all shipped on the JS hologit substrate; the migration targets a future minor when scheduled. The work is tracked as plans in [`plans/`](../plans/) — beginning with the [`holo-tree-napi-spike`](../plans/holo-tree-napi-spike.md) validation spike, which hardens the upstream Rust libs before any full swap — rather than as a backlog note.
+
+The tree-ops migration is **phase 1** of a larger evolution toward a Rust-core
+engine with thin per-language bindings (Node, then Python). The target
+architecture — what lives in the core vs the binding, the bytes-authority
+principle, embedded-code execution, and the canonical-form re-baseline — is
+specified in [`rust-core.md`](rust-core.md), and the full build-out is the plan
+DAG in [`plans/`](../plans/).

--- a/specs/rust-core.md
+++ b/specs/rust-core.md
@@ -1,0 +1,156 @@
+# Rust core & language bindings (v-next target architecture)
+
+**Status: target / direction.** This spec records committed architectural
+*decisions* for gitsheets' evolution into a Rust-core engine with thin
+language bindings. It is forward-looking: most of it is **not yet implemented**,
+and a spec-drift audit will (correctly) report it as unimplemented. The build-out
+is tracked as a plan DAG in [`plans/`](../plans/) (see [Phasing](#phasing)). It
+extends the substrate evolution begun by the holo-tree migration
+([#127](https://github.com/JarvusInnovations/gitsheets/issues/127),
+[`architecture.md`](architecture.md)).
+
+## Goal
+
+gitsheets should eventually be consumable from **more than one language** (Node.js
+first, **Python** next, others later). The way to get there without
+re-implementing — or worse, *diverging* — the engine per language is a single
+**Rust core** that owns the engine, with **thin per-language bindings** that only
+adapt it to each host's idioms.
+
+## The load-bearing principle: the bytes-authority lives in the core
+
+> **Anything that determines on-disk bytes, or must be identical across bindings,
+> lives in the Rust core. Anything that is purely a host language's API ergonomics
+> or the consumer's own types lives in the binding.**
+
+The on-disk form is a **contract every binding must agree on byte-for-byte**. If
+Node and Python each owned TOML serialization, normalization, path rendering, or
+validation, the *same logical write from two bindings would produce different
+commits* → divergence. That is unacceptable, and it is the principle that decides
+every "core vs binding" question below.
+
+This reverses the single-binding-era guidance (which kept serialization in JS):
+under multi-binding, centralizing the bytes-authority is mandatory, not optional.
+
+## Division of labor
+
+### Rust core (`gitsheets-core`)
+
+Owns everything bytes-determining or consistency-critical:
+
+- Tree / blob / commit operations (via holo-tree; shipped as `@hologit/holo-tree`).
+- **TOML parse + serialize** (`toml` / `toml_edit`).
+- **Normalization** — key sorting, byte-stable canonical form.
+- **Path-template rendering** (record → path), including partition derivations.
+- **Persisted-shape validation** (JSON Schema).
+- **Definition-embedded logic execution** — see [Embedded code](#embedded-code-execution).
+- Query traversal + filtering; secondary indexing.
+- Diff + patch semantics (RFC 7396 / RFC 6902).
+- The `Sheet` / `Transaction` / `Store` state machine.
+
+### Language binding (thin: `node`, `python`, …)
+
+Owns only what is genuinely host-specific:
+
+- Idiomatic API surface (naming, async conventions).
+- **Marshalling** native objects ↔ the core value type, preserving type fidelity
+  (TOML datetime → JS `Date` / Python `datetime`; integer vs float).
+- The **consumer-supplied runtime validator** hook (Standard Schema / Zod in JS,
+  Pydantic in Python). This runs on the *native* object and is *allowed* to be
+  language-specific — it is the consumer's app concern, not the store's contract.
+- Error-variant → idiomatic-exception mapping.
+
+The one real subtlety is the write order: native object → **binding** runs the
+consumer validator → marshal to core value → **core** does shape-validation +
+normalize + serialize + write.
+
+## The FFI boundary
+
+- **Records cross as a typed core value, not JSON.** JSON flattens TOML datetimes
+  to strings and blurs integer/float. The core value type preserves TOML's types;
+  each binding maps it idiomatically (napi-rs / pyo3 both support custom
+  conversions).
+- **Batch at the boundary.** Bulk APIs (`upsertMany`, `queryAll`) cross the FFI
+  *once* with an array; the whole batch is parsed/serialized and the tree built
+  natively in Rust. This is where the core most rewards bulk-write workloads —
+  versus per-record marshalling + per-record tree writes.
+
+## Embedded code execution
+
+Some behavior is **embedded in the sheet definition** itself — today, raw-JS sort
+comparators (`Sheet.<field>.sort` string rules, run via `node:vm`); plausibly
+later, partition-path derivations and custom validation expressions. Embedded
+code is the one thing that does **not** portability-flatten the way TOML bytes do:
+a definition-embedded snippet must produce identical results under every binding.
+
+The resolution is two-part:
+
+1. **Declarative-first, native in the core.** The common cases stay *data, not
+   code* and are evaluated natively in Rust: `${{ field }}` path substitution,
+   `{field: ASC}` sort directives, JSON-Schema validation, built-in partition
+   derivations (date-parts, hashing, bucketing). This already mirrors how
+   `Sheet`'s sorter treats `true`/`false`/array/`{field:dir}` declaratively and
+   reserves raw JS only as an escape hatch.
+
+2. **JS escape-hatch via an embedded engine *in the core*.** When a definition
+   genuinely needs arbitrary logic, it runs in a JS engine **embedded in the Rust
+   core** — *not* the host binding's JS runtime. Running it in the core is what
+   keeps it portable: a Python consumer gets the *core's* engine, so Node and
+   Python produce identical results. The engine + each definition's compiled
+   snippets are held **persistently** on the `Sheet`/`Store` handle (compile once
+   on open, reuse across every operation; no per-op re-parse).
+
+**Engine choice** (decided when the plan is picked up): a small embeddable engine
+— `rquickjs` (QuickJS) for maturity, or `boa_engine` (pure-Rust, no C toolchain →
+trivial cross-platform prebuilds). Full V8 is overkill for snippet evaluation.
+
+**Two constraints this creates:**
+
+- **Thread-confinement.** Embedded JS contexts are single-threaded (`!Send`).
+  The persistent context is pinned to the `Store`'s owning thread — the same
+  thread-model discipline holo-tree's cache already needs.
+- **The engine is part of the canonical-behavior contract.** Sort order and
+  partition paths depend on its JS semantics, so the **engine version is pinned**
+  and an upgrade is treated like a normalization change (same discipline as the
+  TOML serializer and the validator).
+
+## Canonical-form rebaseline
+
+Moving TOML serialization to the Rust `toml`/`toml_edit` stack changes the
+canonical bytes (at minimum integer-underscore: `31_618` → `31618`). gitsheets
+always serializes *fresh* from an object, so `toml_edit`'s format-preserving "0%
+churn" does not apply — expect the integer normalization. This is a **deliberate
+one-time re-baseline**:
+
+- **Decision: do it, and do it while gitsheets effectively has a single user.**
+  The blast radius (re-normalizing existing repos) only grows with adoption.
+- It is a documented change to [`behaviors/normalization.md`](behaviors/normalization.md)
+  plus a single re-normalize commit per repo.
+- Measurements behind this decision:
+  [#196](https://github.com/JarvusInnovations/gitsheets/issues/196).
+
+## Phasing
+
+The DAG in [`plans/`](../plans/) realizes this in dependency order. The
+load-bearing sequencing rule: **the bytes-authority must land before a second
+binding exists**, or Node and Python will disagree on bytes.
+
+1. **Tree ops in Rust** — `@hologit/holo-tree` binding; tree/blob/commit move off
+   hologit JS, TOML stays JS, behind the unchanged public API.
+   (`holo-tree-napi-spike` → `holo-tree-migration`.)
+2. **Bytes-authority core** — establish `gitsheets-core`; move TOML +
+   normalization, path templates, shape validation, and definition-embedded logic
+   into it; execute the rebaseline. This is the gate for multi-binding.
+3. **Engine + thin bindings** — record engine (CRUD/query/index/diff), the
+   `Sheet`/`Transaction`/`Store` state machine, re-thin the Node binding, add the
+   Python binding.
+
+## Non-negotiables (carried from the existing specs)
+
+- **No consumer-visible public-API change** for the Node surface across the
+  migration (per [`architecture.md`](architecture.md) / #127). The bytes
+  re-baseline is the one deliberate, documented exception, gated on the rebaseline
+  decision above.
+- Parity passes are required wherever a Rust component replaces a JS one with
+  observable output: the TOML serializer (#196), the JSON-Schema validator vs
+  `ajv`, and the embedded engine vs `node:vm`.


### PR DESCRIPTION
Captures the v-next direction worked out in design discussion: gitsheets evolving
into a **Rust-core engine with thin per-language bindings** (Node, then Python).
This is a specs+plans PR — no code; it maps the whole build-out.

## Spec: `specs/rust-core.md` (forward-looking target)

The load-bearing principle: **anything that determines on-disk bytes, or must be
identical across bindings, lives in the Rust core; anything that's purely a host
language's API ergonomics or the consumer's own types lives in the binding.**
Multi-binding makes centralizing the bytes-authority mandatory — Node and Python
writing the same record must emit byte-identical commits.

It specifies:
- **Division of labor** — core owns TOML parse+serialize, normalization, path
  templates, shape validation, definition-embedded logic, query/index, diff/patch,
  and the Sheet/Transaction/Store state machine; bindings own only API ergonomics,
  native marshalling, the consumer validator, and error mapping.
- **The FFI boundary** — records cross as a typed, TOML-faithful value (not JSON,
  which flattens dates); batch at the boundary.
- **Embedded code** — declarative-first, with a JS engine **embedded in the core**
  for the escape-hatch, so definition-embedded snippets stay portable across all
  bindings (a Python consumer gets the core's engine). Engine version is pinned as
  part of the canonical-behavior contract.
- **Canonical-form re-baseline** — adopt the Rust serializer's form (integer
  underscores, per #196); do it while gitsheets effectively has one user.

## Plans: a 10-node DAG (8 new)

```mermaid
graph TB
  holo_tree_napi_spike("holo-tree-napi-spike ✓") --> holo_tree_migration("holo-tree-migration")
  holo_tree_migration --> gitsheets_core_foundation("gitsheets-core-foundation")
  gitsheets_core_foundation --> toml_canonical_core("toml-canonical-core")
  gitsheets_core_foundation --> definition_logic_core("definition-logic-core")
  toml_canonical_core --> canonical_rebaseline("canonical-rebaseline")
  toml_canonical_core --> record_engine_core("record-engine-core")
  definition_logic_core --> record_engine_core
  record_engine_core --> sheet_store_core("sheet-store-core")
  sheet_store_core --> node_binding_thin("node-binding-thin")
  canonical_rebaseline --> node_binding_thin
  sheet_store_core --> python_binding("python-binding")
```

**Phasing:** (1) tree ops in Rust — `holo-tree-migration`; (2) bytes-authority core
+ rebaseline — `gitsheets-core-foundation` → TOML/normalization, definition-logic,
record engine; (3) engine + thin bindings — `sheet-store-core` → re-thin Node, add
Python. The sequencing rule baked into the deps: **the bytes-authority must land
before binding #2 exists.**

Also clears `holo-tree-migration`'s `awaits` — `@hologit/holo-tree@0.1.1` is now
published, so it's the ready root that unblocks all eight.

## Notes for review

- `rust-core.md` is explicitly **forward-looking** — a spec-drift audit will report
  it unimplemented; that's expected for a target spec, the build-out is the DAG.
- Parity passes are called out wherever Rust replaces JS with observable output:
  the TOML serializer (#196), the JSON-Schema validator vs `ajv`, the embedded
  engine vs `node:vm`.
- Open decisions are folded into the relevant plans' Risks (core fatness, ajv
  parity, rebaseline timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)