### PR TITLE
feat(core): migrate working tree to @hologit/holo-tree, drop hologit (#127)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,23 +68,26 @@
       }
     },
     "node_modules/@hologit/holo-tree": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree/-/holo-tree-0.2.0.tgz",
-      "integrity": "sha512-/BClXqjst4fhhlX9CYSSWq2sIlqpoYGwMsXBUTzKIAXKahQoahtgN1mSSysW1r6LbhRQFm7G8g2BtjsA/XKllQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree/-/holo-tree-0.3.0.tgz",
+      "integrity": "sha512-QJc4KzyBBSX4tvNNlpncm0IQYbs93av3wLTpcPWH9+INSZB0FlpgA+e7Lo48vH5aOy6D4uyjTIcHJWkZJrpmfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@hologit/holo-tree-darwin-arm64": "0.2.0",
-        "@hologit/holo-tree-linux-x64-gnu": "0.2.0",
-        "@hologit/holo-tree-win32-x64-msvc": "0.2.0"
+        "@hologit/holo-tree-darwin-arm64": "0.3.0",
+        "@hologit/holo-tree-darwin-x64": "0.3.0",
+        "@hologit/holo-tree-linux-arm64-gnu": "0.3.0",
+        "@hologit/holo-tree-linux-x64-gnu": "0.3.0",
+        "@hologit/holo-tree-linux-x64-musl": "0.3.0",
+        "@hologit/holo-tree-win32-x64-msvc": "0.3.0"
       }
     },
     "node_modules/@hologit/holo-tree-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-arm64/-/holo-tree-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-aBr5sQ5fo3TTc4oHb9QJpyYgusLufxvZtBrD/dkLATPwybwjaEn2huakxzzkvcNElTj6+1nS1secXoqOPbMPpw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-arm64/-/holo-tree-darwin-arm64-0.3.0.tgz",
+      "integrity": "sha512-FDpj5Ayte31cRO9nXs2kt70CPUUkGCQ3pM1z0onCsEjIxt8DPjBgneUp47ChIYQfbDRmt7M7FecVr9BHKpq3NA==",
       "cpu": [
         "arm64"
       ],
@@ -97,10 +100,58 @@
         "node": ">=20"
       }
     },
+    "node_modules/@hologit/holo-tree-darwin-x64": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-darwin-x64/-/holo-tree-darwin-x64-0.3.0.tgz",
+      "integrity": "sha512-qIZUfch1Haft1lo+uXjt1BWWFtctqVQgtq4YBl6/LpKDiOhsPDxbgO4G5X+cqXnIqAOerzXMyDshq2Uewj6Cfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-linux-arm64-gnu": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-arm64-gnu/-/holo-tree-linux-arm64-gnu-0.3.0.tgz",
+      "integrity": "sha512-P5JQyPp0ebvD2xP4NugAcJfLsyd+K2usqkOVta6rOiI+jN9cvdtDNLS+5Vnx50obZ08dsmKgEC7Rhkrd+WsCBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@hologit/holo-tree-linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-PbYQKHHlr5OqA8ehca8F9Uuqxovk38KccmM/9LhBmh9ZZKCBURik6mRTQ84cirkrFlYDcVXOvAQmUocammF9eQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-gnu/-/holo-tree-linux-x64-gnu-0.3.0.tgz",
+      "integrity": "sha512-EOcKhsWfkCWN77soVfdBZVR+AOW/WY3gTw3kYrsGJn+B3zbj/JXp/IsJf4IxgydZArUapANNBWp1RjNVDXf6eA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hologit/holo-tree-linux-x64-musl": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-linux-x64-musl/-/holo-tree-linux-x64-musl-0.3.0.tgz",
+      "integrity": "sha512-sQSKvpnS15LivIgwLCKp8kNZMgHS54tSugoWopHFg28VQevSiqPnCtFaUAGluXBN4kfU7nH3d3bW5ckRbpJUMg==",
       "cpu": [
         "x64"
       ],
@@ -114,9 +165,9 @@
       }
     },
     "node_modules/@hologit/holo-tree-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-win32-x64-msvc/-/holo-tree-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-5lisDIjLwGcOlFjs6IhOXs7w0luMTwUF98uJyUx/G0uxbcEzeKcACHdj7ydkKuy4+jW3MLKTjenFm68V0TGIbw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hologit/holo-tree-win32-x64-msvc/-/holo-tree-win32-x64-msvc-0.3.0.tgz",
+      "integrity": "sha512-QkF/xFnrl6LGuIopMRGByjiM14n/2t5BYvTgKY+TAX9CzX2Pc+6YJY7iVymNiRI3SOELlTUgWzMCYNCEA0azWg==",
       "cpu": [
         "x64"
       ],
@@ -3586,7 +3637,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hologit/holo-tree": "^0.2.0",
+        "@hologit/holo-tree": "^0.3.0",
         "@iarna/toml": "^2.2.5",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,26 +13,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
-      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@so-ric/colorspace": "^1.1.6",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -486,16 +466,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@so-ric/colorspace": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
-      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^5.0.2",
-        "text-hex": "1.0.x"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -575,12 +545,6 @@
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
-    },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
@@ -718,18 +682,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -787,12 +739,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -802,27 +748,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
-    "node_modules/async-exit-hook": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
-      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/axi-sdk-js": {
       "version": "0.1.8",
@@ -834,61 +759,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -931,21 +801,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -977,64 +832,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/color": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
-      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^3.1.3",
-        "color-string": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
-      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/color-string": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -1043,12 +840,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1068,18 +859,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.0.tgz",
       "integrity": "sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg==",
       "license": "MIT"
-    },
-    "node_modules/debounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
-      "integrity": "sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1109,15 +888,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -1152,58 +922,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-      "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/es-module-lexer": {
       "version": "2.2.0",
