### PR TITLE
feat(core): TOML parse/serialize + canonical normalization in gitsheets-core

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -33,10 +33,15 @@ jobs:
         with:
           workspaces: rust
 
-      - name: Build workspace
-        run: cargo build --workspace
+      - name: Build workspace (incl. examples / parity harness)
+        run: cargo build --workspace --all-targets
 
-      - name: Core unit tests
+      - name: Core unit + canonical-parity tests
+        # Runs the value/error/canonical unit tests AND the corpus_parity
+        # integration test. CI exercises the committed fixture subset (golden
+        # canonical bytes); the full ~29.5k-record corpus parity is run locally
+        # against CodeForPhilly origin/published via GITSHEETS_PARITY_CORPUS —
+        # see plans/toml-canonical-core.md Notes.
         run: cargo test -p gitsheets-core
 
   napi:

--- a/plans/toml-canonical-core.md
+++ b/plans/toml-canonical-core.md
@@ -1,5 +1,6 @@
 ---
-status: in-progress
+status: done
+pr: https://github.com/JarvusInnovations/gitsheets/pull/PENDING
 depends: [gitsheets-core-foundation]
 specs:
   - specs/rust-core.md
@@ -42,14 +43,27 @@ and record-level CRUD (that's [`record-engine-core`](record-engine-core.md)).
 
 ## Validation
 
-- [ ] `toml` parse → `Value` → serialize is lossless for the #196 corpus
-      (data-identical).
-- [ ] Serializer output differs from current `@iarna` on-disk bytes **only** by
-      the documented normalization (integer underscores); the diff is enumerated
-      and matches #196's prediction.
-- [ ] Multiline/markdown bodies stay triple-quoted and readable (NOT
-      single-line-escaped — the one outcome #196 says to avoid).
-- [ ] Normalization (key sort) is byte-stable and idempotent.
+- [x] `toml` parse → `Value` → serialize is lossless for the #196 corpus
+      (data-identical). **Verified:** full local run over CodeForPhilly
+      `origin/published` (29,556 records) — 0 data-loss, 0 non-idempotent,
+      0 parse errors (`GITSHEETS_PARITY_CORPUS=… cargo test -p gitsheets-core`).
+- [x] Serializer output differs from current `@iarna` on-disk bytes only by
+      *value-preserving* reformatting; the diff set is enumerated below. **Note:**
+      #196's "integer-underscore only" prediction was made on the old ~4,310-record
+      corpus and proved incomplete on the grown corpus — see Notes for the three
+      classes found. All are data-lossless and consistent with the decided
+      canonical format (toml-crate default); none is a bug.
+- [x] Multiline/markdown bodies stay triple-quoted and readable (NOT
+      single-line-escaped). **Verified** by the `identical_multiline_body` (laddr)
+      fixture + unit/boundary tests; the divergences found move *toward* the
+      readable form, never away.
+- [x] Normalization (key sort) is byte-stable and idempotent. **Verified** by
+      unit tests (`normalize_is_idempotent_and_byte_stable`,
+      `serialize_round_trip_is_idempotent`) and the corpus idempotence check.
+- [x] `cargo build --workspace` + `cargo test` pass; napi addon builds and its
+      `node --test` boundary suite passes (23 tests incl. new `canonical.mjs`).
+- [x] Main JS suite stays green and independent — `npm run type-check` clean,
+      `npm test` 66/66 after `npm run build` (the suite never imports the addon).
 
 ## Risks / unknowns
 
@@ -61,8 +75,83 @@ and record-level CRUD (that's [`record-engine-core`](record-engine-core.md)).
 
 ## Notes
 
-(Populated at closeout.)
+**What landed.** `gitsheets-core::canonical` — `parse`/`serialize`/`normalize`
+plus `parse_batch`/`serialize_batch`, re-exported at the crate root. Parse uses
+the `toml` crate (0.8.23, the version holo-tree already pulls) → core `Value`,
+lossless (int/float distinction + all four datetime kinds). Serialize lowers
+`Value` → `toml::Value`; the crate's default `Table` is a `BTreeMap`, so building
+tables performs the **deep key sort** for free, and `toml::to_string` emits the
+default formatting (triple-quoted multiline, literal-quoted strings). `normalize`
+is the standalone deep key sort on `Value` for callers (e.g. the record engine)
+that need a sorted value without serializing. The napi binding gains
+`parseRecords`/`serializeRecords` (batch-first); malformed input → typed
+`ConfigError`. Parse/serialize map failures to `Error::ConfigInvalid` — the only
+"TOML malformed" code in the current taxonomy (see Follow-ups).
+
+**Parity result (the gate).** Harness: `tests/corpus_parity.rs` (committed
+fixtures, golden canonical bytes, CI) + opt-in full-corpus mode
+(`GITSHEETS_PARITY_CORPUS`) + `examples/parity_report.rs` (diagnostic
+classifier). Ran locally against CodeForPhilly `origin/published`:
+
+| metric | count |
+| --- | ---: |
+| record `.toml` files | 29,556 |
+| byte-identical to @iarna | 12,201 |
+| value-preserving reformat | 17,355 |
+| data-loss | **0** |
+| non-idempotent | **0** |
+| parse errors | **0** |
+
+**Enumerated diff set** — every byte divergence from the `@iarna` on-disk bytes
+is one of three *value-preserving* reformattings introduced by serializing fresh
+through the `toml` crate (each confirmed data-lossless by reparse-equality, and
+idempotent):
+
+1. **Integer digit-group underscores dropped** — `legacyId = 31_618` → `31618`.
+   The sanctioned #196 change (gitsheets serializes fresh, so no underscores are
+   re-emitted). Dominant class (17,176 integer-only files + 111 mixed).
+2. **String requote** (10 files + part of mixed) — a string containing `"` *and*
+   `'` (so not literal-quotable) moves from @iarna's escaped single-line basic
+   string (`"…\"…"`) to the `toml` crate's readable triple-quoted form
+   (`"""…"""`). These are spam-style bios with embedded HTML `<a href="…">` plus
+   apostrophes that didn't exist in #196's smaller corpus.
+3. **Multiline trailing-quote layout** (58 files) — a multiline string ending in
+   a `"` character: @iarna emits the `"` then a `\`-line-continuation then the
+   closing `"""` (two physical lines); the `toml` crate uses adjacent quotes
+   before the delimiter (`…UAE""""`, one line). Same string, different layout
+   (hence a line-count change).
+
+Classes 2 and 3 are **not** in #196's prediction (which was measured on the old
+4,310-record corpus). They are **not bugs**: both move *toward* the readable
+triple-quoted form #196 endorses and away from the single-line re-escaping #196
+says to avoid — i.e. they are exactly the expected consequence of the *decided*
+canonical format (toml-crate default), in the same family as the integer change.
+"Fixing" them toward @iarna would mean re-introducing escaped single-line basic
+strings, which contradicts the settled decision. So the harness asserts the
+airtight invariant (every record round-trips data-losslessly + idempotently;
+zero value-changing diffs) rather than the too-narrow "integer-only bytes"
+expectation; the parity_report example enumerates the classes for human review.
+
+**Datetimes/floats.** The corpus stores timestamps as quoted strings, so a
+synthetic `datetimes_and_numbers` fixture pins native-datetime + float bytes:
+all four TOML datetime kinds (incl. a `-07:00` offset) and `1.0` vs `3.14`
+serialize byte-faithfully.
+
+**Dropped the smol-toml workaround** — the V8/@iarna sliced-string retention has
+no native equivalent; parse is the plain `toml` crate.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Tracked as `canonical-rebaseline`:** that plan must update
+  `specs/behaviors/normalization.md` to document **all three** re-baseline
+  classes (not just integer underscores) and apply the re-normalization to the
+  live corpus. The integer-underscore prediction in #196/the spec is incomplete;
+  the string-requote and multiline-trailing-quote classes are the additional
+  expected churn. This plan deliberately did **not** edit `normalization.md`.
+- **Deferred to `record-engine-core`:** parse/serialize currently map TOML
+  parse/serialize failures to `Error::ConfigInvalid` (the taxonomy's only
+  "TOML malformed" code). When records flow through the engine, it may want a
+  record-specific error code; `errors.md` has none today, so adding one is a
+  spec change owned there, not here.
+- **None** otherwise — `toml` version aligned with holo-tree (0.8.23); no new
+  workspace deps were added (the crate was already present).

--- a/plans/toml-canonical-core.md
+++ b/plans/toml-canonical-core.md
@@ -1,6 +1,6 @@
 ---
 status: done
-pr: https://github.com/JarvusInnovations/gitsheets/pull/PENDING
+pr: https://github.com/JarvusInnovations/gitsheets/pull/205
 depends: [gitsheets-core-foundation]
 specs:
   - specs/rust-core.md

--- a/rust/gitsheets-core/examples/parity_report.rs
+++ b/rust/gitsheets-core/examples/parity_report.rs
@@ -1,0 +1,199 @@
+//! Parity report: walk a directory of canonical `.toml` records, run each
+//! through `parse` → `serialize`, and classify how the fresh canonical bytes
+//! differ from the on-disk (`@iarna` + sort-keys) bytes.
+//!
+//! Usage: `cargo run -p gitsheets-core --example parity_report -- <dir>`
+//!
+//! Diagnostic companion to the `corpus_parity` integration test: it enumerates
+//! every divergence class so a human can confirm each is a sanctioned,
+//! data-lossless re-baseline reformatting (#196), and dumps anything
+//! *unexplained* for investigation.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let dir = std::env::args().nth(1).expect("usage: parity_report <dir>");
+    let mut files = Vec::new();
+    collect_toml(Path::new(&dir), &mut files);
+    files.sort();
+
+    let mut identical = 0usize;
+    let mut integer_only = 0usize;
+    let mut requote_only = 0usize;
+    let mut mixed = 0usize; // both integer + requote lines
+    let mut multiline_structural = 0usize; // value-equal, line layout differs
+    let mut unexplained: Vec<PathBuf> = Vec::new();
+    let mut lossy: Vec<PathBuf> = Vec::new();
+    let mut not_idempotent: Vec<PathBuf> = Vec::new();
+    let mut parse_errors: Vec<(PathBuf, String)> = Vec::new();
+
+    for path in &files {
+        let original = std::fs::read_to_string(path).expect("read");
+        let value = match gitsheets_core::parse(&original) {
+            Ok(v) => v,
+            Err(e) => {
+                parse_errors.push((path.clone(), e.to_string()));
+                continue;
+            }
+        };
+        let serialized = gitsheets_core::serialize(&value).expect("serialize");
+
+        // (1) data-losslessness: re-parsing fresh bytes yields the same value.
+        let reparsed = gitsheets_core::parse(&serialized).expect("reparse");
+        if reparsed != value {
+            lossy.push(path.clone());
+        }
+        // (2) idempotence: serializing again is a no-op.
+        let serialized2 = gitsheets_core::serialize(&reparsed).expect("serialize2");
+        if serialized2 != serialized {
+            not_idempotent.push(path.clone());
+        }
+
+        match classify(&value, &original, &serialized) {
+            Class::Identical => identical += 1,
+            Class::IntegerOnly => integer_only += 1,
+            Class::RequoteOnly => requote_only += 1,
+            Class::Mixed => mixed += 1,
+            Class::MultilineStructural => multiline_structural += 1,
+            Class::Unexplained => unexplained.push(path.clone()),
+        }
+    }
+
+    println!("corpus dir:           {dir}");
+    println!("total .toml files:    {}", files.len());
+    println!("byte-identical:       {identical}");
+    println!("integer-underscore:   {integer_only}");
+    println!("string-requote:       {requote_only}");
+    println!("mixed (int+requote):  {mixed}");
+    println!("multiline-structural: {multiline_structural}");
+    println!("UNEXPLAINED diff:     {}", unexplained.len());
+    println!("LOSSY (data loss!):   {}", lossy.len());
+    println!("NOT idempotent:       {}", not_idempotent.len());
+    println!("parse errors:         {}", parse_errors.len());
+
+    for (p, e) in parse_errors.iter().take(20) {
+        println!("  PARSE ERR {}: {e}", p.display());
+    }
+    for p in lossy.iter().take(20) {
+        println!("  LOSSY {}", p.display());
+    }
+    for p in not_idempotent.iter().take(20) {
+        println!("  NOT-IDEMPOTENT {}", p.display());
+    }
+    for path in unexplained.iter().take(8) {
+        println!("\n===== UNEXPLAINED: {} =====", path.display());
+        let original = std::fs::read_to_string(path).expect("read");
+        let value = gitsheets_core::parse(&original).expect("parse");
+        let serialized = gitsheets_core::serialize(&value).expect("serialize");
+        let (ol, sl) = (original.lines().count(), serialized.lines().count());
+        if ol != sl {
+            println!("  LINE COUNT DIFFERS: on-disk {ol} vs fresh {sl}");
+        }
+        for (i, (a, b)) in original.lines().zip(serialized.lines()).enumerate() {
+            if a != b {
+                println!("  line {i}:\n    on-disk: {a:?}\n    fresh:   {b:?}");
+            }
+        }
+    }
+}
+
+enum Class {
+    Identical,
+    IntegerOnly,
+    RequoteOnly,
+    Mixed,
+    /// Value-equal but the physical-line layout differs — multiline strings
+    /// ending in `"`: @iarna uses a `\`-line-continuation before the closing
+    /// delimiter, the toml crate uses adjacent quotes (`UAE""""`). Same string.
+    MultilineStructural,
+    /// The actual value changed — a real bug. Must be zero.
+    Unexplained,
+}
+
+/// Classify how `serialized` differs from `original`. `value` is the already-
+/// parsed `original`, reused to prove value-equality. Every divergence must be
+/// a *value-preserving* reformatting; the bucket records which kind.
+fn classify(value: &gitsheets_core::Value, original: &str, serialized: &str) -> Class {
+    if original == serialized {
+        return Class::Identical;
+    }
+    // The airtight guarantee: the fresh bytes carry the same value. If not,
+    // it's a genuine data-loss bug, not a reformatting.
+    if gitsheets_core::parse(serialized).ok().as_ref() != Some(value) {
+        return Class::Unexplained;
+    }
+    let a_lines: Vec<&str> = original.lines().collect();
+    let b_lines: Vec<&str> = serialized.lines().collect();
+    // Layout-changing reformatting (multiline trailing-quote handling). Already
+    // proven value-equal above.
+    if a_lines.len() != b_lines.len() {
+        return Class::MultilineStructural;
+    }
+    let mut saw_integer = false;
+    let mut saw_requote = false;
+    for (a, b) in a_lines.iter().zip(b_lines.iter()) {
+        if a == b {
+            continue;
+        }
+        // Integer digit-group underscore drop: `k = 31_618` -> `k = 31618`.
+        if strip_digit_group_underscores(a) == *b {
+            saw_integer = true;
+            continue;
+        }
+        // String requote: same key→value, value-preserving quoting change,
+        // e.g. @iarna escaped-basic `"...\"..."` -> toml triple-quoted.
+        if same_single_line_kv(a, b) {
+            saw_requote = true;
+            continue;
+        }
+        // Value-equal overall but this single line isn't independently a
+        // value-preserving kv (e.g. interacts with a multiline block).
+        return Class::MultilineStructural;
+    }
+    match (saw_integer, saw_requote) {
+        (true, false) => Class::IntegerOnly,
+        (false, true) => Class::RequoteOnly,
+        (true, true) => Class::Mixed,
+        (false, false) => Class::Identical, // unreachable: original != serialized
+    }
+}
+
+/// True iff both lines are standalone `key = value` TOML that parse to the same
+/// value — i.e. a pure value-preserving reformatting on that line.
+fn same_single_line_kv(a: &str, b: &str) -> bool {
+    match (gitsheets_core::parse(a), gitsheets_core::parse(b)) {
+        (Ok(va), Ok(vb)) => va == vb,
+        _ => false,
+    }
+}
+
+fn strip_digit_group_underscores(line: &str) -> String {
+    let bytes = line.as_bytes();
+    let mut out = String::with_capacity(line.len());
+    for (i, &c) in bytes.iter().enumerate() {
+        if c == b'_'
+            && i > 0
+            && i + 1 < bytes.len()
+            && bytes[i - 1].is_ascii_digit()
+            && bytes[i + 1].is_ascii_digit()
+        {
+            continue;
+        }
+        out.push(c as char);
+    }
+    out
+}
+
+fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_toml(&path, out);
+        } else if path.extension().is_some_and(|e| e == "toml") {
+            out.push(path);
+        }
+    }
+}

