### PR TITLE
feat(core): migrate Transaction commit + ref movement to @hologit/holo-tree (#127)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,23 +68,23 @@
       }
     },
     "node_modules/@hologit/holo-tree": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree/-/holo-tree-0.1.1.tgz",
-      "integrity": "sha512-WrezDbkZcS4lrjR9nA9v30D38MgUBdvIqhSjb9Mnj0Ie+UQAaBEHGbR8H1+YdOZS/iCkKApCMtWVshKrdvrAdQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree/-/holo-tree-0.2.0.tgz",
+      "integrity": "sha512-/BClXqjst4fhhlX9CYSSWq2sIlqpoYGwMsXBUTzKIAXKahQoahtgN1mSSysW1r6LbhRQFm7G8g2BtjsA/XKllQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@hologit/holo-tree-darwin-arm64": "0.1.1",
-        "@hologit/holo-tree-linux-x64-gnu": "0.1.1",
-        "@hologit/holo-tree-win32-x64-msvc": "0.1.1"
+        "@hologit/holo-tree-darwin-arm64": "0.2.0",
+        "@hologit/holo-tree-linux-x64-gnu": "0.2.0",
+        "@hologit/holo-tree-win32-x64-msvc": "0.2.0"
       }
     },
     "node_modules/@hologit/holo-tree-darwin-arm64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-arm64/-/holo-tree-darwin-arm64-0.1.1.tgz",
-      "integrity": "sha512-SFycKBrYgY5XeEgJfEEAaF6xo3CIOTsgWEM6gb0fGmc/f/KQ+d2MnoSOMfIZHAakUu9CUJvIT2JziQlZ3czckg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-arm64/-/holo-tree-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-aBr5sQ5fo3TTc4oHb9QJpyYgusLufxvZtBrD/dkLATPwybwjaEn2huakxzzkvcNElTj6+1nS1secXoqOPbMPpw==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@hologit/holo-tree-linux-x64-gnu": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.1.1.tgz",
-      "integrity": "sha512-eopPdX3HilYzGqko/lKY+k5qQEKI4dp5rcX/6q3dSEOA/EoBgctMH86/LUqh2ksxB5FOIE+m1Fn4W3UPtsOyYg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.2.0.tgz",
+      "integrity": "sha512-PbYQKHHlr5OqA8ehca8F9Uuqxovk38KccmM/9LhBmh9ZZKCBURik6mRTQ84cirkrFlYDcVXOvAQmUocammF9eQ==",
       "cpu": [
         "x64"
       ],
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@hologit/holo-tree-win32-x64-msvc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-win32-x64-msvc/-/holo-tree-win32-x64-msvc-0.1.1.tgz",
-      "integrity": "sha512-AyuS6PpUiv+jnFXV10ISPhwvieoB4dlNHDGNcsivqukXfSlwSVWoR194wrANqc5S3m2/vwP7Ybpt8Hmdr212Dg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-win32-x64-msvc/-/holo-tree-win32-x64-msvc-0.2.0.tgz",
+      "integrity": "sha512-5lisDIjLwGcOlFjs6IhOXs7w0luMTwUF98uJyUx/G0uxbcEzeKcACHdj7ydkKuy4+jW3MLKTjenFm68V0TGIbw==",
       "cpu": [
         "x64"
       ],
@@ -3586,7 +3586,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hologit/holo-tree": "^0.1.1",
+        "@hologit/holo-tree": "^0.2.0",
         "@iarna/toml": "^2.2.5",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
-    "@hologit/holo-tree": "^0.1.1",
+    "@hologit/holo-tree": "^0.2.0",
     "@iarna/toml": "^2.2.5",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/gitsheets/src/substrate.ts
+++ b/packages/gitsheets/src/substrate.ts
@@ -1,24 +1,28 @@
 // Tree substrate — the seam between gitsheets and its git-object backend.
 //