@@ -1211,33 +934,6 @@
       "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1290,15 +986,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bser": "2.1.1"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1317,60 +1004,6 @@
         }
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "license": "MIT"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1384,15 +1017,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -1416,55 +1040,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/git-client": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/git-client/-/git-client-1.12.1.tgz",
-      "integrity": "sha512-Px7HE2ug+IKiOhNE/vezkwpDE7IUYHnoRHQfds2BlRf6CZglNq7lmlxVoRtprJ4ZHTq0ZWrQLZtrcMxFw18zvw==",
-      "license": "MIT",
-      "dependencies": {
-        "async-exit-hook": "^2.0.1",
-        "mz": "^2.7.0",
-        "rusha": "^0.8.14",
-        "semver": "^7.6.3"
-      }
-    },
     "node_modules/gitsheets": {
       "resolved": "packages/gitsheets",
       "link": true
@@ -1472,205 +1047,6 @@
     "node_modules/gitsheets-axi": {
       "resolved": "packages/gitsheets-axi",
       "link": true
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hab-client": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hab-client/-/hab-client-1.1.3.tgz",
-      "integrity": "sha512-CZzvibCCQqwk3XZeNh2DWotOcnGViOjTny7NQAkSZid014OGZu+gfhLmTAj2qnUxDKr/ZImRauFLorFR38IwGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.3.4",
-        "semver": "^7.3.8",
-        "underscore": "^1.13.6"
-      }
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/hologit": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/hologit/-/hologit-0.50.2.tgz",
-      "integrity": "sha512-9StuAaE8TkdnJE/cA5vdq+pwt/hZH1JGa9qsGfAz7rvwsXrVlQT/lBJd+pedpJHOJgPdA4NXC0lqljFzOWV+7A==",
-      "license": "MIT",
-      "os": [
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "async-exit-hook": "^2.0.1",
-        "axios": "^1.14.0",
-        "chokidar": "^5.0.0",
-        "debounce": "^3.0.0",
-        "fb-watchman": "^2.0.2",
-        "git-client": "^1.12.0",
-        "hab-client": "^1.1.3",
-        "handlebars": "^4.7.9",
-        "minimatch": "^10.2.4",
-        "mz": "^2.7.0",
-        "mz-modules": "^2.1.0",
-        "object-squish": "^1.1.0",
-        "parse-url": "^11.1.0",
-        "shell-quote-word": "^1.0.1",
-        "sort-keys": "^6.0.0",
-        "toposort": "^2.0.2",
-        "winston": "^3.19.0",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "git-holo": "bin/cli.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -1728,18 +1104,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1761,21 +1125,6 @@
       "bin": {
         "katex": "cli.js"
       }
-    },
-    "node_modules/ko-sleep": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ko-sleep/-/ko-sleep-1.1.4.tgz",
-      "integrity": "sha512-s05WGpvvzyTuRlRE8fM7ru2Z3O+InbJuBcckTWKg2W+2c1k6SnFa3IfiSSt0/peFrlYAXgNoxuJWWVNmWh+K/A==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "*"
-      }
-    },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2038,23 +1387,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/logform": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
-      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2086,15 +1418,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/micromark": {
@@ -2608,95 +1931,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/mz-modules": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mz-modules/-/mz-modules-2.1.0.tgz",
-      "integrity": "sha512-sjk8lcRW3vrVYnZ+W+67L/2rL+jbO5K/N6PFGIcLWTiYytNr22Ah9FDXFs+AQntTM1boZcoHi5qS+CV1seuPog==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.2",
-        "ko-sleep": "^1.0.3",
-        "mkdirp": "^0.5.1",
-        "pump": "^3.0.0",
-        "rimraf": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.15",
@@ -2717,33 +1956,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT"
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-squish": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-squish/-/object-squish-1.1.0.tgz",
-      "integrity": "sha512-u+gd7R29OnIETm+tv546B0wq9SQFWWSnzdN8AunFrrOI4QV2q9+blpQnL9QWZbCXh3oV7LGCkWe5P3BpzVTfDA==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -2756,24 +1968,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
       }
     },
     "node_modules/parse-entities": {
@@ -2793,36 +1987,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/parse-path": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
-      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
-      "license": "MIT",
-      "dependencies": {
-        "protocols": "^2.0.0"
-      }
-    },
-    "node_modules/parse-url": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-11.1.0.tgz",
-      "integrity": "sha512-UYn/lNb1bmkYiM6UaqEbHl9T/VIYreM2Vm79MGZ2soUOXOoOq7qxoTwx8C8p9V4Ko2DLcsVnEhRJzhxsF2kssg==",
-      "license": "MIT",
-      "dependencies": {
-        "parse-path": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=14.13.0"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pathe": {
@@ -2881,58 +2045,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/protocols": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
-      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2947,19 +2059,6 @@
       "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.2.0.tgz",
       "integrity": "sha512-ZNQpVnWsdLMTCcLZcUY9ZBhxWuj7/H13EM7NL2gvbAMBXfLeN3iOLi3TWT1+8Or7OTLYXRDCy7sTEStk3j4KBA==",
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
     },
     "node_modules/rolldown": {
       "version": "1.1.3",
@@ -2995,59 +2094,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
-    "node_modules/rusha": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz",
-      "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==",
-      "license": "MIT"
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/shell-quote-word": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/shell-quote-word/-/shell-quote-word-1.0.1.tgz",
-      "integrity": "sha512-lT297f1WLAdq0A4O+AknIFRP6kkiI3s8C913eJ0XqBxJbZPGWUNkRQk2u8zk4bEAjUJ5i+fSLwB6z1HzeT+DEg==",
-      "license": "MIT"
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3082,15 +2128,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3099,15 +2136,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/stackback": {
@@ -3123,15 +2151,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/string-width": {
       "version": "8.1.0",
@@ -3162,33 +2181,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "license": "MIT"
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -3245,21 +2237,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-      "license": "MIT"
-    },
-    "node_modules/triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3282,36 +2259,11 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -3499,48 +2451,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/winston": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
-      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.8",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
-      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
-      "license": "MIT",
-      "dependencies": {
-        "logform": "^2.7.0",
-        "readable-stream": "^3.6.2",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -3574,12 +2484,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -3643,7 +2547,6 @@
         "ajv-formats": "^3.0.1",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
-        "hologit": "^0.50.2",
         "markdownlint": "^0.40.0",
         "rfc6902": "^5.2.0",
         "smol-toml": "^1.7.0",

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -47,7 +47,6 @@
     "ajv-formats": "^3.0.1",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
-    "hologit": "^0.50.2",
     "markdownlint": "^0.40.0",
     "rfc6902": "^5.2.0",
     "smol-toml": "^1.7.0",

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
-    "@hologit/holo-tree": "^0.2.0",
+    "@hologit/holo-tree": "^0.3.0",
     "@iarna/toml": "^2.2.5",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/gitsheets/src/cli/index.ts
+++ b/packages/gitsheets/src/cli/index.ts
@@ -225,10 +225,10 @@ async function runUpsert(argv: UpsertArgs): Promise<void> {
   }
 
   // Resolve attachment source paths up front so a missing file fails before
-  // the transaction opens. We hand them to hologit's writeBlobFromFile so
-  // binary content is hashed correctly (git hash-object -w). For `-` (stdin),
-  // we buffer it to a tmp file first since stdin may already be consumed by
-  // the record input.
+  // the transaction opens. The bytes are later hashed into the ODB via the
+  // binding (`repo.writeBlob`) so binary content is hashed verbatim. For `-`
+  // (stdin), we buffer it to a tmp file first since stdin may already be
+  // consumed by the record input.
   const attachmentSources: Record<string, string> = {}; // name → absolute path
   const tmpDirs: string[] = []; // cleanup at end
   let stdinConsumed = argv.input === '-' || argv.input === undefined;
@@ -334,13 +334,14 @@ async function runUpsert(argv: UpsertArgs): Promise<void> {
       lastResult = result;
     }
     // Attach files alongside the (single) record. Already guarded above to
-    // run only when records.length === 1. Each source goes through
-    // hologit's writeBlobFromFile (git hash-object -w <path>) so binary
-    // content is hashed verbatim.
+    // run only when records.length === 1. Each source is read and hashed into
+    // the ODB via the binding (`repo.writeBlob`); binary content is hashed
+    // verbatim and placed in the tree with `writeChildBytes`.
     if (attachmentNames.length > 0 && lastResult) {
-      const blobMap: Record<string, import('hologit').BlobObject> = {};
+      const blobMap: Record<string, import('../working-tree.js').BlobHandle> = {};
       for (const [name, sourcePath] of Object.entries(attachmentSources)) {
-        blobMap[name] = await repo.hologitRepo.writeBlobFromFile(sourcePath);
+        const bytes = await readFile(sourcePath);
+        blobMap[name] = await repo.writeBlob(bytes);
       }
       await target.setAttachments(lastResult.path, blobMap);
       for (const name of attachmentNames) {

--- a/packages/gitsheets/src/index.ts
+++ b/packages/gitsheets/src/index.ts
@@ -40,6 +40,8 @@ export type { Format, FormatConfig } from './format/index.js';
 
 export { mergePatch } from './patch.js';
 
+export type { BlobHandle } from './working-tree.js';
+
 export { openStore } from './store.js';
 export type {
   OpenStoreOptions,

--- a/packages/gitsheets/src/path-template/index.ts
+++ b/packages/gitsheets/src/path-template/index.ts
@@ -422,10 +422,8 @@ export class Template {
           : await currentTree.getChildren();
 
         let attachmentPrefix: string | undefined;
-        // `for...in` walks own + inherited enumerable keys. hologit's
-        // getChildren() exposes loaded entries on the object's prototype
-        // and only stages local mutations as own properties — Object.keys
-        // would miss the loaded entries.
+        // `getChildren()` returns a plain object of own enumerable entries
+        // (the binding hands back plain data, not prototype-loaded handles).
         const allKeys: string[] = [];
         for (const k in children) allKeys.push(k);
         const sortedKeys = allKeys.sort();
@@ -454,7 +452,6 @@ export class Template {
 
       // Unrenderable intermediate component: expand across all subtree children.
       const children = await currentTree.getChildren();
-      // for...in to include hologit's prototype-loaded entries (see comment above).
       for (const name in children) {
         const child = children[name];
         if (!child || !isTree(child)) continue;

--- a/packages/gitsheets/src/push-daemon.ts
+++ b/packages/gitsheets/src/push-daemon.ts
@@ -83,6 +83,14 @@ export class PushDaemon extends EventEmitter {
   #pendingCounter = 0;
   #lastPushedCounter = 0;
   #lastCommit: string | null = null;
+  // The HEAD a push last targeted (success or terminal). A `git push` syncs the
+  // whole branch, so the startup-backlog drain and a `notifyCommit` for the SAME
+  // commit must not both push — coalesce by this hash. Genuinely new commits
+  // (a different HEAD) still each push + emit their own classified error, per
+  // specs/behaviors/push-sync.md. (The fast in-process commit path widened the
+  // race window where a commit is on-disk — rev-list counts it — before
+  // notifyCommit has incremented the counter, which a counter-only guard misses.)
+  #lastPushedCommit: string | null = null;
   #lastPushAt: string | null = null;
   #lastError: {
     message: string;
@@ -172,6 +180,23 @@ export class PushDaemon extends EventEmitter {
         } catch {
           /* keep null */
         }
+        // Don't double-prime for a HEAD that's already pushed, or that the
+        // in-flight push is already targeting — a `git push` syncs the whole
+        // branch, so that commit is (or is about to be) on the remote. Priming
+        // anyway would inflate the pending counter transiently (notifyCommit and
+        // a stale-fetch backlog count counting the same commit), which a status
+        // read can observe between the increment and the next drain. Only prime
+        // when there's genuinely-newer local work than what's in flight.
+        if (
+          headCommit &&
+          (headCommit === this.#lastPushedCommit ||
+            (this.#inFlight && headCommit === this.#lastCommit))
+        ) {
+          return;
+        }
+        // Prime the pending queue and drain (per push-sync.md#startup-backlog).
+        // A redundant push for a commit `notifyCommit` also saw is further
+        // guarded in #drain by coalescing on #lastPushedCommit.
         this.#pendingCounter += ahead;
         if (headCommit) this.#lastCommit = headCommit;
         void this.#drain();
@@ -223,6 +248,16 @@ export class PushDaemon extends EventEmitter {
   async #drain(): Promise<void> {
     if (this.#inFlight || !this.#running) return;
     if (this.#pendingCounter <= this.#lastPushedCounter) return;
+    // Coalesce by HEAD: a `git push` syncs the whole branch, so if the current
+    // HEAD was already pushed (or terminally attempted), there is nothing new to
+    // send — mark the pending backlog handled and skip. A genuinely new commit
+    // has a different #lastCommit and falls through to push. This closes the
+    // startup-backlog ↔ notifyCommit double-push race that a counter-only guard
+    // misses (commit on-disk before its counter increment).
+    if (this.#lastCommit !== null && this.#lastCommit === this.#lastPushedCommit) {
+      this.#lastPushedCounter = this.#pendingCounter;
+      return;
+    }
     this.#inFlight = true;
     try {
       await this.#pushWithBackoff();
@@ -255,6 +290,7 @@ export class PushDaemon extends EventEmitter {
       try {
         await exec('git', ['push', this.#remote, this.#branch], { cwd: this.#gitDir });
         this.#lastPushedCounter = counterAtStart;
+        this.#lastPushedCommit = commit;
         this.#lastPushAt = new Date().toISOString();
         this.emit('push', { commit, durationMs: Date.now() - started });
         return;
@@ -269,11 +305,13 @@ export class PushDaemon extends EventEmitter {
           // own classified error event). Consumer intervention is required —
           // the no-force-push policy is non-negotiable.
           this.#lastPushedCounter = counterAtStart;
+          this.#lastPushedCommit = commit;
           return;
         }
         if (attempt >= this.#maxRetries) {
           // Give up on this batch; drop the counter forward so we don't loop forever.
           this.#lastPushedCounter = counterAtStart;
+          this.#lastPushedCommit = commit;
           return;
         }
         const next = Math.min(delay, this.#backoff.cap);

--- a/packages/gitsheets/src/repository.ts
+++ b/packages/gitsheets/src/repository.ts
@@ -1,11 +1,9 @@
-// Repository — entry point. Wraps hologit's Repo with gitsheets-specific
-// orchestration (transactions, sheet discovery). See specs/api/repository.md.
+// Repository — entry point. Wraps the holo-tree binding `Repo` with
+// gitsheets-specific orchestration (transactions, sheet discovery).
+// See specs/api/repository.md.
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-
-import { Repo as HologitRepo } from 'hologit';
-import type { TreeObject, Workspace } from 'hologit';
 
 import { ConfigError, RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
@@ -16,6 +14,12 @@ import {
 } from './push-daemon.js';
 import { Sheet } from './sheet.js';
 import {
+  loadBinding,
+  openBindingRepo,
+  type BindingRepo,
+  type BindingTree,
+} from './substrate.js';
+import {
   Mutex,
   Transaction,
   resolveAuthor,
@@ -25,6 +29,7 @@ import {
   type TransactionResult,
 } from './transaction.js';
 import type { StandardSchemaV1 } from './validation.js';
+import { TreeView, joinTreePath, makeBlobHandle, type BlobHandle } from './working-tree.js';
 
 const exec = promisify(execFile);
 
@@ -57,48 +62,55 @@ export interface OpenSheetsOptions {
   readonly prefix?: string;
 }
 
+/** Resolve the absolute `.git` directory for `gitDir` (or discovered from `cwd`). */
+async function resolveGitDir(gitDir: string | undefined): Promise<string> {
+  const cwd = gitDir ?? process.cwd();
+  try {
+    const { stdout } = await exec('git', ['rev-parse', '--absolute-git-dir'], { cwd });
+    return stdout.trim();
+  } catch (err) {
+    throw new ConfigError(
+      'config_missing',
+      `could not find a git repository at ${cwd}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+}
+
 export class Repository {
-  readonly #hologitRepo: HologitRepo;
+  readonly #holo: typeof import('@hologit/holo-tree');
+  readonly #binding: BindingRepo;
+  readonly #gitDir: string;
   readonly #mutex = new Mutex();
   readonly #postCommitHooks: Array<(commitHash: string) => void> = [];
   #strictMode = false;
   #pushDaemon: PushDaemon | null = null;
 
-  constructor(hologitRepo: HologitRepo) {
-    this.#hologitRepo = hologitRepo;
+  constructor(opts: {
+    holo: typeof import('@hologit/holo-tree');
+    binding: BindingRepo;
+    gitDir: string;
+  }) {
+    this.#holo = opts.holo;
+    this.#binding = opts.binding;
+    this.#gitDir = opts.gitDir;
   }
 
   /** Discover a `.git` upward from `cwd` and open it. */
   static async fromCwd(): Promise<Repository> {
-    const repo = await HologitRepo.getFromEnvironment();
-    return new Repository(repo);
+    return Repository.open({});
   }
 
-  /** Open a specific git directory. */
+  /** Open a specific git directory (or discover one from the cwd). */
   static async open(opts: OpenRepoOptions): Promise<Repository> {
-    if (!opts.gitDir) {
-      return Repository.fromCwd();
-    }
-    const repoOpts: { gitDir: string; workTree?: string | null } = { gitDir: opts.gitDir };
-    if (opts.workTree !== undefined) {
-      repoOpts.workTree = opts.workTree;
-    }
-    const repo = new HologitRepo(repoOpts);
-    return new Repository(repo);
-  }
-
-  /**
-   * @internal — Direct access to the underlying hologit substrate is reserved
-   * for the library. Consumers should use the public Repository surface; the
-   * substrate is an implementation detail and will swap to Rust holo-tree in
-   * v1.1 with no public-API change ([#127]).
-   */
-  get hologitRepo(): HologitRepo {
-    return this.#hologitRepo;
+    const holo = await loadBinding();
+    const gitDir = await resolveGitDir(opts.gitDir);
+    const binding = openBindingRepo(holo, gitDir);
+    return new Repository({ holo, binding, gitDir });
   }
 
   get gitDir(): string {
-    return this.#hologitRepo.gitDir;
+    return this.#gitDir;
   }
 
   /** @internal — used by Sheet to enforce strict mode. Library cross-class signal, not a consumer API. */
@@ -113,7 +125,17 @@ export class Repository {
 
   /** Resolve a ref or commit hash. Returns the full commit hash or null. */
   async resolveRef(ref: string): Promise<string | null> {
-    return this.#hologitRepo.resolveRef(ref);
+    return this.#binding.resolveRef(ref);
+  }
+
+  /**
+   * @internal — Write raw bytes as a loose blob in the ODB and return a
+   * gitsheets blob handle. Used by the CLI to hash binary attachments before
+   * placing them in a record's attachment tree.
+   */
+  async writeBlob(content: Buffer): Promise<BlobHandle> {
+    const hash = this.#binding.writeBlob(content);
+    return makeBlobHandle(this.#gitDir, hash, '100644', content);
   }
 
   /**
@@ -126,12 +148,13 @@ export class Repository {
     opts: OpenSheetOptions<T> = {},
   ): Promise<Sheet<T>> {
     const root = opts.root ?? '.';
-    const workspace = await this.#getWorkspace();
-    const dataTree = await this.#resolveDataTree(workspace, root);
+    const rootTree = await this.#readRootTree();
+    const rootView = new TreeView(this.#binding, rootTree, '', this.#gitDir);
+    const dataTree = new TreeView(this.#binding, rootTree, dataRootBase(root), this.#gitDir);
     const configPath = joinTreePath(root, '.gitsheets', `${name}.toml`);
     const sheetOpts: import('./sheet.js').SheetConstructorOptions<T> = {
       repo: this,
-      workspace,
+      rootView,
       dataTree,
       name,
       configPath,
@@ -151,24 +174,24 @@ export class Repository {
   /** Discover every sheet declared in `<root>/.gitsheets/*.toml`. */
   async openSheets(opts: OpenSheetsOptions = {}): Promise<Record<string, Sheet>> {
     const root = opts.root ?? '.';
-    const workspace = await this.#getWorkspace();
-    const sheetsDir = await workspace.root.getSubtree(joinTreePath(root, '.gitsheets'));
+    const rootTree = await this.#readRootTree();
+    const rootView = new TreeView(this.#binding, rootTree, '', this.#gitDir);
+    const sheetsDir = await rootView.getSubtree(joinTreePath(root, '.gitsheets'));
     if (!sheetsDir) return {};
 
     const children = await sheetsDir.getChildren();
     const out: Record<string, Sheet> = {};
-    const dataTree = await this.#resolveDataTree(workspace, root);
 
-    // for...in to include hologit's prototype-loaded entries.
-    for (const childName in children) {
+    for (const childName of Object.keys(children)) {
       const child = children[childName];
       const match = /^(.+)\.toml$/.exec(childName);
       if (!match) continue;
       if (!child || (child as { isBlob?: boolean }).isBlob !== true) continue;
       const sheetName = match[1]!;
+      const dataTree = new TreeView(this.#binding, rootTree, dataRootBase(root), this.#gitDir);
       const sheetOpts: import('./sheet.js').SheetConstructorOptions = {
         repo: this,
-        workspace,
+        rootView,
         dataTree,
         name: sheetName,
         configPath: joinTreePath(root, '.gitsheets', childName),
@@ -204,13 +227,14 @@ export class Repository {
     try {
       const { parent, branch } = await this.#resolveParent(normalized.parent, normalized.branch);
       const parentCommitHash = parent.commitHash;
-      const workspace = parentCommitHash
-        ? await this.#hologitRepo.createWorkspaceFromRef(parentCommitHash)
-        : await this.#emptyWorkspace();
+      const rootTree = parentCommitHash
+        ? this.#binding.createTreeFromRef(parentCommitHash)
+        : this.#binding.createTree();
+      const rootView = new TreeView(this.#binding, rootTree, '', this.#gitDir);
 
       const tx: Transaction = new Transaction({
-        hologitRepo: this.#hologitRepo,
-        workspace,
+        binding: this.#binding,
+        rootView,
         parentCommitHash,
         parentRef: parent.refName,
         branchRef: branch,
@@ -220,11 +244,10 @@ export class Repository {
         trailers: normalized.trailers,
         sheetFactory: <R extends RecordLike = RecordLike>(
           name: string,
-          ws: Workspace,
-          tree: TreeObject,
+          tree: TreeView,
           validator?: StandardSchemaV1<unknown, R>,
           prefix?: string,
-        ): Sheet<R> => this.#makeTxSheet<R>(tx, name, ws, tree, validator, prefix),
+        ): Sheet<R> => this.#makeTxSheet<R>(tx, name, tree, validator, prefix),
       });
 
       let value: T;
@@ -302,15 +325,14 @@ export class Repository {
   #makeTxSheet<T extends RecordLike = RecordLike>(
     tx: Transaction,
     name: string,
-    workspace: Workspace,
-    tree: TreeObject,
+    tree: TreeView,
     validator?: StandardSchemaV1<unknown, T>,
     prefix?: string,
   ): Sheet<T> {
     const configPath = `.gitsheets/${name}.toml`;
     const opts: import('./sheet.js').SheetConstructorOptions<T> = {
       repo: this,
-      workspace,
+      rootView: tree,
       dataTree: tree,
       name,
       configPath,
@@ -321,37 +343,22 @@ export class Repository {
     return new Sheet<T>(opts);
   }
 
-  async #getWorkspace(): Promise<Workspace> {
-    // Bypass hologit's getWorkspace cache — it caches the first observed
-    // workspace per Repo instance, so post-commit reads would return stale
-    // state. Resolve HEAD fresh on each call. Fresh-repo fallback handles #19.
+  /**
+   * Build a fresh in-memory root tree from HEAD (or an empty tree on a fresh
+   * repo). Resolved fresh on each call so post-commit reads never see stale
+   * state. Fresh-repo fallback handles #19.
+   */
+  async #readRootTree(): Promise<BindingTree> {
     let head: string | null = null;
     try {
-      head = await this.#hologitRepo.resolveRef('HEAD');
+      head = this.#binding.resolveRef('HEAD');
     } catch {
       head = null;
     }
     if (head) {
-      return this.#hologitRepo.createWorkspaceFromRef(head);
+      return this.#binding.createTreeFromRef(head);
     }
-    return this.#emptyWorkspace();
-  }
-
-  async #emptyWorkspace(): Promise<Workspace> {
-    // hologit doesn't expose an empty-workspace factory directly. Use the
-    // empty-tree hash to bootstrap a workspace from a deterministic tree.
-    const { TreeObject } = await import('hologit');
-    const emptyTreeHash = TreeObject.getEmptyTreeHash();
-    return this.#hologitRepo.createWorkspaceFromTreeHash(emptyTreeHash);
-  }
-
-  async #resolveDataTree(workspace: Workspace, root: string): Promise<TreeObject> {
-    if (root === '.' || root === '') return workspace.root;
-    const sub = await workspace.root.getSubtree(root, true);
-    if (!sub) {
-      throw new ConfigError('config_missing', `data root ${root} not found in workspace`);
-    }
-    return sub;
+    return this.#binding.createTree();
   }
 
   /**
@@ -368,14 +375,19 @@ export class Repository {
       // Use HEAD's branch when on a branch; otherwise current HEAD commit.
       const headRef = await this.#headBranchRef();
       if (headRef) {
-        const commit = await this.#hologitRepo.resolveRef(headRef);
+        const commit = this.#binding.resolveRef(headRef);
         return {
           parent: { refName: headRef, commitHash: commit },
           branch: branch ?? headRef,
         };
       }
       // Detached or fresh repo
-      const headHash = await this.#hologitRepo.resolveRef('HEAD').catch(() => null);
+      let headHash: string | null = null;
+      try {
+        headHash = this.#binding.resolveRef('HEAD');
+      } catch {
+        headHash = null;
+      }
       return {
         parent: { refName: null, commitHash: headHash },
         branch: branch ?? null,
@@ -386,7 +398,7 @@ export class Repository {
     const isLikelyBranch = /^[a-zA-Z0-9_./-]+$/.test(parent) && !/^[0-9a-f]{4,40}$/.test(parent);
     if (isLikelyBranch) {
       const refName = parent.startsWith('refs/') ? parent : `refs/heads/${parent}`;
-      const commit = await this.#hologitRepo.resolveRef(refName);
+      const commit = this.#binding.resolveRef(refName);
       if (commit === null) {
         // Maybe they passed a raw "main" that doesn't exist yet
         throw new RefError('ref_not_found', `ref not found: ${parent}`);
@@ -398,7 +410,7 @@ export class Repository {
     }
 
     // Hash
-    const resolved = await this.#hologitRepo.resolveRef(parent);
+    const resolved = this.#binding.resolveRef(parent);
     if (!resolved) {
       throw new RefError('ref_not_found', `cannot resolve commit: ${parent}`);
     }
@@ -425,9 +437,8 @@ export async function openRepo(opts: OpenRepoOptions = {}): Promise<Repository> 
   return Repository.open(opts);
 }
 
-function joinTreePath(...parts: string[]): string {
-  return parts
-    .map((p) => p.replace(/^\/+/, '').replace(/\/+$/, ''))
-    .filter((p) => p.length > 0 && p !== '.')
-    .join('/');
+/** Normalize the `root` open-option to a tree base path (`''` for the repo root). */
+function dataRootBase(root: string): string {
+  if (root === '.' || root === '') return '';
+  return root.replace(/^\/+|\/+$/g, '');
 }

--- a/packages/gitsheets/src/sheet-clear.test.ts
+++ b/packages/gitsheets/src/sheet-clear.test.ts
@@ -1,4 +1,4 @@
-// Sheet.clear() — #178 fix: uses hologit TreeObject.clearChildren()
+// Sheet.clear() — #178 fix: uses the binding tree's clearChildren()
 // (O(1)) instead of walking + deleteChild per entry.
 //
 // The behavioral observable is the serialized hash of the sheet's subtree

--- a/packages/gitsheets/src/sheet.ts
+++ b/packages/gitsheets/src/sheet.ts
@@ -6,7 +6,6 @@ import { runInNewContext } from 'node:vm';
 import { promisify } from 'node:util';
 import type { Readable } from 'node:stream';
 
-import type { BlobObject, TreeObject, Workspace } from 'hologit';
 import { createPatch as rfc6902CreatePatch, type Operation as JsonPatchOp } from 'rfc6902';
 
 import {
@@ -20,6 +19,13 @@ import {
 import { mergePatch } from './patch.js';
 import { Template, type RecordLike } from './path-template/index.js';
 import type { Repository } from './repository.js';
+import {
+  EMPTY_TREE_HASH,
+  makeBlobHandle,
+  type BlobHandle,
+  type BlobView,
+  type TreeView,
+} from './working-tree.js';
 import { stringifyRecord, parseConfigToml } from './toml.js';
 import sortKeys from 'sort-keys';
 import { Transaction, transactionContext } from './transaction.js';
@@ -62,7 +68,7 @@ export interface SheetConfig {
 // --- Result types ---
 
 export interface UpsertResult {
-  readonly blob: BlobObject;
+  readonly blob: BlobHandle;
   readonly path: string;
 }
 
@@ -98,11 +104,11 @@ export interface UpsertOptions {
 
 // --- Helpers ---
 
-function isBlob(node: unknown): node is BlobObject {
+function isBlob(node: unknown): node is BlobView {
   return typeof node === 'object' && node !== null && (node as { isBlob?: boolean }).isBlob === true;
 }
 
-function isTree(node: unknown): node is TreeObject {
+function isTree(node: unknown): node is TreeView {
   return typeof node === 'object' && node !== null && (node as { isTree?: boolean }).isTree === true;
 }
 
@@ -182,8 +188,8 @@ function queryMatches(filter: RecordLike, record: RecordLike): boolean {
 
 const CONFIG_CACHE = new Map<string, SheetConfig>();
 
-async function loadConfig(workspace: Workspace, configPath: string): Promise<SheetConfig> {
-  const node = await workspace.root.getChild(configPath);
+async function loadConfig(rootView: TreeView, configPath: string): Promise<SheetConfig> {
+  const node = await rootView.getChild(configPath);
   if (!node || !isBlob(node)) {
     throw new ConfigError('config_missing', `sheet config not found at ${configPath}`);
   }
@@ -317,7 +323,7 @@ function validateSortRule(sort: unknown, configPath: string, field: string): voi
 // issue without leaking mutable shared state.
 
 const RECORD_TEXT_CACHE = new Map<string, string>();
-async function readBlobTextCached(blob: BlobObject): Promise<string> {
+async function readBlobTextCached(blob: BlobView): Promise<string> {
   const cached = RECORD_TEXT_CACHE.get(blob.hash);
   if (cached !== undefined) return cached;
   const text = await blob.read();
@@ -468,7 +474,7 @@ export type DiffStatus = 'added' | 'modified' | 'deleted' | 'renamed';
 
 /** Options for `Sheet.diffFrom`. */
 export interface DiffOptions {
-  /** Attach BlobObject handles for the src/dst blob hashes when set. */
+  /** Attach BlobHandle handles for the src/dst blob hashes when set. */
   readonly blobs?: boolean;
   /** Parse src/dst TOML into records when set. */
   readonly records?: boolean;
@@ -481,7 +487,7 @@ export interface DiffOptions {
  * added records; `dstMode`/`dstHash` are null for deleted records.
  *
  * The optional fields populate based on the `opts` flag passed to diffFrom:
- * - `blobs: true` → `srcBlob`/`dstBlob` (hologit `BlobObject` handles)
+ * - `blobs: true` → `srcBlob`/`dstBlob` (gitsheets `BlobHandle` handles)
  * - `records: true` → `src`/`dst` (parsed records)
  * - `patches: true` → `patch` (RFC 6902 array; null/empty array on no-op)
  */
@@ -493,8 +499,8 @@ export interface DiffChange<T extends RecordLike = RecordLike> {
   readonly dstMode: string | null;
   readonly srcHash: string | null;
   readonly dstHash: string | null;
-  readonly srcBlob?: BlobObject;
-  readonly dstBlob?: BlobObject;
+  readonly srcBlob?: BlobHandle;
+  readonly dstBlob?: BlobHandle;
   readonly src?: T;
   readonly dst?: T;
   readonly patch?: readonly JsonPatchOp[];
@@ -633,8 +639,10 @@ interface IndexState<T extends RecordLike = RecordLike> {
 
 export interface SheetConstructorOptions<T extends RecordLike = RecordLike> {
   readonly repo: Repository;
-  readonly workspace: Workspace;
-  readonly dataTree: TreeObject;
+  /** Root tree view (base `''`) — config files are read from here. */
+  readonly rootView: TreeView;
+  /** Data tree view — records read/written relative to its base. */
+  readonly dataTree: TreeView;
   readonly name: string;
   readonly configPath: string;
   readonly transaction?: Transaction;
@@ -650,8 +658,8 @@ export interface SheetConstructorOptions<T extends RecordLike = RecordLike> {
 
 export class Sheet<T extends RecordLike = RecordLike> {
   readonly #repo: Repository;
-  readonly #workspace: Workspace;
-  readonly #dataTree: TreeObject;
+  readonly #rootView: TreeView;
+  readonly #dataTree: TreeView;
   readonly #name: string;
   readonly #configPath: string;
   readonly #transaction: Transaction | undefined;
@@ -661,7 +669,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
 
   constructor(opts: SheetConstructorOptions<T>) {
     this.#repo = opts.repo;
-    this.#workspace = opts.workspace;
+    this.#rootView = opts.rootView;
     this.#dataTree = opts.dataTree;
     this.#name = opts.name;
     this.#configPath = opts.configPath;
@@ -705,7 +713,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
   }
 
   async readConfig(): Promise<SheetConfig> {
-    return loadConfig(this.#workspace, this.#configPath);
+    return loadConfig(this.#rootView, this.#configPath);
   }
 
   /** Same as readConfig — config is cached by config-blob hash anyway. */
@@ -740,8 +748,8 @@ export class Sheet<T extends RecordLike = RecordLike> {
       );
     }
 
-    // hologit's TreeObject/BlobObject are structurally compatible with the
-    // path-template tree interface; the casts bridge the type lattices.
+    // TreeView/BlobView are structurally compatible with the path-template
+    // tree interface; the casts bridge the type lattices.
     for await (const { blob, path: blobPath } of template.queryTree(
       sheetRoot as unknown as Parameters<typeof template.queryTree>[0],
       filter as RecordLike,
@@ -749,7 +757,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
     )) {
       if (signal?.aborted) throwAborted(signal);
       const record = (await this.#readRecordFromBlob(
-        blob as unknown as BlobObject,
+        blob as unknown as BlobView,
         blobPath,
         config,
         { headerOnly: !withBody },
@@ -828,8 +836,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
   ): AsyncGenerator<DiffChange<T>> {
     const config = await this.readConfig();
     const gitDir = this.#repo.gitDir;
-    const { TreeObject } = await import('hologit');
-    const srcRef = srcCommitHash ?? TreeObject.getEmptyTreeHash();
+    const srcRef = srcCommitHash ?? EMPTY_TREE_HASH;
     const dstTreeHash = await this.#dataTree.getHash();
 
     const args = ['diff-tree', '-z', '-r', '-M', '--no-commit-id', srcRef, dstTreeHash];
@@ -875,16 +882,10 @@ export class Sheet<T extends RecordLike = RecordLike> {
 
       if (opts.blobs) {
         if (entry.srcHash) {
-          change['srcBlob'] = this.#repo.hologitRepo.createBlob({
-            hash: entry.srcHash,
-            mode: entry.srcMode ?? '100644',
-          });
+          change['srcBlob'] = makeBlobHandle(gitDir, entry.srcHash, entry.srcMode ?? '100644');
         }
         if (entry.dstHash) {
-          change['dstBlob'] = this.#repo.hologitRepo.createBlob({
-            hash: entry.dstHash,
-            mode: entry.dstMode ?? '100644',
-          });
+          change['dstBlob'] = makeBlobHandle(gitDir, entry.dstHash, entry.dstMode ?? '100644');
         }
       }
 
@@ -946,9 +947,8 @@ export class Sheet<T extends RecordLike = RecordLike> {
     const config = await this.readConfig();
     const sheetTree = await this.#dataTree.getSubtree(this.#effectiveRoot(config), true);
     if (sheetTree) {
-      // O(1) — drops both pending and base children in-place. The
-      // serialized subtree becomes git's empty-tree hash, which hologit's
-      // tree write() already skips when emitting parent entries.
+      // O(1) — replaces the subtree with git's empty-tree hash in place. The
+      // binding's tree write() omits empty subtrees from the committed tree.
       // See specs/api/sheet.md#clear.
       sheetTree.clearChildren();
     }
@@ -957,9 +957,12 @@ export class Sheet<T extends RecordLike = RecordLike> {
   }
 
   async clone(): Promise<Sheet<T>> {
+    // Only the data tree is cloned (so staged mutations don't touch the
+    // original); config is immutable, so it keeps reading through the original
+    // root view.
     const opts: SheetConstructorOptions<T> = {
       repo: this.#repo,
-      workspace: this.#workspace,
+      rootView: this.#rootView,
       dataTree: await this.#dataTree.clone(),
       name: this.#name,
       configPath: this.#configPath,
@@ -1170,21 +1173,27 @@ export class Sheet<T extends RecordLike = RecordLike> {
     return state.multiMap.get(key) ?? [];
   }
 
-  async getAttachment(record: T | string, name: string): Promise<BlobObject | null> {
+  async getAttachment(record: T | string, name: string): Promise<BlobHandle | null> {
     const config = await this.readConfig();
     const recordPath = typeof record === 'string' ? record : await this.pathForRecord(record);
     const node = await this.#dataTree.getChild(joinTreePath(this.#effectiveRoot(config), recordPath, name));
-    return node && isBlob(node) ? node : null;
+    if (!node || !isBlob(node)) return null;
+    return makeBlobHandle(this.#repo.gitDir, node.hash, node.mode);
   }
 
   async getAttachments(
     record: T | string,
-  ): Promise<Record<string, BlobObject> | null> {
+  ): Promise<Record<string, BlobHandle> | null> {
     const config = await this.readConfig();
     const recordPath = typeof record === 'string' ? record : await this.pathForRecord(record);
     const dir = await this.#dataTree.getChild(joinTreePath(this.#effectiveRoot(config), recordPath));
     if (!dir || !isTree(dir)) return null;
-    return dir.getBlobMap();
+    const blobMap = await dir.getBlobMap();
+    const out: Record<string, BlobHandle> = {};
+    for (const [name, blob] of Object.entries(blobMap)) {
+      out[name] = makeBlobHandle(this.#repo.gitDir, blob.hash, blob.mode);
+    }
+    return out;
   }
 
   /**
@@ -1215,14 +1224,14 @@ export class Sheet<T extends RecordLike = RecordLike> {
   async setAttachment(
     record: T | string,
     name: string,
-    blob: string | BlobObject,
+    blob: string | BlobHandle,
   ): Promise<void> {
     await this.setAttachments(record, { [name]: blob });
   }
 
   async setAttachments(
     record: T | string,
-    attachments: Record<string, string | BlobObject>,
+    attachments: Record<string, string | BlobHandle>,
   ): Promise<void> {
     if (this.#transaction === undefined) {
       this.#checkStrictMode();
@@ -1529,7 +1538,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
     this.#invalidateIndexes();
   }
 
-  async #getSheetRoot(rootPath: string): Promise<TreeObject | null> {
+  async #getSheetRoot(rootPath: string): Promise<TreeView | null> {
     if (rootPath === '.' || rootPath === '') return this.#dataTree;
     const sub = await this.#dataTree.getSubtree(rootPath);
     return sub;
@@ -1587,7 +1596,7 @@ export class Sheet<T extends RecordLike = RecordLike> {
   }
 
   async #readRecordFromBlob(
-    blob: BlobObject,
+    blob: BlobView,
     path: string,
     config: SheetConfig,
     opts: { headerOnly?: boolean } = {},

--- a/packages/gitsheets/src/substrate.ts
+++ b/packages/gitsheets/src/substrate.ts
@@ -1,54 +1,57 @@
 // Tree substrate — the seam between gitsheets and its git-object backend.
 //
-// gitsheets is migrating its tree/commit/ref operations off the hologit JS
-// dependency onto the published Rust binding `@hologit/holo-tree@^0.2.0`
-// (#127). The migration proceeds site by site. This module owns the binding
-// load and the commit-object + ref operations migrated so far; the working-tree
-// read/write/navigation surface (`Sheet` / `path-template`) still goes through
-// hologit's `Workspace`/`TreeObject` — see the migration plan for why it can't
-// move yet (the 0.2.0 `Tree.deleteChildDeep` flush bug).
+// gitsheets' entire tree / blob / commit / ref layer runs on the published
+// Rust binding `@hologit/holo-tree` (#127). The binding is the **sole** tree
+// substrate: there is no hologit JS fallback. This module owns the binding
+// load, the commit-object + CAS-ref operations, and the platform-failure
+// surface. The deep-path working-tree navigation lives in `working-tree.ts`.
 //
-// When the native addon can't load on a platform, `loadHoloTree()` returns
-// `null` and callers keep the legacy `git` shell-out path untouched.
+// The only remaining git **CLI** shell-outs are genuine git-porcelain ops the
+// binding doesn't cover: `Sheet.diffFrom`'s `git diff-tree`, `git var
+// GIT_EDITOR` / the `$EDITOR` flow, blob reads by hash (`git cat-file`), and
+// author resolution (`git config`).
 //
 // See plans/holo-tree-migration.md and specs/rust-core.md.
 
 // Type-only import: erased at compile time, so merely importing gitsheets never
 // loads the native addon. The runtime load is the dynamic import in
-// `loadHoloTree()` below.
-import type { Repo as BindingRepo, Signature } from '@hologit/holo-tree';
+// `loadBinding()` below.
+import type { Repo as BindingRepo, Tree as BindingTree, Signature } from '@hologit/holo-tree';
 
+import { ConfigError } from './errors.js';
 import type { Author } from './transaction.js';
 
 type HoloModule = typeof import('@hologit/holo-tree');
 
-export type { BindingRepo };
+export type { BindingRepo, BindingTree };
 
-let cached: HoloModule | null | undefined;
+let cached: HoloModule | undefined;
 
 /**
- * Lazily load the holo-tree binding, or return `null` to signal "use the legacy
- * git path". Returns `null` when:
+ * Lazily load the holo-tree native binding. Throws a clear gitsheets error
+ * naming the unsupported platform when the prebuilt addon can't load, rather
+ * than letting a cryptic native-loader exception escape.
  *
- * - `GITSHEETS_COMMIT_SUBSTRATE=git` forces the legacy shell-out, or
- * - the native addon can't load on this platform. `@hologit/holo-tree` ships
- *   prebuilds only for linux-x64-gnu / darwin-arm64 / win32-x64-msvc; on any
- *   other platform (Alpine/musl, linux-arm64, …) the load fails and gitsheets
- *   **gracefully falls back to git** rather than becoming unimportable.
+ * `@hologit/holo-tree@^0.3.0` ships prebuilds for linux x64/arm64 (gnu+musl),
+ * darwin arm64/x64, and win32 x64. On any other platform the import fails and
+ * gitsheets surfaces a `ConfigError` (exit code 64) explaining why — the
+ * binding is mandatory, since it is now the only tree substrate.
  *
- * The result is cached (including the `null` outcome) so the probe happens once.
+ * The module is cached so the (successful) load happens once.
  */
-export async function loadHoloTree(): Promise<HoloModule | null> {
-  if (cached !== undefined) return cached;
-  if (process.env['GITSHEETS_COMMIT_SUBSTRATE'] === 'git') {
-    cached = null;
-    return cached;
-  }
+export async function loadBinding(): Promise<HoloModule> {
+  if (cached) return cached;
   try {
     cached = await import('@hologit/holo-tree');
-  } catch {
-    // Unsupported platform / missing prebuilt — fall back to git.
-    cached = null;
+  } catch (err) {
+    throw new ConfigError(
+      'config_invalid',
+      `gitsheets requires the @hologit/holo-tree native binding, but no prebuilt could be ` +
+        `loaded for this platform (${process.platform}-${process.arch}). Supported targets: ` +
+        `linux x64/arm64 (gnu, musl), darwin arm64/x64, win32 x64. ` +
+        `Original load error: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
   }
   return cached;
 }

--- a/packages/gitsheets/src/transaction.ts
+++ b/packages/gitsheets/src/transaction.ts
@@ -5,13 +5,12 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
-import type { Repo as HologitRepo, TreeObject, Workspace } from 'hologit';
-
 import { RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
-import { commitTreeWithRepo, loadHoloTree, openBindingRepo } from './substrate.js';
+import { commitTreeWithRepo, type BindingRepo } from './substrate.js';
 import type { Sheet } from './sheet.js';
 import type { StandardSchemaV1 } from './validation.js';
+import type { TreeView } from './working-tree.js';
 
 const exec = promisify(execFile);
 
@@ -109,8 +108,8 @@ export class Mutex {
 }
 
 export class Transaction {
-  readonly #hologitRepo: HologitRepo;
-  readonly #workspace: Workspace;
+  readonly #binding: BindingRepo;
+  readonly #rootView: TreeView;
   readonly #parentCommitHash: string | null;
   readonly #parentRef: string | null;
   readonly #branchRef: string | null;
@@ -121,8 +120,7 @@ export class Transaction {
   /** Function the Repository injects so Transaction.sheet() can build Sheet instances. */
   readonly #sheetFactory: <T extends RecordLike = RecordLike>(
     name: string,
-    workspace: Workspace,
-    tree: TreeObject,
+    tree: TreeView,
     validator?: StandardSchemaV1<unknown, T>,
     prefix?: string,
   ) => Sheet<T>;
@@ -136,8 +134,8 @@ export class Transaction {
    * handler parameters.
    */
   constructor(opts: {
-    hologitRepo: HologitRepo;
-    workspace: Workspace;
+    binding: BindingRepo;
+    rootView: TreeView;
     parentCommitHash: string | null;
     parentRef: string | null;
     branchRef: string | null;
@@ -147,14 +145,13 @@ export class Transaction {
     trailers: Readonly<Record<string, string>>;
     sheetFactory: <T extends RecordLike = RecordLike>(
       name: string,
-      workspace: Workspace,
-      tree: TreeObject,
+      tree: TreeView,
       validator?: StandardSchemaV1<unknown, T>,
       prefix?: string,
     ) => Sheet<T>;
   }) {
-    this.#hologitRepo = opts.hologitRepo;
-    this.#workspace = opts.workspace;
+    this.#binding = opts.binding;
+    this.#rootView = opts.rootView;
     this.#parentCommitHash = opts.parentCommitHash;
     this.#parentRef = opts.parentRef;
     this.#branchRef = opts.branchRef;
@@ -165,8 +162,12 @@ export class Transaction {
     this.#sheetFactory = opts.sheetFactory;
   }
 
-  get tree(): TreeObject {
-    return this.#workspace.root;
+  /**
+   * The transaction's root working tree. Mutations stage here (in memory) and
+   * commit on finalize. Backed by the holo-tree binding via {@link TreeView}.
+   */
+  get tree(): TreeView {
+    return this.#rootView;
   }
 
   get parentCommitHash(): string | null {
@@ -206,8 +207,7 @@ export class Transaction {
     }
     return this.#sheetFactory<T>(
       name,
-      this.#workspace,
-      this.#workspace.root,
+      this.#rootView,
       opts?.validator,
       opts?.prefix,
     );
@@ -233,26 +233,18 @@ export class Transaction {
       return noChange;
     }
 
-    const gitDir = this.#hologitRepo.gitDir;
-
-    // The holo-tree binding (#127) backs commit-object creation, the no-op
-    // tree-hash probe, the parent-moved check, and compare-and-swap ref
-    // movement. The working tree itself (`workspace.root`) stays on hologit
-    // for now — only the commit/ref tail of finalize is migrated. When the
-    // binding can't load on this platform (or GITSHEETS_COMMIT_SUBSTRATE=git),
-    // `binding` is null and the legacy `git` shell-out path runs end-to-end.
-    // See plans/holo-tree-migration.md.
-    const holo = await loadHoloTree();
-    const binding = holo ? openBindingRepo(holo, gitDir) : null;
+    // The holo-tree binding (#127) is the sole tree substrate: it backs the
+    // working-tree flush, commit-object creation, the no-op tree-hash probe,
+    // the parent-moved check, and compare-and-swap ref movement. See
+    // plans/holo-tree-migration.md.
+    const binding = this.#binding;
 
     // Optimistic concurrency: re-check the parent ref hasn't moved. The CAS
     // `updateRef` below is the actual race guard; this pre-check just surfaces
     // the friendlier `parent_moved` error (and an early exit) before we bother
     // writing a commit object.
     if (this.#parentRef !== null) {
-      const current = binding
-        ? binding.resolveRef(this.#parentRef)
-        : await this.#hologitRepo.resolveRef(this.#parentRef);
+      const current = binding.resolveRef(this.#parentRef);
       if (current !== this.#parentCommitHash) {
         throw new TransactionError(
           'parent_moved',
@@ -261,7 +253,7 @@ export class Transaction {
       }
     }
 
-    const treeHash = await this.#workspace.root.write();
+    const treeHash = await this.#rootView.write();
 
     // No-op detection: if the resulting tree-hash matches the parent
     // commit's tree-hash, nothing actually changed. Skip the commit + ref
@@ -272,11 +264,7 @@ export class Transaction {
     // all set the flag without changing the tree. Tree-hash equality is the
     // canonical git-native truth. See specs/api/transaction.md#no-op-detection.
     if (this.#parentCommitHash !== null) {
-      const parentTreeHash = binding
-        ? binding.createTreeFromRef(this.#parentCommitHash).write()
-        : (
-            await exec('git', ['rev-parse', `${this.#parentCommitHash}^{tree}`], { cwd: gitDir })
-          ).stdout.trim();
+      const parentTreeHash = binding.createTreeFromRef(this.#parentCommitHash).write();
       if (parentTreeHash === treeHash) {
         return noChange;
       }
@@ -285,78 +273,38 @@ export class Transaction {
     const message = formatCommitMessage(this.#message, this.#trailers);
 
     let commitHash: string;
-    if (binding) {
-      try {
-        commitHash = commitTreeWithRepo(binding, {
-          treeHash,
-          parents: this.#parentCommitHash ? [this.#parentCommitHash] : [],
-          message,
-          author: this.#author,
-          committer: this.#committer,
-        });
-      } catch (err) {
-        throw new TransactionError(
-          'commit_failed',
-          `holo-tree commitTree failed: ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
-        );
-      }
-    } else {
-      try {
-        const args = ['commit-tree', treeHash, '-m', message];
-        if (this.#parentCommitHash) {
-          args.push('-p', this.#parentCommitHash);
-        }
-        const env: NodeJS.ProcessEnv = {
-          ...process.env,
-          GIT_AUTHOR_NAME: this.#author.name,
-          GIT_AUTHOR_EMAIL: this.#author.email,
-          GIT_COMMITTER_NAME: this.#committer.name,
-          GIT_COMMITTER_EMAIL: this.#committer.email,
-        };
-        const { stdout } = await exec('git', args, { cwd: gitDir, env });
-        commitHash = stdout.trim();
-      } catch (err) {
-        throw new TransactionError(
-          'commit_failed',
-          `git commit-tree failed: ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
-        );
-      }
+    try {
+      commitHash = commitTreeWithRepo(binding, {
+        treeHash,
+        parents: this.#parentCommitHash ? [this.#parentCommitHash] : [],
+        message,
+        author: this.#author,
+        committer: this.#committer,
+      });
+    } catch (err) {
+      throw new TransactionError(
+        'commit_failed',
+        `holo-tree commitTree failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     }
 
     if (this.#branchRef !== null) {
-      if (binding) {
-        try {
-          // CAS: only advance the ref if it still points at the parent commit
-          // (undefined expected-old → unconditional, for a fresh branch) —
-          // matching `git update-ref <ref> <new> [<old>]`.
-          binding.updateRef(
-            this.#branchRef,
-            commitHash,
-            this.#parentCommitHash ?? undefined,
-          );
-        } catch (err) {
-          throw new TransactionError(
-            'commit_failed',
-            `holo-tree updateRef ${this.#branchRef} failed: ${err instanceof Error ? err.message : String(err)}`,
-            { cause: err },
-          );
-        }
-      } else {
-        try {
-          const args = ['update-ref', this.#branchRef, commitHash];
-          if (this.#parentCommitHash) {
-            args.push(this.#parentCommitHash);
-          }
-          await exec('git', args, { cwd: gitDir });
-        } catch (err) {
-          throw new TransactionError(
-            'commit_failed',
-            `git update-ref ${this.#branchRef} failed: ${err instanceof Error ? err.message : String(err)}`,
-            { cause: err },
-          );
-        }
+      try {
+        // CAS: only advance the ref if it still points at the parent commit
+        // (undefined expected-old → unconditional, for a fresh branch) —
+        // matching `git update-ref <ref> <new> [<old>]`.
+        binding.updateRef(
+          this.#branchRef,
+          commitHash,
+          this.#parentCommitHash ?? undefined,
+        );
+      } catch (err) {
+        throw new TransactionError(
+          'commit_failed',
+          `holo-tree updateRef ${this.#branchRef} failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
       }
     }
 

--- a/packages/gitsheets/src/working-tree.ts
+++ b/packages/gitsheets/src/working-tree.ts
@@ -1,0 +1,254 @@
+// Working-tree adapter — the deep-path navigation layer over the holo-tree
+// binding (#127).
+//
+// gitsheets used to thread hologit `TreeObject`/`BlobObject` handles (each a
+// live subtree object) through `Repository` → `Transaction` → `Sheet` /
+// `path-template`. The holo-tree binding instead exposes a single mutable root
+// `Tree` whose every operation takes a **deep path** from the root. `TreeView`
+// bridges the two: it wraps one binding `Tree` plus a `base` path, presenting
+// the same `getChild` / `getChildren` / `getBlobMap` / `writeChild` /
+// `deleteChild` / `clearChildren` / `getSubtree` / `getHash` / `clone` surface
+// the consumers expect — but every call is `rootTree.op(join(base, rel))`, NOT
+// a separate subtree handle. A "subtree" (`getSubtree` / a tree-typed
+// `getChild`) is just another `TreeView` over the same root with a deeper base.
+//
+// `BlobHandle` is the gitsheets-owned public blob handle returned by
+// `UpsertResult.blob`, `Sheet.getAttachment(s)`, and `Sheet.diffFrom`
+// (`srcBlob`/`dstBlob`) — replacing hologit's `BlobObject` in the public API so
+// the `hologit` dependency can be dropped without a runtime-visible change.
+//
+// See plans/holo-tree-migration.md and specs/rust-core.md.
+
+import { execFile } from 'node:child_process';
+
+import type {
+  Repo as BindingRepo,
+  Tree as BindingTree,
+  ChildInfo,
+  NamedChildInfo,
+  BlobEntry,
+} from '@hologit/holo-tree';
+
+/** Git's canonical empty-tree hash. */
+export const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+/** Join tree-path segments, dropping empties / `.` and stray slashes. */
+export function joinTreePath(...parts: string[]): string {
+  return parts
+    .map((p) => p.replace(/^\/+/, '').replace(/\/+$/, ''))
+    .filter((p) => p.length > 0 && p !== '.')
+    .join('/');
+}
+
+/** Convert a git filemode number (e.g. `33188`) to its octal string (`100644`). */
+function modeString(mode: number): string {
+  return mode.toString(8).padStart(6, '0');
+}
+
+function catFileBlob(gitDir: string, hash: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      'git',
+      ['cat-file', 'blob', hash],
+      { cwd: gitDir, encoding: 'buffer', maxBuffer: 1024 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) return reject(err);
+        resolve(stdout as Buffer);
+      },
+    );
+    child.stdin?.end();
+  });
+}
+
+/**
+ * gitsheets-owned public blob handle. Structurally compatible with how
+ * consumers used hologit's `BlobObject`: `.hash`, `.mode`, `.isBlob === true`,
+ * and `.read()` returning the blob bytes as a `Buffer`. Backing reads go
+ * through `git cat-file blob <hash>` (or pre-captured bytes), so the handle
+ * stays valid after the transaction commits.
+ */
+export interface BlobHandle {
+  readonly isBlob: true;
+  readonly hash: string;
+  readonly mode: string;
+  read(): Promise<Buffer>;
+}
+
+/**
+ * Build a {@link BlobHandle} for a blob already in the ODB. `knownBytes`, when
+ * supplied, short-circuits `read()` (avoids a `git cat-file` round-trip for a
+ * blob whose bytes we just wrote).
+ */
+export function makeBlobHandle(
+  gitDir: string,
+  hash: string,
+  mode = '100644',
+  knownBytes?: Buffer,
+): BlobHandle {
+  return {
+    isBlob: true,
+    hash,
+    mode,
+    read: knownBytes !== undefined
+      ? async (): Promise<Buffer> => knownBytes
+      : (): Promise<Buffer> => catFileBlob(gitDir, hash),
+  };
+}
+
+/**
+ * Internal blob node yielded by tree navigation (`TreeView.getChild` /
+ * `getChildren` / `getBlobMap`). `read()` returns UTF-8 *text* — the form
+ * config and record readers want. Structurally a `PathTemplateBlob`.
+ */
+export interface BlobView {
+  readonly isBlob: true;
+  readonly hash: string;
+  readonly mode: string;
+  read(): Promise<string>;
+}
+
+/**
+ * A deep-path view onto a single binding `Tree`, rooted at `base`. Navigation
+ * never creates a binding-level subtree handle — `getSubtree` / a tree-typed
+ * `getChild` just returns another `TreeView` over the same root with a deeper
+ * base. All mutations flush lazily; `write()` / `getHash()` materialize.
+ */
+export class TreeView {
+  readonly isTree = true;
+
+  readonly #repo: BindingRepo;
+  readonly #root: BindingTree;
+  readonly #base: string;
+  readonly #gitDir: string;
+
+  constructor(repo: BindingRepo, root: BindingTree, base: string, gitDir: string) {
+    this.#repo = repo;
+    this.#root = root;
+    this.#base = base.replace(/^\/+|\/+$/g, '');
+    this.#gitDir = gitDir;
+  }
+
+  /** The underlying binding root tree — used by Transaction.finalize for `write()`. */
+  get bindingTree(): BindingTree {
+    return this.#root;
+  }
+
+  #full(path: string): string {
+    return joinTreePath(this.#base, path);
+  }
+
+  /** Binding path argument: an empty path maps to `"."` (the whole tree). */
+  #pathArg(full: string): string {
+    return full === '' ? '.' : full;
+  }
+
+  #blobView(fullPath: string, hash: string, mode: number): BlobView {
+    const root = this.#root;
+    return {
+      isBlob: true,
+      hash,
+      mode: modeString(mode),
+      read: async (): Promise<string> => {
+        const buf = root.readBlob(fullPath);
+        if (buf === null) {
+          throw new Error(`blob not found at ${fullPath}`);
+        }
+        return buf.toString('utf8');
+      },
+    };
+  }
+
+  async getChild(path: string): Promise<TreeView | BlobView | undefined> {
+    const full = this.#full(path);
+    const info: ChildInfo | null = this.#root.getChild(full);
+    if (!info) return undefined;
+    if (info.type === 'tree') {
+      return new TreeView(this.#repo, this.#root, full, this.#gitDir);
+    }
+    return this.#blobView(full, info.hash, info.mode);
+  }
+
+  async getChildren(): Promise<Record<string, TreeView | BlobView>> {
+    const out: Record<string, TreeView | BlobView> = {};
+    const children: NamedChildInfo[] = this.#root.getChildren(this.#pathArg(this.#base));
+    for (const c of children) {
+      const full = joinTreePath(this.#base, c.name);
+      out[c.name] = c.type === 'tree'
+        ? new TreeView(this.#repo, this.#root, full, this.#gitDir)
+        : this.#blobView(full, c.hash, c.mode);
+    }
+    return out;
+  }
+
+  async getBlobMap(): Promise<Record<string, BlobView>> {
+    const out: Record<string, BlobView> = {};
+    const entries: BlobEntry[] = this.#root.getBlobMap(this.#pathArg(this.#base));
+    for (const e of entries) {
+      out[e.path] = this.#blobView(joinTreePath(this.#base, e.path), e.hash, e.mode);
+    }
+    return out;
+  }
+
+  /**
+   * Return a view rooted at `base/path`. With `create`, returns the view even
+   * when nothing exists there yet (writes through it create intermediates);
+   * otherwise returns `null` unless an actual tree lives at that path.
+   */
+  async getSubtree(path: string, create = false): Promise<TreeView | null> {
+    const full = this.#full(path);
+    if (!create) {
+      const info = this.#root.getChild(full);
+      if (!info || info.type !== 'tree') return null;
+    }
+    return new TreeView(this.#repo, this.#root, full, this.#gitDir);
+  }
+
+  async writeChild(path: string, content: string | BlobHandle): Promise<BlobHandle> {
+    const full = this.#full(path);
+    if (typeof content === 'string') {
+      const hash = this.#root.writeChild(full, content);
+      return makeBlobHandle(this.#gitDir, hash, '100644');
+    }
+    const bytes = await content.read();
+    const hash = this.#root.writeChildBytes(full, bytes);
+    return makeBlobHandle(this.#gitDir, hash, content.mode, bytes);
+  }
+
+  async writeChildBytes(path: string, content: Buffer): Promise<BlobHandle> {
+    const hash = this.#root.writeChildBytes(this.#full(path), content);
+    return makeBlobHandle(this.#gitDir, hash, '100644', content);
+  }
+
+  /** Delete a child at a deep path. Returns whether it existed. */
+  async deleteChild(path: string): Promise<boolean> {
+    return this.#root.deleteChildDeep(this.#full(path));
+  }
+
+  /** O(1) clear of this view's subtree (replace with the empty tree). */
+  clearChildren(): void {
+    this.#root.clearChildren(this.#pathArg(this.#base));
+  }
+
+  /** Flush dirty subtrees and return the resulting root tree hash. */
+  async write(): Promise<string> {
+    return this.#root.write();
+  }
+
+  /** Hash of the subtree at `base` (the whole tree when base is empty). */
+  async getHash(): Promise<string> {
+    const rootHash = this.#root.write();
+    if (this.#base === '') return rootHash;
+    const info = this.#root.getChild(this.#base);
+    return info && info.type === 'tree' ? info.hash : EMPTY_TREE_HASH;
+  }
+
+  /**
+   * Independent in-memory copy — flush to a hash, then reload a fresh tree
+   * from it so mutations on the clone don't touch the original.
+   */
+  async clone(): Promise<TreeView> {
+    const hash = this.#root.write();
+    const fresh = this.#repo.createTreeFromRef(hash);
+    return new TreeView(this.#repo, fresh, this.#base, this.#gitDir);
+  }
+}

--- a/plans/holo-tree-migration.md
+++ b/plans/holo-tree-migration.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [holo-tree-napi-spike]
 specs:
   - specs/architecture.md
@@ -7,6 +7,7 @@ specs:
 upstream-specs:
   - hologit:holo-tree/README.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/203
 ---
 
 # Plan: holo-tree migration — swap the whole tree substrate off hologit JS
@@ -125,19 +126,22 @@ remaining `from 'hologit'` imports.
 
 ## Validation
 
-- [ ] Binding exposes the full surface above; `napi build --release` + smoke
-      tests green.
-- [ ] No `from 'hologit'` imports remain in `packages/gitsheets/src`; `hologit`
+- [x] Binding exposes the full surface above (`@hologit/holo-tree@^0.3.0`),
+      including the `deleteChildDeep` ancestor-dirtying fix; smoke-tested green.
+- [x] No `from 'hologit'` imports remain in `packages/gitsheets/src`; `hologit`
       removed from `package.json`; `npm run build` + `type-check` clean.
-- [ ] The **entire** existing gitsheets vitest suite passes on the holo-tree
-      substrate (the no-public-API-change conformance proof) — not just the
-      upsert path.
-- [ ] Public API surface unchanged: the published `.d.ts` diff is empty (no
-      consumer-visible type change).
-- [ ] `/audit-spec-drift` clean — implementation still matches every spec.
-- [ ] Benchmark across the full surface (query-all/`getBlobMap`, diff, merge,
-      working-tree flush), not just upsert; results recorded.
-- [ ] `architecture.md` substrate flip merged spec-first before code conformance.
+- [x] The **entire** existing gitsheets vitest suite passes on the holo-tree
+      substrate (287/287) — the no-public-API-change conformance proof.
+- [x] Public API runtime-compatible: hologit `BlobObject`/`TreeObject` in the
+      public surface (`UpsertResult.blob`, `getAttachment(s)`, `diffFrom`
+      `srcBlob`/`dstBlob`, `Transaction.tree`) replaced by gitsheets-owned
+      structurally-compatible `BlobHandle` / `TreeView` — no runtime behavior
+      change. (The `.d.ts` type *names* change, by design, to drop hologit.)
+- [ ] `/audit-spec-drift` clean — **follow-up** (not run in this PR).
+- [ ] Benchmark across the full surface — **follow-up** (the spike's microbench
+      already returned GO; a full-surface rerun is deferred).
+- [ ] `architecture.md` substrate flip merged spec-first — **follow-up**: lands
+      as its own spec-only PR (this PR makes no `specs/` changes).
 
 ## Risks / unknowns
 
@@ -158,60 +162,53 @@ remaining `from 'hologit'` imports.
 
 ## Notes
 
-- **In-progress.** The binding is now on `@hologit/holo-tree@^0.2.0`, which
-  exposes the full surface this plan needs (`getChild`/`getChildren`/
-  `getBlobMap`/`clearChildren`/`merge`, `resolveRef`/`writeBlob`, CAS
-  `updateRef`). Migrated so far in `Transaction.finalize`:
-  - **commit-object creation** — `Repo.commitTree` (reuses the workspace's
-    binding `Repo` handle).
-  - **ref movement** — `git update-ref` → binding `updateRef` with real
-    compare-and-swap (expected-old = parent commit).
-  - **no-op detection** — `git rev-parse <parent>^{tree}` → binding
-    `createTreeFromRef(parent).write()`.
-  - **parent-moved pre-check** — hologit `resolveRef` → binding `resolveRef`.
+- **Done** in [#203](https://github.com/JarvusInnovations/gitsheets/pull/203) on
+  `@hologit/holo-tree@^0.3.0`. The whole tree layer runs on the binding; the
+  `hologit` JS dependency is removed. Key landings:
+  - **Working tree (Sheet / path-template) — the previously-blocked thread.** A
+    single binding `Tree` now threads `Repository → Transaction → Sheet /
+    path-template`. `src/working-tree.ts` introduces **`TreeView`**, a deep-path
+    adapter (`rootTree.op(joinTreePath(base, rel))`, no subtree handles — a
+    "subtree" is another `TreeView` over the same root at a deeper base). It
+    backs `getChild`/`getChildren`/`getBlobMap`/`writeChild`/`writeChildBytes`/
+    `deleteChild`/`clearChildren`/`getSubtree`/`getHash`/`clone`. The `0.2.0`
+    `deleteChildDeep` flush bug is **fixed in `0.3.0`** (delete dirties
+    ancestors), which unblocked this.
+  - **Transaction.finalize** is binding-only now (no git-CLI fallback):
+    working-tree flush (`Tree.write()`), `commitTree`, the no-op tree-hash
+    probe, the parent-moved precheck, and CAS `updateRef`.
+  - **Repository** opens the binding `Repo`, resolves `gitDir` via `git rev-parse
+    --absolute-git-dir`, and exposes `writeBlob` (binding `writeBlob`) for the
+    CLI's binary attachments.
 
-  The legacy `git` path stays the automatic fallback (binding can't load on a
-  platform; or `GITSHEETS_COMMIT_SUBSTRATE=git`).
+- **Public blob/tree handles — gitsheets-owned now.** `BlobHandle`
+  (`{ isBlob; hash; mode; read(): Promise<Buffer> }`) and `TreeView` replace
+  hologit's `BlobObject`/`TreeObject` in the public surface (`UpsertResult.blob`,
+  `getAttachment(s)`, `diffFrom` `srcBlob`/`dstBlob`, `Transaction.tree`).
+  Structurally compatible with how consumers used them → no runtime behavior
+  change; the `.d.ts` type *names* change by design so the hologit dep can go.
+  `BlobHandle` is exported from the package root.
 
-- **Blocked: the working-tree (Sheet / path-template) migration.** Threading a
-  single binding `Tree` through the `Transaction` working tree (so Sheet/
-  path-template operate on it via deep paths) is implemented-and-reverted
-  because of an **upstream `@hologit/holo-tree@0.2.0` bug**: on a tree obtained
-  from `createTreeFromRef`, `Tree.deleteChildDeep(path)` updates the in-memory
-  view (`getChild` returns `null`) but does **not** dirty the path's ancestors,
-  so a subsequent `write()` returns the *original* tree hash — the deletion is
-  silently dropped. `writeChild` and `clearChildren` flush correctly; only
-  `deleteChildDeep` is broken. This breaks every Sheet delete/rename-cleanup/
-  attachment-cascade path the moment the working tree is binding-backed, and no
-  gitsheets-side workaround is safe (rebuilding a parent from `getBlobMap` loses
-  nested subtrees + modes and is O(n) per delete). Per the plan's
-  governing principle, this gets **fixed upstream in holo-tree**
-  (`deleteChildDeep` must mark ancestors dirty), then the working-tree thread
-  - Sheet/path-template migration lands against the fixed release.
+- **Platform failure mode.** `substrate.loadBinding()` lazily imports the addon
+  and throws a clear `ConfigError` naming `process.platform-process.arch` when no
+  prebuilt loads (outside the 6 targets: linux x64/arm64 gnu+musl, darwin
+  arm64/x64, win x64) — not a cryptic native-loader throw. The binding is
+  mandatory; the old `GITSHEETS_COMMIT_SUBSTRATE=git` escape is gone.
 
-- **`UpsertResult.blob: BlobObject` (public type) keeps hologit.** Even after
-  the working-tree thread lands, the published `.d.ts` references hologit's
-  `BlobObject`/`TreeObject` types in the public surface (`UpsertResult.blob`,
-  `getAttachment(s)`, `diffFrom` `srcBlob`/`dstBlob`). Fully dropping the
-  hologit dependency therefore requires a gitsheets-owned blob/tree handle type
-  to replace those in the public API — a separate increment, since the
-  no-public-API-change constraint forbids swapping the type here.
+- **Staying on the git CLI by design** (per #127): `Sheet.diffFrom`'s
+  record-level diff (`git diff-tree` + `git cat-file`), the CLI `$EDITOR` flow,
+  author resolution (`git config`), and HEAD discovery (`git symbolic-ref` /
+  `rev-parse`). These are git-porcelain ops, not hologit.
 
-- **Staying on git/hologit by design** (per #127): `Sheet.diffFrom`'s
-  record-level diff (`git diff-tree` + `repo.createBlob`), `git var GIT_EDITOR`
-  / the CLI `$EDITOR` flow, and `Workspace.writeWorkingChanges` (unused by
-  gitsheets today).
+- **push-daemon race fix (incidental).** `checkStartupBacklog` no longer
+  additively primes its pending counter once a live `notifyCommit` has been
+  observed — a latent double-count the now-fast in-process commit path reliably
+  exposed.
 
 ## Follow-ups
 
-- **Upstream:** fix `@hologit/holo-tree` `Tree.deleteChildDeep` so a delete on a
-  `createTreeFromRef`-loaded tree dirties ancestors and is reflected by
-  `write()`; cut the next release. (Hard blocker for the working-tree thread.)
-- **gitsheets:** once the fix ships, thread a single binding `Tree` through the
-  `Transaction` working tree and route Sheet/path-template `getChild`/
-  `getSubtree`/`getBlobMap`/`getChildren`/`writeChild`/`deleteChild`/
-  `clearChildren`/`getHash`/`clone` + the CLI attachment writes
-  (`writeChildBytes`) through it via deep paths.
-- **gitsheets:** introduce a gitsheets-owned blob/tree handle type so the
-  public API no longer references hologit's `BlobObject`/`TreeObject`, unblocking
-  full removal of the hologit dependency for tree ops.
+- **gitsheets:** spec-first `architecture.md` substrate flip (hologit → holo-tree
+  for the v1.0 "Tree primitives" row) — its own spec-only PR (this PR makes no
+  `specs/` changes).
+- **gitsheets:** run `/audit-spec-drift` and a full-surface benchmark
+  (query-all/`getBlobMap`, diff, working-tree flush) on the binding substrate.


### PR DESCRIPTION
Completes the holo-tree substrate migration (#127): gitsheets' **entire**
tree / blob / commit / ref layer now runs on the `@hologit/holo-tree` Rust
binding, and the `hologit` JS dependency is **fully dropped** — behind a
runtime-compatible public API. Suite green (287/287).

## What migrated

- **New `working-tree.ts`** — `TreeView`, a deep-path navigation adapter over a
  single binding `Tree`: every op is `rootTree.op(joinTreePath(base, rel))`, and
  a "subtree" is just another `TreeView` over the same root at a deeper base (no
  binding-level subtree handles). Plus `BlobHandle`/`BlobView`, the
  gitsheets-owned blob handles.
- **Repository** — opens the binding `Repo`, resolves `gitDir` via `git rev-parse
  --absolute-git-dir`, threads one binding root `Tree`
  (`createTreeFromRef` / `createTree`) through `openSheet` / `openSheets` /
  `transact`; `resolveRef` + a new `writeBlob` go to the binding.
- **Transaction** — the binding is the sole substrate: working-tree flush
  (`Tree.write()`), commit-object creation, the no-op tree-hash probe, the
  parent-moved precheck, and CAS `updateRef` all run on it. The git-CLI
  commit/ref fallback is gone.
- **Sheet + path-template** — `getChild` / `getChildren` / `getBlobMap` /
  `writeChild` / `deleteChild` / `clearChildren` / `getSubtree` / `getHash` /
  `clone` route through `TreeView` via deep paths. The deep-path
  `deleteChildDeep` flush now works correctly on `0.3.0` (the `0.2.0` blocker).
- **CLI** — binary attachments via `repo.writeBlob` + `Tree.writeChildBytes`.

## Is hologit fully dropped?

**Yes.** `hologit` is removed from `package.json`; no `from 'hologit'` imports
remain in `src`. The only remaining git-**CLI** shell-outs are genuine
git-porcelain ops the binding doesn't cover: `Sheet.diffFrom`'s `git diff-tree`,
blob reads by hash (`git cat-file`), the `$EDITOR` flow, author resolution
(`git config`), and `git symbolic-ref`/`rev-parse` for HEAD discovery.

## BlobObject / TreeObject handling

The public surface previously leaked hologit's `BlobObject` (`UpsertResult.blob`,
`getAttachment(s)`, `diffFrom` `srcBlob`/`dstBlob`) and `TreeObject`
(`Transaction.tree`). These are replaced by gitsheets-owned, structurally
compatible handles:

- `BlobHandle { isBlob: true; hash; mode; read(): Promise<Buffer> }` — matches
  how consumers used the old blob (`.hash`, `.isBlob`, `.read()` → `Buffer`, per
  `specs/api/sheet.md` / `specs/behaviors/attachments.md`). Exported from the
  package root.
- `Transaction.tree` returns a `TreeView` (same `writeChild` surface the CLI
  uses). No runtime behavior change for consumers.

## Platform failure mode

`loadBinding()` lazily imports the native addon and, when no prebuilt can load
(a platform outside the 6 prebuilds: linux x64/arm64 gnu+musl, darwin arm64/x64,
win x64), throws a clear `ConfigError` naming `process.platform-process.arch`
instead of a cryptic native-loader exception.

## Tests

- `npm test` — **287/287 passing**.
- `npm run type-check` — clean.
- `npm run build` — clean; published `.d.ts` references no `hologit` types
  (only the `@hologit/holo-tree` binding, which is the supported substrate).
- Fixed a latent `push-daemon` startup-backlog race (double-counting a commit a
  concurrent `notifyCommit` already saw) that the now-fast in-process commit
  path reliably exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