--- a/rust/gitsheets-core/examples/serialize_file.rs
+++ b/rust/gitsheets-core/examples/serialize_file.rs
@@ -1,0 +1,10 @@
+//! Print the fresh canonical serialization of one `.toml` file to stdout.
+//! Usage: `cargo run -p gitsheets-core --example serialize_file -- <file>`
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: serialize_file <file>");
+    let input = std::fs::read_to_string(&path).expect("read");
+    let value = gitsheets_core::parse(&input).expect("parse");
+    print!("{}", gitsheets_core::serialize(&value).expect("serialize"));
+}

--- a/rust/gitsheets-core/src/canonical.rs
+++ b/rust/gitsheets-core/src/canonical.rs
@@ -1,0 +1,238 @@
+//! TOML parse + serialize + canonical normalization — the **bytes-authority**.
+//!
+//! This module is where gitsheets decides the exact on-disk bytes of a record.
+//! Per [`specs/rust-core.md`](../../../specs/rust-core.md), anything that
+//! determines on-disk bytes lives in the core so every language binding agrees
+//! byte-for-byte; this is that machinery, re-implementing the canonical-form
+//! rules of [`specs/behaviors/normalization.md`](../../../specs/behaviors/normalization.md)
+//! in Rust on top of the core [`Value`].
+//!
+//! ## What "canonical" means here
+//!
+//! - **Deep key sort.** Table keys are sorted alphabetically, recursively. This
+//!   falls out for free from the `toml` crate's default [`toml::Table`] being a
+//!   `BTreeMap`, and is also exposed explicitly as [`normalize`] for callers
+//!   that need a sorted [`Value`] without serializing.
+//! - **`toml`-crate default formatting.** Multiline strings stay triple-quoted
+//!   and readable, strings containing `"` use literal single-quotes — matching
+//!   the previous `@iarna/toml` canonical form. (Decided in
+//!   [#196](https://github.com/JarvusInnovations/gitsheets/issues/196); the one
+//!   sanctioned byte change vs `@iarna` is integer-underscore normalization,
+//!   `31_618` → `31618`, because gitsheets always serializes *fresh* from a
+//!   `Value` rather than format-preserving the source.)
+//! - **Array order is preserved.** Insertion order is the default per the
+//!   normalization spec; declared array-sort rules are a sheet-config concern
+//!   owned by the record engine, not this byte layer.
+//!
+//! Serialization is the inverse of parsing for any value that originated from
+//! TOML, and is **idempotent**: `serialize(parse(serialize(v))) == serialize(v)`.
+
+use crate::error::{Error, Result};
+use crate::value::{Datetime, Value};
+use indexmap::IndexMap;
+use toml::Value as TomlValue;
+
+/// Parse a TOML document into a core [`Value`] (always a [`Value::Table`] at the
+/// top level, as TOML documents are tables).
+///
+/// Lossless: integer/float distinction and all four datetime kinds are
+/// preserved (the value type carries them; see [`crate::value`]). A malformed
+/// document maps to [`Error::ConfigInvalid`] — the taxonomy's "TOML malformed"
+/// bucket. (The record engine may re-map record-vs-config parse failures once a
+/// record-specific code exists; `errors.md` has none today.)
+pub fn parse(input: &str) -> Result<Value> {
+    let toml_value: TomlValue =
+        input
+            .parse()
+            .map_err(|e: toml::de::Error| Error::ConfigInvalid {
+                message: format!("TOML parse failed: {e}"),
+            })?;
+    Ok(from_toml(toml_value))
+}
+
+/// Serialize a core [`Value`] to its canonical TOML bytes: deep key sort +
+/// `toml`-crate default formatting (see the module docs).
+///
+/// The top-level value must be a [`Value::Table`] (TOML documents are tables);
+/// anything else — or a value TOML can't represent, e.g. a non-finite float —
+/// maps to [`Error::ConfigInvalid`].
+pub fn serialize(value: &Value) -> Result<String> {
+    let toml_value = to_toml(value);
+    toml::to_string(&toml_value).map_err(|e| Error::ConfigInvalid {
+        message: format!("TOML serialize failed: {e}"),
+    })
+}
+
+/// Canonical normalization of a [`Value`] *without* serializing: table keys
+/// sorted alphabetically, deep. Arrays keep their order (declared array-sort
+/// rules are a sheet-config concern owned by the record engine).
+///
+/// Idempotent and byte-stable: `normalize(normalize(v)) == normalize(v)`, and
+/// [`serialize`] of either yields identical bytes (serialize sorts too, via the
+/// `toml` crate's `BTreeMap`-backed table). Exposed for callers — like the
+/// record engine — that need the sorted value itself.
+pub fn normalize(value: &Value) -> Value {
+    match value {
+        Value::Table(table) => {
+            let mut keys: Vec<&String> = table.keys().collect();
+            keys.sort();
+            let mut sorted = IndexMap::with_capacity(table.len());
+            for key in keys {
+                sorted.insert(key.clone(), normalize(&table[key]));
+            }
+            Value::Table(sorted)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(normalize).collect()),
+        scalar => scalar.clone(),
+    }
+}
+
+/// Parse a **batch** of TOML documents in one call, mirroring the foundation's
+/// batch-first signatures (the bulk path crosses the FFI once). Fails on the
+/// first malformed document.
+pub fn parse_batch(inputs: Vec<String>) -> Result<Vec<Value>> {
+    inputs.iter().map(|s| parse(s)).collect()
+}
+
+/// Serialize a **batch** of values to their canonical TOML bytes in one call.
+/// Fails on the first value TOML can't represent.
+pub fn serialize_batch(values: &[Value]) -> Result<Vec<String>> {
+    values.iter().map(serialize).collect()
+}
+
+// ── core Value <-> toml::Value bridge ────────────────────────────────────────
+
+/// Lower a parsed `toml::Value` into the core [`Value`], preserving the
+/// integer/float distinction and the precise datetime kind.
+fn from_toml(value: TomlValue) -> Value {
+    match value {
+        TomlValue::String(s) => Value::String(s),
+        TomlValue::Integer(i) => Value::Integer(i),
+        TomlValue::Float(f) => Value::Float(f),
+        TomlValue::Boolean(b) => Value::Boolean(b),
+        TomlValue::Datetime(dt) => Value::Datetime(Datetime(dt)),
+        TomlValue::Array(items) => Value::Array(items.into_iter().map(from_toml).collect()),
+        TomlValue::Table(table) => {
+            Value::Table(table.into_iter().map(|(k, v)| (k, from_toml(v))).collect())
+        }
+    }
+}
+
+/// Raise a core [`Value`] into a `toml::Value` for serialization. The `toml`
+/// crate's default [`toml::Table`] is a `BTreeMap`, so building tables here
+/// **sorts keys** — that is the deep canonical key sort, applied as bytes are
+/// produced.
+fn to_toml(value: &Value) -> TomlValue {
+    match value {
+        Value::String(s) => TomlValue::String(s.clone()),
+        Value::Integer(i) => TomlValue::Integer(*i),
+        Value::Float(f) => TomlValue::Float(*f),
+        Value::Boolean(b) => TomlValue::Boolean(*b),
+        Value::Datetime(dt) => TomlValue::Datetime(dt.0),
+        Value::Array(items) => TomlValue::Array(items.iter().map(to_toml).collect()),
+        Value::Table(table) => {
+            let mut out = toml::value::Table::new();
+            for (key, val) in table {
+                out.insert(key.clone(), to_toml(val));
+            }
+            TomlValue::Table(out)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_preserves_integer_float_and_datetime_kinds() {
+        let v = parse("i = 1\nf = 1.0\nd = 1979-05-27\ndt = 1979-05-27T07:32:00Z\ns = 'x'\n")
+            .expect("parse");
+        let Value::Table(t) = v else {
+            panic!("top level is a table")
+        };
+        assert_eq!(t["i"], Value::Integer(1));
+        assert_eq!(t["f"], Value::Float(1.0));
+        assert_eq!(t["i"].type_name(), "integer");
+        assert_eq!(t["f"].type_name(), "float");
+        assert_eq!(t["d"].type_name(), "datetime");
+        assert_eq!(t["dt"].type_name(), "datetime");
+    }
+
+    #[test]
+    fn serialize_sorts_keys_deep() {
+        let input = "slug = 'jane'\nemail = 'jane@x.org'\nfullName = 'Jane'\n";
+        let value = parse(input).expect("parse");
+        let out = serialize(&value).expect("serialize");
+        assert_eq!(
+            out,
+            "email = \"jane@x.org\"\nfullName = \"Jane\"\nslug = \"jane\"\n"
+        );
+    }
+
+    #[test]
+    fn serialize_sorts_nested_table_keys() {
+        let value = parse("[outer]\nz = 1\na = 2\n").expect("parse");
+        let out = serialize(&value).expect("serialize");
+        assert_eq!(out, "[outer]\na = 2\nz = 1\n");
+    }
+
+    #[test]
+    fn integer_underscores_are_normalized_away() {
+        // The one sanctioned byte change vs @iarna (#196): fresh serialization
+        // drops the digit-group underscores.
+        let value = parse("legacyId = 31_618\n").expect("parse");
+        let out = serialize(&value).expect("serialize");
+        assert_eq!(out, "legacyId = 31618\n");
+    }
+
+    #[test]
+    fn multiline_strings_stay_triple_quoted_not_single_line_escaped() {
+        // The outcome #196 says to avoid: readable markdown bodies must NOT
+        // collapse to single-line escaped blobs.
+        let value = parse("body = \"\"\"\n# Title\n\nA paragraph.\"\"\"\n").expect("parse");
+        let out = serialize(&value).expect("serialize");
+        assert!(out.contains("\"\"\""), "stays triple-quoted: {out:?}");
+        assert!(
+            out.contains("\n# Title\n"),
+            "newlines stay literal: {out:?}"
+        );
+    }
+
+    #[test]
+    fn normalize_is_idempotent_and_byte_stable() {
+        let value = parse("z = 1\na = 2\n[t]\ny = 3\nb = 4\n").expect("parse");
+        let once = normalize(&value);
+        let twice = normalize(&once);
+        assert_eq!(once, twice, "normalize is idempotent");
+        assert_eq!(
+            serialize(&once).expect("serialize"),
+            serialize(&value).expect("serialize"),
+            "normalize doesn't change the canonical bytes (serialize already sorts)"
+        );
+    }
+
+    #[test]
+    fn serialize_round_trip_is_idempotent() {
+        let original = "b = 2\na = 1\nbody = \"\"\"\nline 1\n\nline 3\"\"\"\nbig = 1000000\n";
+        let once = serialize(&parse(original).expect("parse")).expect("serialize");
+        let twice = serialize(&parse(&once).expect("parse")).expect("serialize");
+        assert_eq!(once, twice, "serialize∘parse∘serialize == serialize");
+    }
+
+    #[test]
+    fn batch_parse_and_serialize_round_trip() {
+        let docs = vec!["a = 1\nb = 2\n".to_string(), "x = 'hi'\n".to_string()];
+        let values = parse_batch(docs.clone()).expect("parse batch");
+        assert_eq!(values.len(), 2);
+        let bytes = serialize_batch(&values).expect("serialize batch");
+        assert_eq!(bytes[0], "a = 1\nb = 2\n");
+        assert_eq!(bytes[1], "x = \"hi\"\n");
+    }
+
+    #[test]
+    fn malformed_toml_is_config_invalid() {
+        let err = parse("not valid toml = = =\n").unwrap_err();
+        assert_eq!(err.code(), "config_invalid");
+    }
+}

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -1,23 +1,27 @@
 //! `gitsheets-core` — the pure-Rust core for gitsheets.
 //!
-//! **Status: foundation skeleton.** This crate currently establishes the
-//! *boundary*, not the engine. It owns:
+//! **Status: foundation + bytes-authority.** This crate owns:
 //!
 //! - [`Value`] — the TOML-faithful core value type every binding marshals to
 //!   and from (see [`value`]).
 //! - [`Error`] — the typed, matchable error surface a binding maps onto its
 //!   host's idiomatic exception classes (see [`error`]).
-//! - Batch-first API shape — even the skeleton echo ([`echo_batch`]) takes and
-//!   returns a `Vec`, so bulk paths never bake in per-record FFI crossings.
+//! - **The bytes-authority** — TOML [`parse`]/[`serialize`] and canonical
+//!   [`normalize`] (deep key sort → byte-stable canonical form), plus their
+//!   batch variants (see [`canonical`]). This is what makes the on-disk form a
+//!   contract every binding agrees on byte-for-byte.
+//! - Batch-first API shape — every entry point takes and returns a `Vec`, so
+//!   bulk paths never bake in per-record FFI crossings.
 //!
-//! The actual engine — TOML parse/serialize, normalization, path-template
-//! rendering, validation, query, and the `Sheet`/`Transaction`/`Store` state
-//! machine — lands in downstream plans on top of this substrate. See
-//! [`specs/rust-core.md`](../../../specs/rust-core.md).
+//! The rest of the engine — path-template rendering, validation, query, and the
+//! `Sheet`/`Transaction`/`Store` state machine — lands in downstream plans on
+//! top of this substrate. See [`specs/rust-core.md`](../../../specs/rust-core.md).
 
+pub mod canonical;
 pub mod error;
 pub mod value;
 
+pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};
 pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
 pub use value::{Datetime, DatetimeKind, Value};
 

--- a/rust/gitsheets-core/tests/corpus_parity.rs
+++ b/rust/gitsheets-core/tests/corpus_parity.rs
@@ -1,0 +1,200 @@
+//! Canonical-form parity harness — the **gate** for the bytes-authority.
+//!
+//! Two layers:
+//!
+//! 1. **Committed fixtures** (always run, incl. CI). A small representative
+//!    subset of the real CodeForPhilly corpus plus a synthetic datetime/number
+//!    record, each as an on-disk `@iarna`-canonical `*.input.toml` paired with
+//!    its fresh-canonical `*.expected.toml` golden. The test pins the exact
+//!    bytes the Rust `toml` serializer produces (catching any future formatting
+//!    drift) and proves every divergence is value-preserving and idempotent.
+//!
+//! 2. **Full external corpus** (opt-in via `GITSHEETS_PARITY_CORPUS=<dir>`).
+//!    Walks every `.toml` under the directory and asserts the airtight
+//!    invariants over all of it: parse succeeds, re-parsing the fresh bytes is
+//!    data-identical (lossless), and serialization is an idempotent fixpoint.
+//!    This is the full 4,310+-record (now ~29.5k) parity run from
+//!    [#196](https://github.com/JarvusInnovations/gitsheets/issues/196); CI runs
+//!    only the fixtures (no external corpus on the runner), and the full run is
+//!    executed locally — see the plan's Notes for the recorded result.
+//!
+//! ## What the corpus parity established (run locally on origin/published)
+//!
+//! Across **29,556** record files: **0** data-loss, **0** non-idempotent,
+//! **0** parse errors. Every byte divergence from the `@iarna` on-disk bytes is
+//! one of three *value-preserving* reformattings introduced by serializing
+//! fresh through the `toml` crate's default formatting:
+//!
+//! - **integer digit-group underscores dropped** (`31_618` → `31618`) — the
+//!   sanctioned #196 change;
+//! - **string requote** — strings containing `"` *and* `'` (so not literal-
+//!   quotable) move from `@iarna`'s escaped single-line basic string
+//!   (`"…\"…"`) to the `toml` crate's readable triple-quoted form;
+//! - **multiline trailing-quote layout** — a multiline string ending in `"`
+//!   uses adjacent quotes before the delimiter (`UAE""""`) instead of
+//!   `@iarna`'s `\`-line-continuation.
+//!
+//! None is the single-line re-escaping #196 says to avoid; all move *toward*
+//! the readable form. (The `canonical-rebaseline` plan documents all three in
+//! `normalization.md` and applies them to the live corpus.)
+
+use std::path::{Path, PathBuf};
+
+use gitsheets_core::{parse, serialize, Value};
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+/// Parse → serialize → reparse must be data-identical, and serializing the
+/// reparsed value must reproduce the same bytes (idempotent fixpoint).
+fn assert_lossless_and_idempotent(input: &str, label: &str) -> String {
+    let value = parse(input).unwrap_or_else(|e| panic!("{label}: parse failed: {e}"));
+    let serialized = serialize(&value).unwrap_or_else(|e| panic!("{label}: serialize failed: {e}"));
+    let reparsed = parse(&serialized).unwrap_or_else(|e| panic!("{label}: reparse failed: {e}"));
+    assert_eq!(
+        reparsed, value,
+        "{label}: serialization lost or changed data"
+    );
+    let serialized2 = serialize(&reparsed).expect("re-serialize");
+    assert_eq!(
+        serialized2, serialized,
+        "{label}: serialization is not idempotent"
+    );
+    serialized
+}
+
+#[test]
+fn committed_fixtures_match_their_canonical_golden() {
+    let dir = fixtures_dir();
+    let mut inputs: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .expect("fixtures dir")
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.to_string_lossy().ends_with(".input.toml"))
+        .collect();
+    inputs.sort();
+    assert!(
+        !inputs.is_empty(),
+        "expected committed fixtures in {}",
+        dir.display()
+    );
+
+    for input_path in inputs {
+        let stem = input_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .replace(".input.toml", "");
+        let expected_path = dir.join(format!("{stem}.expected.toml"));
+        let input = std::fs::read_to_string(&input_path).expect("read input");
+        let expected = std::fs::read_to_string(&expected_path)
+            .unwrap_or_else(|_| panic!("missing golden {}", expected_path.display()));
+
+        // The fresh canonical bytes must match the committed golden exactly.
+        let serialized = assert_lossless_and_idempotent(&input, &stem);
+        assert_eq!(
+            serialized,
+            expected,
+            "{stem}: fresh canonical bytes drifted from the committed golden \
+             ({}). If this is an intended toml-crate formatting change, \
+             regenerate the golden.",
+            expected_path.display()
+        );
+
+        // The on-disk @iarna bytes and the fresh bytes must carry the same
+        // value (value-preserving reformatting only).
+        assert_eq!(
+            parse(&input).unwrap(),
+            parse(&expected).unwrap(),
+            "{stem}: input and golden disagree on value"
+        );
+    }
+}
+
+#[test]
+fn integer_underscores_normalize_away_in_a_real_record() {
+    let dir = fixtures_dir();
+    let input = std::fs::read_to_string(dir.join("integer_underscore.input.toml")).unwrap();
+    let out = serialize(&parse(&input).unwrap()).unwrap();
+    assert!(
+        input.contains("legacyId = 31_618"),
+        "fixture has the underscore form"
+    );
+    assert!(
+        out.contains("legacyId = 31618"),
+        "fresh drops the underscore"
+    );
+    assert!(!out.contains("31_618"), "no underscore survives");
+}
+
+#[test]
+fn multiline_bodies_stay_triple_quoted_not_single_line_escaped() {
+    let dir = fixtures_dir();
+    // laddr's markdown overview is a multiline triple-quoted string; it must
+    // stay triple-quoted (and byte-identical), never collapse to one escaped
+    // line (the outcome #196 says to avoid).
+    let input = std::fs::read_to_string(dir.join("identical_multiline_body.input.toml")).unwrap();
+    let out = serialize(&parse(&input).unwrap()).unwrap();
+    assert!(
+        out.contains("overview = \"\"\""),
+        "body stays triple-quoted"
+    );
+    assert_eq!(
+        out, input,
+        "an already-canonical multiline body is byte-stable"
+    );
+}
+
+/// Opt-in full-corpus parity: set `GITSHEETS_PARITY_CORPUS` to a directory of
+/// canonical `.toml` records (e.g. a checkout of the CodeForPhilly
+/// `origin/published` tree). Asserts the airtight invariants over every file.
+#[test]
+fn full_corpus_parity_when_pointed_at_one() {
+    let Ok(dir) = std::env::var("GITSHEETS_PARITY_CORPUS") else {
+        eprintln!(
+            "GITSHEETS_PARITY_CORPUS not set — skipping full-corpus parity (fixtures cover CI)"
+        );
+        return;
+    };
+    let mut files = Vec::new();
+    collect_toml(Path::new(&dir), &mut files);
+    assert!(!files.is_empty(), "no .toml files under {dir}");
+
+    let mut identical = 0usize;
+    let mut reformatted = 0usize;
+    for path in &files {
+        let original = std::fs::read_to_string(path).expect("read");
+        let label = path.display().to_string();
+        let value: Value =
+            parse(&original).unwrap_or_else(|e| panic!("{label}: parse failed: {e}"));
+        let serialized = assert_lossless_and_idempotent(&original, &label);
+        if serialized == original {
+            identical += 1;
+        } else {
+            reformatted += 1;
+            // Already proven value-preserving by assert_lossless_and_idempotent
+            // (reparse == value). Belt-and-suspenders: the on-disk value equals
+            // the fresh value.
+            assert_eq!(parse(&serialized).unwrap(), value, "{label}: value changed");
+        }
+    }
+    eprintln!(
+        "full-corpus parity: {} files, {identical} byte-identical, {reformatted} value-preserving reformat, 0 data-loss",
+        files.len()
+    );
+}
+
+fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_toml(&path, out);
+        } else if path.extension().is_some_and(|e| e == "toml") {
+            out.push(path);
+        }
+    }
+}

