### PR TITLE
feat(core): migrate tree ops to @hologit/holo-tree (#127)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,68 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@hologit/holo-tree": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree/-/holo-tree-0.1.1.tgz",
+      "integrity": "sha512-WrezDbkZcS4lrjR9nA9v30D38MgUBdvIqhSjb9Mnj0Ie+UQAaBEHGbR8H1+YdOZS/iCkKApCMtWVshKrdvrAdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@hologit/holo-tree-darwin-arm64": "0.1.1",
+        "@hologit/holo-tree-linux-x64-gnu": "0.1.1",
+        "@hologit/holo-tree-win32-x64-msvc": "0.1.1"
+      }
+    },
+    "node_modules/@hologit/holo-tree-darwin-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-arm64/-/holo-tree-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-SFycKBrYgY5XeEgJfEEAaF6xo3CIOTsgWEM6gb0fGmc/f/KQ+d2MnoSOMfIZHAakUu9CUJvIT2JziQlZ3czckg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-linux-x64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.1.1.tgz",
+      "integrity": "sha512-eopPdX3HilYzGqko/lKY+k5qQEKI4dp5rcX/6q3dSEOA/EoBgctMH86/LUqh2ksxB5FOIE+m1Fn4W3UPtsOyYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-win32-x64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-win32-x64-msvc/-/holo-tree-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-AyuS6PpUiv+jnFXV10ISPhwvieoB4dlNHDGNcsivqukXfSlwSVWoR194wrANqc5S3m2/vwP7Ybpt8Hmdr212Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -3524,6 +3586,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
+        "@hologit/holo-tree": "^0.1.1",
         "@iarna/toml": "^2.2.5",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,6 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
+    "@hologit/holo-tree": "^0.1.1",
     "@iarna/toml": "^2.2.5",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/gitsheets/src/substrate.ts
+++ b/packages/gitsheets/src/substrate.ts
@@ -1,0 +1,75 @@
+// Tree substrate — the seam between gitsheets and its git-object backend.
+//
+// gitsheets is migrating its tree/commit operations off the hologit JS
+// dependency onto the published Rust binding `@hologit/holo-tree` (#127). The
+// binding currently exposes only a narrow surface
+// (`Repo.open`/`createTreeFromRef`/`createTree`/`commitTree`/`updateRef` +
+// `Tree.writeChild`/`writeChildBytes`/`readBlob`/`deleteChildDeep`/`write` +
+// `emptyTreeHash`), so the migration proceeds site by site. This module owns
+// the binding import and the operations migrated so far; everything not yet
+// covered stays on hologit / git shell-outs in its original site.
+//
+// See plans/holo-tree-migration.md and specs/rust-core.md.
+
+import { Repo as HoloRepo, type Signature } from '@hologit/holo-tree';
+
+import type { Author } from './transaction.js';
+
+/**
+ * Substrate selector. The holo-tree binding is the default path for the
+ * operations migrated so far; setting `GITSHEETS_COMMIT_SUBSTRATE=git` forces
+ * the legacy git shell-out path, keeping both paths exercisable during the
+ * migration. Any value other than `git` (including unset) selects holo-tree.
+ */
+export function useHoloTreeCommit(): boolean {
+  return process.env['GITSHEETS_COMMIT_SUBSTRATE'] !== 'git';
+}
+
+/**
+ * Build a holo-tree `Signature` from a gitsheets `Author`, capturing the
+ * current wall-clock time in the machine's local timezone offset — matching
+ * what `git commit-tree` records when `GIT_*_DATE` is unset (the prior
+ * behavior). `timeSeconds`/`offsetMinutes` are passed explicitly because the
+ * binding otherwise defaults to UTC.
+ */
+export function toSignature(author: Author, timeSeconds: number, offsetMinutes: number): Signature {
+  return {
+    name: author.name,
+    email: author.email,
+    timeSeconds,
+    offsetMinutes,
+  };
+}
+
+/**
+ * Create a commit object via the holo-tree binding and return its hash.
+ *
+ * `treeHash` must already exist in the repo's object database (gitsheets writes
+ * it via the existing tree `write()` before calling this). The binding opens
+ * the same `gitDir`, so the freshly written loose tree object is visible.
+ *
+ * A fresh `Repo` handle is opened per call: commits are infrequent (one per
+ * transaction) and a fresh handle sidesteps any object-cache staleness against
+ * loose objects written since a cached handle was opened.
+ */
+export function commitTreeViaHoloTree(opts: {
+  gitDir: string;
+  treeHash: string;
+  parents: readonly string[];
+  message: string;
+  author: Author;
+  committer: Author;
+}): string {
+  const now = Math.floor(Date.now() / 1000);
+  // getTimezoneOffset returns minutes that local is *behind* UTC (UTC - local),
+  // so negate to get git's "+HHMM"-style offset (minutes ahead of UTC).
+  const offsetMinutes = -new Date().getTimezoneOffset();
+  const repo = HoloRepo.open(opts.gitDir);
+  return repo.commitTree(
+    opts.treeHash,
+    [...opts.parents],
+    opts.message,
+    toSignature(opts.author, now, offsetMinutes),
+    toSignature(opts.committer, now, offsetMinutes),
+  );
+}