-// gitsheets is migrating its tree/commit operations off the hologit JS
-// dependency onto the published Rust binding `@hologit/holo-tree` (#127). The
-// binding currently exposes only a narrow surface
-// (`Repo.open`/`createTreeFromRef`/`createTree`/`commitTree`/`updateRef` +
-// `Tree.writeChild`/`writeChildBytes`/`readBlob`/`deleteChildDeep`/`write` +
-// `emptyTreeHash`), so the migration proceeds site by site. This module owns
-// the binding load and the operations migrated so far; everything not yet
-// covered stays on hologit / git shell-outs in its original site.
+// gitsheets is migrating its tree/commit/ref operations off the hologit JS
+// dependency onto the published Rust binding `@hologit/holo-tree@^0.2.0`
+// (#127). The migration proceeds site by site. This module owns the binding
+// load and the commit-object + ref operations migrated so far; the working-tree
+// read/write/navigation surface (`Sheet` / `path-template`) still goes through
+// hologit's `Workspace`/`TreeObject` — see the migration plan for why it can't
+// move yet (the 0.2.0 `Tree.deleteChildDeep` flush bug).
+//
+// When the native addon can't load on a platform, `loadHoloTree()` returns
+// `null` and callers keep the legacy `git` shell-out path untouched.
 //
 // See plans/holo-tree-migration.md and specs/rust-core.md.
 
 // Type-only import: erased at compile time, so merely importing gitsheets never
 // loads the native addon. The runtime load is the dynamic import in
 // `loadHoloTree()` below.
-import type { Signature } from '@hologit/holo-tree';
+import type { Repo as BindingRepo, Signature } from '@hologit/holo-tree';
 
 import type { Author } from './transaction.js';
 
 type HoloModule = typeof import('@hologit/holo-tree');
+
+export type { BindingRepo };
 
 let cached: HoloModule | null | undefined;
 
@@ -49,6 +53,11 @@ export async function loadHoloTree(): Promise<HoloModule | null> {
   return cached;
 }
 
+/** Open a binding `Repo` handle at `gitDir`. */
+export function openBindingRepo(holo: HoloModule, gitDir: string): BindingRepo {
+  return holo.Repo.open(gitDir);
+}
+
 /**
  * Build a holo-tree `Signature` from a gitsheets `Author`, capturing the
  * current wall-clock time in the machine's local timezone offset — matching
@@ -66,21 +75,16 @@ export function toSignature(author: Author, timeSeconds: number, offsetMinutes: 
 }
 
 /**
- * Create a commit object via the holo-tree binding (already loaded by the
- * caller via {@link loadHoloTree}) and return its hash.
+ * Create a commit object via the holo-tree binding and return its hash.
  *
  * `treeHash` must already exist in the repo's object database (gitsheets writes
- * it via the existing tree `write()` before calling this). The binding opens
- * the same `gitDir`, so the freshly written loose tree object is visible.
- *
- * A fresh `Repo` handle is opened per call: commits are infrequent (one per
- * transaction) and a fresh handle sidesteps any object-cache staleness against
- * loose objects written since a cached handle was opened.
+ * it via the existing tree `write()` before calling this); `repo` is the same
+ * binding handle gitsheets resolves the parent/ref through, so the freshly
+ * written loose tree object is visible.
  */