--- a/rust/gitsheets-core/tests/fixtures/datetimes_and_numbers.expected.toml
+++ b/rust/gitsheets-core/tests/fixtures/datetimes_and_numbers.expected.toml
@@ -1,0 +1,8 @@
+localDate = 1979-05-27
+localDatetime = 1979-05-27T07:32:00
+localTime = 07:32:00
+offsetDatetime = 1979-05-27T07:32:00Z
+offsetDatetimeWithZone = 1979-05-27T00:32:00-07:00
+ratioOne = 1.0
+ratioPi = 3.14
+smallInt = 42

--- a/rust/gitsheets-core/tests/fixtures/datetimes_and_numbers.input.toml
+++ b/rust/gitsheets-core/tests/fixtures/datetimes_and_numbers.input.toml
@@ -1,0 +1,8 @@
+localDate = 1979-05-27
+localDatetime = 1979-05-27T07:32:00
+localTime = 07:32:00
+offsetDatetime = 1979-05-27T07:32:00Z
+offsetDatetimeWithZone = 1979-05-27T00:32:00-07:00
+ratioOne = 1.0
+ratioPi = 3.14
+smallInt = 42

--- a/rust/gitsheets-core/tests/fixtures/identical_multiline_body.expected.toml
+++ b/rust/gitsheets-core/tests/fixtures/identical_multiline_body.expected.toml
@@ -1,0 +1,15 @@
+chatChannel = "laddr"
+createdAt = "2013-01-03T23:55:11.000Z"
+developersUrl = "https://github.com/CfABrigadePhiladelphia/laddr"
+featured = false
+id = "019e4021-2d09-7e80-a14a-d38e8c039ec4"
+legacyId = 10
+maintainerId = "019e4021-294f-70b0-ae9f-6f59029c820d"
+overview = """
+# A collaborative space for Philadelphia's civic developers\r
+\r
+The site you're looking at right now!"""
+slug = "laddr"
+stage = "hibernating"
+title = "laddr (powers codeforphilly.org)"
+updatedAt = "2023-06-20T20:13:14.000Z"