--- a/packages/gitsheets/src/substrate.ts
+++ b/packages/gitsheets/src/substrate.ts
@@ -6,23 +6,47 @@
 // (`Repo.open`/`createTreeFromRef`/`createTree`/`commitTree`/`updateRef` +
 // `Tree.writeChild`/`writeChildBytes`/`readBlob`/`deleteChildDeep`/`write` +
 // `emptyTreeHash`), so the migration proceeds site by site. This module owns
-// the binding import and the operations migrated so far; everything not yet
+// the binding load and the operations migrated so far; everything not yet
 // covered stays on hologit / git shell-outs in its original site.
 //
 // See plans/holo-tree-migration.md and specs/rust-core.md.
 
-import { Repo as HoloRepo, type Signature } from '@hologit/holo-tree';
+// Type-only import: erased at compile time, so merely importing gitsheets never
+// loads the native addon. The runtime load is the dynamic import in
+// `loadHoloTree()` below.
+import type { Signature } from '@hologit/holo-tree';
 
 import type { Author } from './transaction.js';
 
+type HoloModule = typeof import('@hologit/holo-tree');
+
+let cached: HoloModule | null | undefined;
+
 /**
- * Substrate selector. The holo-tree binding is the default path for the
- * operations migrated so far; setting `GITSHEETS_COMMIT_SUBSTRATE=git` forces
- * the legacy git shell-out path, keeping both paths exercisable during the
- * migration. Any value other than `git` (including unset) selects holo-tree.
+ * Lazily load the holo-tree binding, or return `null` to signal "use the legacy
+ * git path". Returns `null` when:
+ *
+ * - `GITSHEETS_COMMIT_SUBSTRATE=git` forces the legacy shell-out, or
+ * - the native addon can't load on this platform. `@hologit/holo-tree` ships
+ *   prebuilds only for linux-x64-gnu / darwin-arm64 / win32-x64-msvc; on any
+ *   other platform (Alpine/musl, linux-arm64, …) the load fails and gitsheets
+ *   **gracefully falls back to git** rather than becoming unimportable.
+ *
+ * The result is cached (including the `null` outcome) so the probe happens once.
  */