-export function commitTreeViaHoloTree(
-  holo: HoloModule,
+export function commitTreeWithRepo(
+  repo: BindingRepo,
   opts: {
-    gitDir: string;
     treeHash: string;
     parents: readonly string[];
     message: string;
@@ -92,7 +96,6 @@ export function commitTreeViaHoloTree(
   // getTimezoneOffset returns minutes that local is *behind* UTC (UTC - local),
   // so negate to get git's "+HHMM"-style offset (minutes ahead of UTC).
   const offsetMinutes = -new Date().getTimezoneOffset();
-  const repo = holo.Repo.open(opts.gitDir);
   return repo.commitTree(
     opts.treeHash,
     [...opts.parents],

--- a/packages/gitsheets/src/transaction.ts
+++ b/packages/gitsheets/src/transaction.ts
@@ -9,7 +9,7 @@ import type { Repo as HologitRepo, TreeObject, Workspace } from 'hologit';
 
 import { RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
-import { commitTreeViaHoloTree, loadHoloTree } from './substrate.js';
+import { commitTreeWithRepo, loadHoloTree, openBindingRepo } from './substrate.js';
 import type { Sheet } from './sheet.js';
 import type { StandardSchemaV1 } from './validation.js';
 
@@ -221,19 +221,38 @@ export class Transaction {
   async finalize<T>(value: T): Promise<TransactionResult<T>> {
     this.#closed = true;
 
+    const noChange: TransactionResult<T> = {
+      value,
+      commitHash: null,
+      treeHash: null,
+      ref: null,
+      parentCommitHash: this.#parentCommitHash,
+    };
+
     if (!this.#anyMutation) {
-      return {
-        value,
-        commitHash: null,
-        treeHash: null,
-        ref: null,
-        parentCommitHash: this.#parentCommitHash,
-      };
+      return noChange;
     }
 
-    // Optimistic concurrency: re-check the parent ref hasn't moved.
+    const gitDir = this.#hologitRepo.gitDir;
+
+    // The holo-tree binding (#127) backs commit-object creation, the no-op
+    // tree-hash probe, the parent-moved check, and compare-and-swap ref
+    // movement. The working tree itself (`workspace.root`) stays on hologit
+    // for now — only the commit/ref tail of finalize is migrated. When the
+    // binding can't load on this platform (or GITSHEETS_COMMIT_SUBSTRATE=git),
+    // `binding` is null and the legacy `git` shell-out path runs end-to-end.
+    // See plans/holo-tree-migration.md.
+    const holo = await loadHoloTree();
+    const binding = holo ? openBindingRepo(holo, gitDir) : null;
+
+    // Optimistic concurrency: re-check the parent ref hasn't moved. The CAS
+    // `updateRef` below is the actual race guard; this pre-check just surfaces
+    // the friendlier `parent_moved` error (and an early exit) before we bother
+    // writing a commit object.
     if (this.#parentRef !== null) {
-      const current = await this.#hologitRepo.resolveRef(this.#parentRef);
+      const current = binding
+        ? binding.resolveRef(this.#parentRef)
+        : await this.#hologitRepo.resolveRef(this.#parentRef);
       if (current !== this.#parentCommitHash) {
         throw new TransactionError(
           'parent_moved',
@@ -242,53 +261,33 @@ export class Transaction {
       }
     }
 
-    const gitDir = this.#hologitRepo.gitDir;
     const treeHash = await this.#workspace.root.write();
 
     // No-op detection: if the resulting tree-hash matches the parent
-    // commit's tree-hash, nothing actually changed. Skip the commit-tree
-    // spawn + ref update — same return shape as the `!#anyMutation` path
-    // above. The `#anyMutation` flag tracks "a mutating method was
-    // called," which over-approximates: clear() on an already-empty
-    // sheet, upsert() of byte-identical content, and bulk reimport-with-
-    // unchanged-data patterns all set the flag without changing the
-    // tree. Tree-hash equality is the canonical git-native truth.
-    // See specs/api/transaction.md#no-op-detection.
+    // commit's tree-hash, nothing actually changed. Skip the commit + ref
+    // update — same return shape as the `!#anyMutation` path above. The
+    // `#anyMutation` flag tracks "a mutating method was called," which
+    // over-approximates: clear() on an already-empty sheet, upsert() of
+    // byte-identical content, and bulk reimport-with-unchanged-data patterns
+    // all set the flag without changing the tree. Tree-hash equality is the
+    // canonical git-native truth. See specs/api/transaction.md#no-op-detection.
     if (this.#parentCommitHash !== null) {
-      const { stdout: parentTreeStdout } = await exec(
-        'git',
-        ['rev-parse', `${this.#parentCommitHash}^{tree}`],
-        { cwd: gitDir },
-      );
-      const parentTreeHash = parentTreeStdout.trim();
+      const parentTreeHash = binding
+        ? binding.createTreeFromRef(this.#parentCommitHash).write()
+        : (
+            await exec('git', ['rev-parse', `${this.#parentCommitHash}^{tree}`], { cwd: gitDir })
+          ).stdout.trim();
       if (parentTreeHash === treeHash) {
-        return {
-          value,
-          commitHash: null,
-          treeHash: null,
-          ref: null,
-          parentCommitHash: this.#parentCommitHash,
-        };
+        return noChange;
       }
     }
 
     const message = formatCommitMessage(this.#message, this.#trailers);
 
-    // Commit-object creation is migrated onto the @hologit/holo-tree binding
-    // (#127): the tree was just flushed to the ODB by `write()`, and the
-    // binding's `commitTree` writes the commit object against the same gitDir.
-    // The legacy `git commit-tree` shell-out stays reachable via
-    // GITSHEETS_COMMIT_SUBSTRATE=git, and is also the automatic fallback when
-    // the binding can't load on this platform (loadHoloTree() → null). Ref
-    // movement (next block) stays on `git update-ref` because it needs
-    // compare-and-swap, which the binding's `updateRef` does not yet expose.
-    // See plans/holo-tree-migration.md.
     let commitHash: string;
-    const holo = await loadHoloTree();
-    if (holo) {
+    if (binding) {
       try {
-        commitHash = commitTreeViaHoloTree(holo, {
-          gitDir,
+        commitHash = commitTreeWithRepo(binding, {
           treeHash,
           parents: this.#parentCommitHash ? [this.#parentCommitHash] : [],
           message,
@@ -327,18 +326,37 @@ export class Transaction {
     }
 
     if (this.#branchRef !== null) {
-      try {
-        const args = ['update-ref', this.#branchRef, commitHash];
-        if (this.#parentCommitHash) {
-          args.push(this.#parentCommitHash);
+      if (binding) {
+        try {
+          // CAS: only advance the ref if it still points at the parent commit
+          // (undefined expected-old → unconditional, for a fresh branch) —
+          // matching `git update-ref <ref> <new> [<old>]`.
+          binding.updateRef(
+            this.#branchRef,
+            commitHash,
+            this.#parentCommitHash ?? undefined,
+          );
+        } catch (err) {
+          throw new TransactionError(
+            'commit_failed',
+            `holo-tree updateRef ${this.#branchRef} failed: ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err },
+          );
         }
-        await exec('git', args, { cwd: gitDir });
-      } catch (err) {
-        throw new TransactionError(
-          'commit_failed',
-          `git update-ref ${this.#branchRef} failed: ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
-        );
+      } else {
+        try {
+          const args = ['update-ref', this.#branchRef, commitHash];
+          if (this.#parentCommitHash) {
+            args.push(this.#parentCommitHash);
+          }
+          await exec('git', args, { cwd: gitDir });
+        } catch (err) {
+          throw new TransactionError(
+            'commit_failed',
+            `git update-ref ${this.#branchRef} failed: ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err },
+          );
+        }
       }
     }
 

--- a/plans/holo-tree-migration.md
+++ b/plans/holo-tree-migration.md
@@ -158,17 +158,60 @@ remaining `from 'hologit'` imports.
 
 ## Notes
 
-- **In-progress:** commit-object creation (`Transaction.finalize`) migrated onto
-  the published `@hologit/holo-tree@^0.1.1` binding (`Repo.commitTree`); all
-  other sites stay on hologit/git pending binding-surface extensions. The
-  binding's narrow surface (`commitTree`/`updateRef` + `Tree.writeChild`/
-  `readBlob`/`deleteChildDeep`/`write`) cannot yet back the read-heavy Sheet
-  sites (`getChild`/`getSubtree`/`getBlobMap`/`getChildren`/`clearChildren`/
-  `getHash`/`clone`), the `BlobObject`-returning write path, the CAS
-  `updateRef`, `resolveRef`, or `createBlob`/`writeBlobFromFile`. See the PR's
-  "Binding gaps blocking full migration" for the precise op list to add
-  upstream before the remaining sites can move.
+- **In-progress.** The binding is now on `@hologit/holo-tree@^0.2.0`, which
+  exposes the full surface this plan needs (`getChild`/`getChildren`/
+  `getBlobMap`/`clearChildren`/`merge`, `resolveRef`/`writeBlob`, CAS
+  `updateRef`). Migrated so far in `Transaction.finalize`:
+  - **commit-object creation** — `Repo.commitTree` (reuses the workspace's
+    binding `Repo` handle).
+  - **ref movement** — `git update-ref` → binding `updateRef` with real
+    compare-and-swap (expected-old = parent commit).
+  - **no-op detection** — `git rev-parse <parent>^{tree}` → binding
+    `createTreeFromRef(parent).write()`.
+  - **parent-moved pre-check** — hologit `resolveRef` → binding `resolveRef`.
+
+  The legacy `git` path stays the automatic fallback (binding can't load on a
+  platform; or `GITSHEETS_COMMIT_SUBSTRATE=git`).
+
+- **Blocked: the working-tree (Sheet / path-template) migration.** Threading a
+  single binding `Tree` through the `Transaction` working tree (so Sheet/
+  path-template operate on it via deep paths) is implemented-and-reverted
+  because of an **upstream `@hologit/holo-tree@0.2.0` bug**: on a tree obtained
+  from `createTreeFromRef`, `Tree.deleteChildDeep(path)` updates the in-memory
+  view (`getChild` returns `null`) but does **not** dirty the path's ancestors,
+  so a subsequent `write()` returns the *original* tree hash — the deletion is
+  silently dropped. `writeChild` and `clearChildren` flush correctly; only
+  `deleteChildDeep` is broken. This breaks every Sheet delete/rename-cleanup/
+  attachment-cascade path the moment the working tree is binding-backed, and no
+  gitsheets-side workaround is safe (rebuilding a parent from `getBlobMap` loses
+  nested subtrees + modes and is O(n) per delete). Per the plan's
+  governing principle, this gets **fixed upstream in holo-tree**
+  (`deleteChildDeep` must mark ancestors dirty), then the working-tree thread
+  - Sheet/path-template migration lands against the fixed release.
+
+- **`UpsertResult.blob: BlobObject` (public type) keeps hologit.** Even after
+  the working-tree thread lands, the published `.d.ts` references hologit's
+  `BlobObject`/`TreeObject` types in the public surface (`UpsertResult.blob`,
+  `getAttachment(s)`, `diffFrom` `srcBlob`/`dstBlob`). Fully dropping the
+  hologit dependency therefore requires a gitsheets-owned blob/tree handle type
+  to replace those in the public API — a separate increment, since the
+  no-public-API-change constraint forbids swapping the type here.
+
+- **Staying on git/hologit by design** (per #127): `Sheet.diffFrom`'s
+  record-level diff (`git diff-tree` + `repo.createBlob`), `git var GIT_EDITOR`
+  / the CLI `$EDITOR` flow, and `Workspace.writeWorkingChanges` (unused by
+  gitsheets today).
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Upstream:** fix `@hologit/holo-tree` `Tree.deleteChildDeep` so a delete on a
+  `createTreeFromRef`-loaded tree dirties ancestors and is reflected by
+  `write()`; cut the next release. (Hard blocker for the working-tree thread.)
+- **gitsheets:** once the fix ships, thread a single binding `Tree` through the
+  `Transaction` working tree and route Sheet/path-template `getChild`/
+  `getSubtree`/`getBlobMap`/`getChildren`/`writeChild`/`deleteChild`/
+  `clearChildren`/`getHash`/`clone` + the CLI attachment writes
+  (`writeChildBytes`) through it via deep paths.
+- **gitsheets:** introduce a gitsheets-owned blob/tree handle type so the
+  public API no longer references hologit's `BlobObject`/`TreeObject`, unblocking
+  full removal of the hologit dependency for tree ops.


### PR DESCRIPTION
## Summary

Advances the holo-tree migration (#127) by moving the **commit + ref-movement tail of `Transaction.finalize`** onto the `@hologit/holo-tree@^0.2.0` binding, behind the unchanged public API. Bumps the dependency `0.1.1 → 0.2.0` (the 0.2.0 binding adds the full tree/ref surface the migration needs).

This is a **Draft / partial** increment: the working-tree (Sheet / path-template) migration is implemented-and-reverted because of an upstream binding bug (see below). The commit/ref tail never deletes through the binding, so it migrates cleanly and the full suite stays green.

## What migrated to the binding

In `Transaction.finalize` (default path; binding loaded):

- **Ref movement** — `git update-ref` → binding `updateRef` with real **compare-and-swap** (expected-old = parent commit hash), replacing the best-effort shell CAS.
- **No-op detection** — `git rev-parse <parent>^{tree}` → binding `createTreeFromRef(parent).write()`.
- **Parent-moved pre-check** — hologit `resolveRef` → binding `resolveRef`.
- **Commit-object creation** — already on the binding; now reuses the same `Repo` handle (`commitTreeWithRepo`) instead of reopening one per call.

Net: two `git` shell-outs + one hologit `resolveRef` removed from finalize, plus genuine optimistic-concurrency via CAS.

## What stays on hologit / git (and why)

- **Working tree + all Sheet / path-template tree ops** (`getChild`/`getSubtree`/`getBlobMap`/`getChildren`/`writeChild`/`deleteChild`/`clearChildren`/`getHash`/`clone`, config + record reads) — **blocked by an upstream `@hologit/holo-tree@0.2.0` bug.** On a tree from `createTreeFromRef`, `Tree.deleteChildDeep(path)` updates the in-memory view (`getChild` → `null`) but does **not** dirty the path's ancestors, so a later `write()` returns the *original* tree hash and the deletion is silently dropped. `writeChild` / `clearChildren` flush fine; only `deleteChildDeep` is broken. Repro:

  ```js
  const t = repo.createTreeFromRef(commit);  // tree has posts/tmp.md
  t.deleteChildDeep('posts/tmp.md');         // getChild → null
  t.write() === originalTreeHash;            // true (!) — deletion lost
  ```

  Threading a binding `Tree` through the working tree breaks every Sheet delete / rename-cleanup / attachment-cascade path, and no gitsheets-side workaround is safe (rebuilding a parent from `getBlobMap` loses nested subtrees + modes and is O(n) per delete). Per the migration's governing principle this gets **fixed upstream in holo-tree** first; the working-tree thread then lands against the fixed release. Tracked in the plan's Follow-ups.

- **`Sheet.diffFrom`** record-level diff — `git diff-tree` + `repo.createBlob` (out of scope per #127).
- **`UpsertResult.blob: BlobObject`** and the other public `BlobObject`/`TreeObject` return types — these reference hologit's types in the published `.d.ts`. Fully dropping hologit needs a gitsheets-owned handle type to replace them (separate increment; the no-public-API-change constraint forbids swapping the type here).
- **Editor flow** (`$EDITOR`) and `Workspace.writeWorkingChanges` (unused) — stay as-is.

## hologit fully dropped for tree ops?

**No.** The working-tree surface and the public `BlobObject`-returning paths still go through hologit, and the published types reference it. This PR removes git/hologit only from the commit/ref tail of finalize.

## Fallback preserved

The legacy `git` path remains the automatic fallback when the binding can't load on a platform, and is still forceable via `GITSHEETS_COMMIT_SUBSTRATE=git`.

## Validation

- `npm run type-check` — clean.
- `npm test` — **287 passed** (33 files) on the binding path.
- `GITSHEETS_COMMIT_SUBSTRATE=git` fallback — transaction/repository/push-daemon suites green (35 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