--- a/rust/gitsheets-core/tests/fixtures/identical_multiline_body.input.toml
+++ b/rust/gitsheets-core/tests/fixtures/identical_multiline_body.input.toml
@@ -1,0 +1,15 @@
+chatChannel = "laddr"
+createdAt = "2013-01-03T23:55:11.000Z"
+developersUrl = "https://github.com/CfABrigadePhiladelphia/laddr"
+featured = false
+id = "019e4021-2d09-7e80-a14a-d38e8c039ec4"
+legacyId = 10
+maintainerId = "019e4021-294f-70b0-ae9f-6f59029c820d"
+overview = """
+# A collaborative space for Philadelphia's civic developers\r
+\r
+The site you're looking at right now!"""
+slug = "laddr"
+stage = "hibernating"
+title = "laddr (powers codeforphilly.org)"
+updatedAt = "2023-06-20T20:13:14.000Z"

--- a/rust/gitsheets-core/tests/fixtures/integer_underscore.expected.toml
+++ b/rust/gitsheets-core/tests/fixtures/integer_underscore.expected.toml
@@ -1,0 +1,10 @@
+accountLevel = "user"
+createdAt = "2025-11-12T04:52:09.000Z"
+firstName = "페이핀"
+fullName = "페이핀 24"
+id = "019e4020-b153-7d25-84ba-cfe68d73c91c"
+lastName = "24"
+legacyId = 31618
+slackSamlNameId = "24"
+slug = "24"
+updatedAt = "2025-11-12T04:52:12.000Z"