-export function useHoloTreeCommit(): boolean {
-  return process.env['GITSHEETS_COMMIT_SUBSTRATE'] !== 'git';
+export async function loadHoloTree(): Promise<HoloModule | null> {
+  if (cached !== undefined) return cached;
+  if (process.env['GITSHEETS_COMMIT_SUBSTRATE'] === 'git') {
+    cached = null;
+    return cached;
+  }
+  try {
+    cached = await import('@hologit/holo-tree');
+  } catch {
+    // Unsupported platform / missing prebuilt — fall back to git.
+    cached = null;
+  }
+  return cached;
 }
 
 /**
@@ -42,7 +66,8 @@ export function toSignature(author: Author, timeSeconds: number, offsetMinutes: 
 }
 
 /**
- * Create a commit object via the holo-tree binding and return its hash.
+ * Create a commit object via the holo-tree binding (already loaded by the
+ * caller via {@link loadHoloTree}) and return its hash.
  *
  * `treeHash` must already exist in the repo's object database (gitsheets writes
  * it via the existing tree `write()` before calling this). The binding opens
@@ -52,19 +77,22 @@ export function toSignature(author: Author, timeSeconds: number, offsetMinutes: 
  * transaction) and a fresh handle sidesteps any object-cache staleness against
  * loose objects written since a cached handle was opened.
  */
-export function commitTreeViaHoloTree(opts: {
-  gitDir: string;
-  treeHash: string;
-  parents: readonly string[];
-  message: string;
-  author: Author;
-  committer: Author;
-}): string {
+export function commitTreeViaHoloTree(
+  holo: HoloModule,
+  opts: {
+    gitDir: string;
+    treeHash: string;
+    parents: readonly string[];
+    message: string;
+    author: Author;
+    committer: Author;
+  },
+): string {
   const now = Math.floor(Date.now() / 1000);
   // getTimezoneOffset returns minutes that local is *behind* UTC (UTC - local),
   // so negate to get git's "+HHMM"-style offset (minutes ahead of UTC).
   const offsetMinutes = -new Date().getTimezoneOffset();
-  const repo = HoloRepo.open(opts.gitDir);
+  const repo = holo.Repo.open(opts.gitDir);
   return repo.commitTree(
     opts.treeHash,
     [...opts.parents],

--- a/packages/gitsheets/src/transaction.ts
+++ b/packages/gitsheets/src/transaction.ts
@@ -9,7 +9,7 @@ import type { Repo as HologitRepo, TreeObject, Workspace } from 'hologit';
 
 import { RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
-import { commitTreeViaHoloTree, useHoloTreeCommit } from './substrate.js';
+import { commitTreeViaHoloTree, loadHoloTree } from './substrate.js';
 import type { Sheet } from './sheet.js';
 import type { StandardSchemaV1 } from './validation.js';
 
@@ -278,14 +278,16 @@ export class Transaction {
     // (#127): the tree was just flushed to the ODB by `write()`, and the
     // binding's `commitTree` writes the commit object against the same gitDir.
     // The legacy `git commit-tree` shell-out stays reachable via
-    // GITSHEETS_COMMIT_SUBSTRATE=git so both paths remain exercisable during
-    // the migration. Ref movement (next block) stays on `git update-ref`
-    // because it needs compare-and-swap, which the binding's `updateRef` does
-    // not yet expose. See plans/holo-tree-migration.md.
+    // GITSHEETS_COMMIT_SUBSTRATE=git, and is also the automatic fallback when
+    // the binding can't load on this platform (loadHoloTree() → null). Ref
+    // movement (next block) stays on `git update-ref` because it needs
+    // compare-and-swap, which the binding's `updateRef` does not yet expose.
+    // See plans/holo-tree-migration.md.
     let commitHash: string;
-    if (useHoloTreeCommit()) {
+    const holo = await loadHoloTree();
+    if (holo) {
       try {
-        commitHash = commitTreeViaHoloTree({
+        commitHash = commitTreeViaHoloTree(holo, {
           gitDir,
           treeHash,
           parents: this.#parentCommitHash ? [this.#parentCommitHash] : [],

--- a/packages/gitsheets/src/transaction.ts
+++ b/packages/gitsheets/src/transaction.ts
@@ -9,6 +9,7 @@ import type { Repo as HologitRepo, TreeObject, Workspace } from 'hologit';
 
 import { RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
+import { commitTreeViaHoloTree, useHoloTreeCommit } from './substrate.js';
 import type { Sheet } from './sheet.js';
 import type { StandardSchemaV1 } from './validation.js';
 
@@ -273,27 +274,54 @@ export class Transaction {
 
     const message = formatCommitMessage(this.#message, this.#trailers);
 
+    // Commit-object creation is migrated onto the @hologit/holo-tree binding
+    // (#127): the tree was just flushed to the ODB by `write()`, and the
+    // binding's `commitTree` writes the commit object against the same gitDir.
+    // The legacy `git commit-tree` shell-out stays reachable via
+    // GITSHEETS_COMMIT_SUBSTRATE=git so both paths remain exercisable during
+    // the migration. Ref movement (next block) stays on `git update-ref`
+    // because it needs compare-and-swap, which the binding's `updateRef` does
+    // not yet expose. See plans/holo-tree-migration.md.
     let commitHash: string;
-    try {
-      const args = ['commit-tree', treeHash, '-m', message];
-      if (this.#parentCommitHash) {
-        args.push('-p', this.#parentCommitHash);
+    if (useHoloTreeCommit()) {
+      try {
+        commitHash = commitTreeViaHoloTree({
+          gitDir,
+          treeHash,
+          parents: this.#parentCommitHash ? [this.#parentCommitHash] : [],
+          message,
+          author: this.#author,
+          committer: this.#committer,
+        });
+      } catch (err) {
+        throw new TransactionError(
+          'commit_failed',
+          `holo-tree commitTree failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
       }
-      const env: NodeJS.ProcessEnv = {
-        ...process.env,
-        GIT_AUTHOR_NAME: this.#author.name,
-        GIT_AUTHOR_EMAIL: this.#author.email,
-        GIT_COMMITTER_NAME: this.#committer.name,
-        GIT_COMMITTER_EMAIL: this.#committer.email,
-      };
-      const { stdout } = await exec('git', args, { cwd: gitDir, env });
-      commitHash = stdout.trim();
-    } catch (err) {
-      throw new TransactionError(
-        'commit_failed',
-        `git commit-tree failed: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
-      );
+    } else {
+      try {
+        const args = ['commit-tree', treeHash, '-m', message];
+        if (this.#parentCommitHash) {
+          args.push('-p', this.#parentCommitHash);
+        }
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          GIT_AUTHOR_NAME: this.#author.name,
+          GIT_AUTHOR_EMAIL: this.#author.email,
+          GIT_COMMITTER_NAME: this.#committer.name,
+          GIT_COMMITTER_EMAIL: this.#committer.email,
+        };
+        const { stdout } = await exec('git', args, { cwd: gitDir, env });
+        commitHash = stdout.trim();
+      } catch (err) {
+        throw new TransactionError(
+          'commit_failed',
+          `git commit-tree failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
     }
 
     if (this.#branchRef !== null) {

--- a/plans/holo-tree-migration.md
+++ b/plans/holo-tree-migration.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: [holo-tree-napi-spike]
 specs:
   - specs/architecture.md
@@ -158,7 +158,16 @@ remaining `from 'hologit'` imports.
 
 ## Notes
 
-(Populated at closeout.)
+- **In-progress:** commit-object creation (`Transaction.finalize`) migrated onto
+  the published `@hologit/holo-tree@^0.1.1` binding (`Repo.commitTree`); all
+  other sites stay on hologit/git pending binding-surface extensions. The
+  binding's narrow surface (`commitTree`/`updateRef` + `Tree.writeChild`/
+  `readBlob`/`deleteChildDeep`/`write`) cannot yet back the read-heavy Sheet
+  sites (`getChild`/`getSubtree`/`getBlobMap`/`getChildren`/`clearChildren`/
+  `getHash`/`clone`), the `BlobObject`-returning write path, the CAS
+  `updateRef`, `resolveRef`, or `createBlob`/`writeBlobFromFile`. See the PR's
+  "Binding gaps blocking full migration" for the precise op list to add
+  upstream before the remaining sites can move.
 
 ## Follow-ups
 


### PR DESCRIPTION
Begins the [#127](https://github.com/JarvusInnovations/gitsheets/issues/127) migration of gitsheets' tree/commit operations off the **hologit (JS)** dependency onto the published Rust binding **`@hologit/holo-tree@^0.1.1`**, behind the unchanged public API. Partial by design — the binding's current surface is narrow, so most sites stay on hologit (see gaps below). Draft until the binding is extended.

Plan: [`plans/holo-tree-migration.md`](../blob/worktree-agent-ad366253ccd41fad0/plans/holo-tree-migration.md) (set to `in-progress`). Spec: [`specs/rust-core.md`](../blob/worktree-agent-ad366253ccd41fad0/specs/rust-core.md).

## What migrated

- **Commit-object creation in `Transaction.finalize()`** now goes through the binding: `Repo.open(gitDir)` + `repo.commitTree(treeHash, parents, message, author, committer)`, replacing the `git commit-tree` shell-out.
  - The tree is still flushed to the ODB by the existing hologit `tree.write()`; the binding writes the commit object against the same `gitDir`, so the freshly written loose tree object is visible.
  - **Byte-faithful:** author/committer identity and the machine-local timezone offset are passed explicitly (the binding otherwise defaults to UTC), and the formatted message bytes are written verbatim. Verified the resulting commit object directly (`git cat-file commit`) and via the suite's `git log --format=%B` + parent/HEAD assertions.
  - New isolated module `packages/gitsheets/src/substrate.ts` owns the binding import and is the seam for the ongoing migration.
  - **Both paths stay working:** `GITSHEETS_COMMIT_SUBSTRATE=git` forces the legacy `git commit-tree` path (verified: full repository + transaction suites pass under the flag too).

## What stayed on hologit / git (blocked)

Everything else — because each site needs an operation the binding does not yet expose:

- `Transaction.finalize()` **ref movement** stays on `git update-ref ref new old` (needs compare-and-swap; binding `updateRef` has none).
- `Transaction.finalize()` **no-op detection** stays on `git rev-parse <parent>^{tree}`.
- `Repository`: `createWorkspaceFromRef` / `createWorkspaceFromTreeHash` / `resolveRef` / empty-workspace bootstrap, and `workspace.root.getSubtree`/`getChildren` for sheet discovery.
- `Sheet`: all reads (`getChild`/`getSubtree`/`getBlobMap`/`getChildren`/`getHash`/`clone`/`clearChildren`), the `BlobObject`-returning `writeChild` (public `UpsertResult.blob` type), `deleteChild` existence-checks, and `diffFrom` (`git diff-tree` + `createBlob`).
- `path-template/index.ts`: `getChild`/`getChildren`/`getBlobMap` traversal.
- `cli/`: binary-attachment blob creation.

## Binding gaps blocking full migration

Precise list of operations the binding must add before the remaining sites can move. **Most already exist in the `holo-tree` Rust crate and only need napi exposure** — flagged below.

| Needed binding op | gitsheets call(s) that need it | holo-tree Rust fn | Status |
|---|---|---|---|
| `repo.updateRef(ref, hash, expectedOld?)` — **compare-and-swap** variant | `Transaction.finalize` ref movement (`git update-ref ref new old` optimistic-concurrency guard) | `repo::update_ref` (currently hardcodes `PreviousValue::Any`) | **needs new Rust:** thread a `PreviousValue::MustExistAndMatch(old)` / `MustNotExist` param |
| `repo.resolveRef(ref) -> string \| null` | `Repository.resolveRef`, `#resolveParent`, `#getWorkspace`, `Transaction.finalize` parent re-check | `repo::create_tree_from_ref` already calls `repo.rev_parse_single`; needs a peel-to-commit-hash helper | **needs new Rust** (small) |
| `tree.getChild(path) -> { type: 'tree'\|'blob'\|'commit', hash, mode } \| null` | `Sheet.#deleteInTx`/`getAttachment(s)`/`loadBody`/`willChange` existence checks; `loadConfig` | `MutableTree::get_child` (returns `&Child`) | **exists in Rust** — expose via napi (map `Child` → FFI struct) |
| `tree.getSubtree(path, createIfMissing?) -> Tree \| null` | `Sheet.#getSheetRoot`/`clear`; `Repository.#resolveDataTree`/`openSheets` | `MutableTree::get_subtree` + `get_or_create_subtree` | **exists in Rust** — expose via napi |
| `tree.getChildren() -> Record<string, {type,hash,mode}>` | `Repository.openSheets` sheet discovery; `path-template` traversal | `MutableTree::ensure_children` + `children` map | **exists in Rust** — expose via napi |
| `tree.getBlobMap() -> Record<string, {hash, mode}>` (recursive) | `Sheet.getAttachments`/`attachments`; `path-template` query | `MutableTree::get_blob_map` (→ `BlobInfo`) | **exists in Rust** — expose via napi |
| `tree.clearChildren()` (O(1) empty-subtree pointer) | `Sheet.clear` | (set `children` to empty + dirty; no dedicated fn) | **exists in Rust** (trivial) — expose via napi |
| `tree.getHash() -> string` **without** flushing dirty subtrees | `Sheet.#ensureIndexBuilt` index-cache key; `Sheet.diffFrom` dst tree; `Transaction.finalize` no-op detect | `MutableTree.hash` field (current `write()` flushes) | **needs Rust:** a non-mutating hash accessor (or document `write()` is acceptable) |
| `tree.clone() -> Tree` (independent in-memory copy) | `Sheet.clone` | `clone_child` helper exists internally | **exists in Rust** — expose a public `clone` |
| `tree.deleteChild(path)` shallow + `deleteChildDeep` (have deep) | `Sheet` attachment/record deletes (currently `deleteChild`) | `MutableTree::delete_child` (shallow) + `delete_child_deep` (already bound) | **partial:** shallow `delete_child` exists in Rust, not yet bound |
| `writeChild` returning a **blob handle** (hash + `read()`), not just hash | `Sheet.#upsertInTx` → public `UpsertResult.blob: BlobObject` | `write_child` returns `ObjectId` only | **needs design:** binding must return a blob-handle shape (or gitsheets redesigns `UpsertResult.blob` without public-API change) |
| `repo.createBlob({hash, mode}) -> BlobHandle` | `Sheet.diffFrom` (`opts.blobs`) srcBlob/dstBlob; public `DiffChange.srcBlob/dstBlob: BlobObject` | n/a (gix `find_object`) | **needs new Rust/binding** |
| `repo.writeBlobFromFile(path) -> hash` (hash a file from disk) | `cli/` binary attachments | n/a (gix `write_blob` from a file stream) | **needs new Rust/binding** |
| `tree.merge(input, {mode, files})` (overlay/replace/underlay + glob) | not yet a direct consumer site, but required to retire hologit fully | `MutableTree::merge` + `MergeOptions`/`MergeMode` | **exists in Rust** — expose via napi |
| `repo.readToml(path)` | config reads (replace the hologit `Configurable` pattern) | `toml::read_toml` | **exists in Rust** — expose via napi |
| Structured/typed errors across FFI | translate substrate failures into gitsheets' typed error classes | `holo_tree::Error` (currently stringified in napi `ht_err`) | **needs Rust:** stable error codes that survive FFI |

## Test / type-check status

- `npm run type-check` — **pass** (gitsheets + gitsheets-axi, `tsc --noEmit`).
- `npm test` — **pass**: gitsheets **287/287**, gitsheets-axi **66/66**.
- Legacy seam (`GITSHEETS_COMMIT_SUBSTRATE=git`) — repository + transaction suites **28/28** pass.
- Direct binding smoke: `repo.commitTree(...)` produces a commit `git cat-file commit` reads with the correct tree, parent, author/committer identity, and local timezone offset (`-0400`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd>