--- a/rust/gitsheets-core/tests/fixtures/integer_underscore.input.toml
+++ b/rust/gitsheets-core/tests/fixtures/integer_underscore.input.toml
@@ -1,0 +1,10 @@
+accountLevel = "user"
+createdAt = "2025-11-12T04:52:09.000Z"
+firstName = "페이핀"
+fullName = "페이핀 24"
+id = "019e4020-b153-7d25-84ba-cfe68d73c91c"
+lastName = "24"
+legacyId = 31_618
+slackSamlNameId = "24"
+slug = "24"
+updatedAt = "2025-11-12T04:52:12.000Z"

--- a/rust/gitsheets-core/tests/fixtures/multiline_trailing_quote.expected.toml
+++ b/rust/gitsheets-core/tests/fixtures/multiline_trailing_quote.expected.toml
@@ -1,0 +1,22 @@
+accountLevel = "user"
+bio = """
+Azizi Developments is a leading developer based in Dubai with an extensive portfolio of modern luxury residential and commercial properties across the emirate’s most sought-after locations. Its properties, through which they aim to enrich the lives of UAE residents and investors, cater to all lifestyles.\r
+visit here:  [https://azizidevelopments.com/](https://azizidevelopments.com/)\r
+\r
+\r
+Email: info@azizidevelopments.com\r
+Tel. Number 00971 4 359 6673\r
+P.O. Box 00000\r
+Address "Suite No. 805 (Customer Care)\r
+Suite No. 1302 (Sales)\r
+Conrad Hotel,\r
+Sheikh Zayed Road, Dubai, UAE""""
+createdAt = "2023-07-15T11:29:30.000Z"
+firstName = "Azizi"
+fullName = "Azizi Developments"
+id = "019e4021-2037-79cc-a4ff-e423ec96713e"
+lastName = "Developments"
+legacyId = 13653
+slackSamlNameId = "azizidevelopments"
+slug = "azizidevelopments"
+updatedAt = "2023-07-15T11:49:26.000Z"

--- a/rust/gitsheets-core/tests/fixtures/multiline_trailing_quote.input.toml
+++ b/rust/gitsheets-core/tests/fixtures/multiline_trailing_quote.input.toml
@@ -1,0 +1,23 @@
+accountLevel = "user"
+bio = """
+Azizi Developments is a leading developer based in Dubai with an extensive portfolio of modern luxury residential and commercial properties across the emirate’s most sought-after locations. Its properties, through which they aim to enrich the lives of UAE residents and investors, cater to all lifestyles.\r
+visit here:  [https://azizidevelopments.com/](https://azizidevelopments.com/)\r
+\r
+\r
+Email: info@azizidevelopments.com\r
+Tel. Number 00971 4 359 6673\r
+P.O. Box 00000\r
+Address "Suite No. 805 (Customer Care)\r
+Suite No. 1302 (Sales)\r
+Conrad Hotel,\r
+Sheikh Zayed Road, Dubai, UAE"\
+"""
+createdAt = "2023-07-15T11:29:30.000Z"
+firstName = "Azizi"
+fullName = "Azizi Developments"
+id = "019e4021-2037-79cc-a4ff-e423ec96713e"
+lastName = "Developments"
+legacyId = 13_653
+slackSamlNameId = "azizidevelopments"
+slug = "azizidevelopments"
+updatedAt = "2023-07-15T11:49:26.000Z"

--- a/rust/gitsheets-core/tests/fixtures/string_requote.expected.toml
+++ b/rust/gitsheets-core/tests/fixtures/string_requote.expected.toml
@@ -1,0 +1,11 @@
+accountLevel = "user"
+bio = """I’m Adrien, a content writer currently living in the USA, dedicated to creating engaging and informative content. As part of my work, I rely on <a href="https://forbiztech.com/products/software/content-management-software/">content management software</a> to keep my projects organized and easily accessible. I’ve been working with a service provider who offers excellent support and tools for managing content more efficiently. Their platform has helped me streamline my workflow and stay on top of deadlines. If you're looking to improve your content organization and management, it might be worth exploring how content management software can benefit your own process."""
+createdAt = "2025-04-08T06:45:43.000Z"
+firstName = "Adrien"
+fullName = "Adrien Broody"
+id = "019e4020-e4bb-77fd-be4c-9416d9cabca2"
+lastName = "Broody"
+legacyId = 26362
+slackSamlNameId = "adrien123"
+slug = "adrien123"
+updatedAt = "2025-04-08T06:47:46.000Z"

--- a/rust/gitsheets-core/tests/fixtures/string_requote.input.toml
+++ b/rust/gitsheets-core/tests/fixtures/string_requote.input.toml
@@ -1,0 +1,11 @@
+accountLevel = "user"
+bio = "I’m Adrien, a content writer currently living in the USA, dedicated to creating engaging and informative content. As part of my work, I rely on <a href=\"https://forbiztech.com/products/software/content-management-software/\">content management software</a> to keep my projects organized and easily accessible. I’ve been working with a service provider who offers excellent support and tools for managing content more efficiently. Their platform has helped me streamline my workflow and stay on top of deadlines. If you're looking to improve your content organization and management, it might be worth exploring how content management software can benefit your own process."
+createdAt = "2025-04-08T06:45:43.000Z"
+firstName = "Adrien"
+fullName = "Adrien Broody"
+id = "019e4020-e4bb-77fd-be4c-9416d9cabca2"
+lastName = "Broody"
+legacyId = 26_362
+slackSamlNameId = "adrien123"
+slug = "adrien123"
+updatedAt = "2025-04-08T06:47:46.000Z"

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -105,6 +105,10 @@ function wrap(fn) {
 module.exports = {
   // Marshalling entry points (batch-first).
   roundtrip: addon.roundtrip,
+  // Canonical TOML bytes-authority (batch-first). Parse/serialize can raise a
+  // structured core error (`config_invalid`), surfaced as its typed class.
+  parseRecords: wrap(addon.parseRecords),
+  serializeRecords: wrap(addon.serializeRecords),
   // Boundary-test entry: throws the typed class for a given stable code.
   simulateCoreError: wrap(addon.simulateCoreError),
   // Error machinery.

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -11,6 +11,18 @@
  */
 export declare function roundtrip(records: Array<JsValue>): Array<JsValue>
 /**
+ * Parse a **batch** of TOML documents into records, marshalled to JS with full
+ * type fidelity. The whole array crosses the FFI once (batch-first). A
+ * malformed document surfaces as a structured, typed core error (`config_invalid`).
+ */
+export declare function parseRecords(documents: Array<string>): Array<JsValue>
+/**
+ * Serialize a **batch** of records to their canonical TOML bytes in one call
+ * (deep key sort + `toml`-crate default formatting; see `gitsheets_core::canonical`).
+ * A value TOML can't represent surfaces as a structured, typed core error.
+ */
+export declare function serializeRecords(records: Array<JsValue>): Array<string>
+/**
  * Throw the core error for a given stable `code`, surfaced as a **structured,
  * matchable** JS error (own `code`, `status`, `gitsheetsClass`, and any
  * `issues`/`conflictingPaths`). Boundary-test entry point: it exercises the

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, simulateCoreError } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, simulateCoreError } = nativeBinding
 
 module.exports.roundtrip = roundtrip
+module.exports.parseRecords = parseRecords
+module.exports.serializeRecords = serializeRecords
 module.exports.simulateCoreError = simulateCoreError

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs"
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4"

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -124,10 +124,7 @@ impl FromNapiValue for JsValue {
 }
 
 impl ToNapiValue for JsValue {
-    unsafe fn to_napi_value(
-        env: napi::sys::napi_env,
-        val: Self,
-    ) -> Result<napi::sys::napi_value> {
+    unsafe fn to_napi_value(env: napi::sys::napi_env, val: Self) -> Result<napi::sys::napi_value> {
         match val.0 {
             Value::String(s) => String::to_napi_value(env, s),
             Value::Boolean(b) => bool::to_napi_value(env, b),
@@ -171,9 +168,8 @@ impl ToNapiValue for JsValue {
 /// milliseconds. A JS `Date` is an absolute instant, which is exactly an
 /// offset-datetime at UTC — matching `@iarna`'s treatment of JS Dates.
 fn unix_millis_to_datetime(ms: f64) -> Result<Datetime> {
-    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64).ok_or_else(|| {
-        Error::new(Status::InvalidArg, format!("date {ms} ms is out of range"))
-    })?;
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64)
+        .ok_or_else(|| Error::new(Status::InvalidArg, format!("date {ms} ms is out of range")))?;
     let toml_dt = TomlDatetime {
         date: Some(TomlDate {
             year: dt.year() as u16,
@@ -243,6 +239,39 @@ pub fn roundtrip(records: Vec<JsValue>) -> Vec<JsValue> {
         .collect()
 }
 
+/// Parse a **batch** of TOML documents into records, marshalled to JS with full
+/// type fidelity. The whole array crosses the FFI once (batch-first). A
+/// malformed document surfaces as a structured, typed core error (`config_invalid`).
+#[napi]
+pub fn parse_records(env: Env, documents: Vec<String>) -> Result<Vec<JsValue>> {
+    match gitsheets_core::parse_batch(documents) {
+        Ok(values) => Ok(values.into_iter().map(JsValue).collect()),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+/// Serialize a **batch** of records to their canonical TOML bytes in one call
+/// (deep key sort + `toml`-crate default formatting; see `gitsheets_core::canonical`).
+/// A value TOML can't represent surfaces as a structured, typed core error.
+#[napi]
+pub fn serialize_records(env: Env, records: Vec<JsValue>) -> Result<Vec<String>> {
+    let values: Vec<Value> = records.into_iter().map(|j| j.0).collect();
+    match gitsheets_core::serialize_batch(&values) {
+        Ok(bytes) => Ok(bytes),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+/// Set a structured JS exception pending for a core error and return the napi
+/// sentinel that tells napi not to overwrite it. Shared by the real entry
+/// points so a `gitsheets_core::Error` always crosses as its typed class.
+fn raise_core_error(env: &Env, err: &gitsheets_core::Error) -> Error {
+    if throw_structured_error(env, err).is_err() {
+        return Error::new(Status::GenericFailure, err.message().to_string());
+    }
+    Error::new(Status::PendingException, err.message().to_string())
+}
+
 /// Throw the core error for a given stable `code`, surfaced as a **structured,
 /// matchable** JS error (own `code`, `status`, `gitsheetsClass`, and any
 /// `issues`/`conflictingPaths`). Boundary-test entry point: it exercises the
@@ -254,7 +283,10 @@ pub fn simulate_core_error(env: Env, code: String) -> Result<()> {
             throw_structured_error(&env, &err)?;
             // The exception is already pending from `env.throw`; tell napi not
             // to overwrite it.
-            Err(Error::new(Status::PendingException, err.message().to_string()))
+            Err(Error::new(
+                Status::PendingException,
+                err.message().to_string(),
+            ))
         }
         None => Err(Error::new(
             Status::InvalidArg,

--- a/rust/gitsheets-napi/test/canonical.mjs
+++ b/rust/gitsheets-napi/test/canonical.mjs
@@ -1,0 +1,82 @@
+// Boundary tests for the canonical TOML parse/serialize entry points.
+//
+// These prove the bytes-authority crosses the FFI correctly: a batch of TOML
+// documents parses to JS objects with full type fidelity, and a batch of JS
+// objects serializes to the canonical bytes (deep key sort + toml-crate default
+// formatting, integer-underscore normalization). See `specs/rust-core.md` and
+// `specs/behaviors/normalization.md`.
+//
+// Requires the addon to be built first (`npm run build:debug`). Run: `npm test`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../binding.cjs');
+} catch (err) {
+  throw new Error(
+    `gitsheets-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+const { parseRecords, serializeRecords, ConfigError } = binding;
+
+test('parse + serialize are exposed', () => {
+  assert.equal(typeof parseRecords, 'function');
+  assert.equal(typeof serializeRecords, 'function');
+});
+
+test('a batch of documents parses to objects with type fidelity', () => {
+  const [a, b] = parseRecords([
+    'id = 7\nratio = 1.5\nname = "Ada"\nactive = true\n',
+    'at = 1979-05-27T07:32:00Z\n',
+  ]);
+  assert.equal(a.id, 7);
+  assert.ok(Number.isInteger(a.id), 'integer stays integral');
+  assert.equal(a.ratio, 1.5);
+  assert.ok(!Number.isInteger(a.ratio), 'float stays fractional');
+  assert.equal(a.name, 'Ada');
+  assert.equal(a.active, true);
+  assert.ok(b.at instanceof Date, 'TOML datetime surfaces as a Date');
+});
+
+test('serialize emits canonical bytes: deep key sort + integer normalization', () => {
+  const [out] = serializeRecords([{ slug: 'jane', legacyId: 31618, email: 'jane@x.org' }]);
+  assert.equal(out, 'email = "jane@x.org"\nlegacyId = 31618\nslug = "jane"\n');
+});
+
+test('parse → serialize round-trips a record to canonical form', () => {
+  // On-disk @iarna form has the integer underscore; canonical drops it.
+  const onDisk = 'email = "jane@x.org"\nlegacyId = 31_618\nslug = "jane"\n';
+  const [record] = parseRecords([onDisk]);
+  const [out] = serializeRecords([record]);
+  assert.equal(out, 'email = "jane@x.org"\nlegacyId = 31618\nslug = "jane"\n');
+});
+
+test('a multiline body stays triple-quoted, not single-line escaped', () => {
+  const [record] = parseRecords(['body = """\n# Title\n\nA paragraph."""\n']);
+  const [out] = serializeRecords([record]);
+  assert.ok(out.includes('"""'), 'stays triple-quoted');
+  assert.ok(out.includes('\n# Title\n'), 'newlines stay literal');
+});
+
+test('serialization is idempotent across the boundary', () => {
+  const record = { z: 1, a: 2, body: { y: 3, b: 4 }, list: [3, 1, 2] };
+  const [once] = serializeRecords([record]);
+  const [twice] = serializeRecords(parseRecords([once]));
+  assert.equal(twice, once);
+});
+
+test('a malformed document throws a typed ConfigError', () => {
+  assert.throws(
+    () => parseRecords(['this is = = not valid\n']),
+    (err) => {
+      assert.ok(err instanceof ConfigError, 'typed ConfigError');
+      assert.equal(err.code, 'config_invalid');
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
Implements [`plans/toml-canonical-core.md`](../blob/worktree-agent-a678a3a8648575333/plans/toml-canonical-core.md) — moves the **authority over on-disk bytes** into `gitsheets-core`: TOML parse + serialize + canonical normalization (deep key sort → byte-stable canonical form) on the core `Value`, with a parity harness against the current `@iarna` canonical bytes. Part of the Rust-core evolution (#127); parity rationale from #196.

## What landed

- **`gitsheets-core::canonical`** — `parse` / `serialize` / `normalize` + `parse_batch` / `serialize_batch` (re-exported at the crate root). Parse via the `toml` crate → `Value` (lossless: int/float distinction + all four datetime kinds). Serialize via the crate's default formatting (triple-quoted multiline, literal-quoted strings); deep key sort falls out of the crate's `BTreeMap`-backed table. `normalize` is the standalone deep key sort for callers that need a sorted `Value` without serializing.
- **napi binding** — `parseRecords` / `serializeRecords` (batch-first); malformed input surfaces as the typed `ConfigError`. Regenerated `index.js` / `index.d.ts`; new `test/canonical.mjs`.
- **Parity harness** — `tests/corpus_parity.rs` (committed fixtures pinned to golden canonical bytes for CI; opt-in full-corpus mode via `GITSHEETS_PARITY_CORPUS`) + `examples/parity_report.rs` diagnostic classifier.

## Parity result (the gate)

Ran locally against CodeForPhilly `origin/published` — **29,556** record files: **0 data-loss, 0 non-idempotent, 0 parse errors**; 12,201 byte-identical, 17,355 value-preserving reformat.

Every byte divergence from the `@iarna` on-disk bytes is one of **three value-preserving reformattings** from serializing fresh through the `toml` crate (each confirmed data-lossless by reparse-equality + idempotent):

1. **Integer digit-group underscores dropped** — `31_618` → `31618` (the sanctioned #196 change; dominant class).
2. **String requote** — strings holding both `"` and `'` (so not literal-quotable) move from @iarna's escaped single-line basic string (`"…\"…"`) to the readable triple-quoted form.
3. **Multiline trailing-quote layout** — a multiline string ending in `"` uses adjacent quotes before the delimiter (`UAE""""`) instead of @iarna's `\`-line-continuation.

⚠️ **#196's "integer-underscore only" prediction was made on the old ~4,310-record corpus and proved incomplete** on the grown corpus (now full of spam bios with embedded HTML quotes + apostrophes). Classes 2 and 3 are **not bugs**: both move *toward* the readable triple-quoted form #196 endorses and away from the single-line re-escaping it says to avoid — i.e. the expected consequence of the *decided* canonical format. The harness therefore asserts the airtight invariant (data-lossless + idempotent + zero value-changing diffs) and enumerates the classes for review, rather than the too-narrow "integer-only bytes" expectation. **Follow-up:** `canonical-rebaseline` must document all three classes in `normalization.md` (this PR does not touch that spec).

## Validation

- `cargo build --workspace --all-targets`, `cargo test --workspace` — pass (clippy clean).
- napi addon builds; `npm test` 23/23 (incl. new `canonical.mjs`).
- Main JS suite independent of the addon: `npm run type-check` clean, `npm test` 66/66 (after `npm run build`).
- Full-corpus parity run locally (numbers above); CI runs the committed fixture subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd