### PR TITLE
feat(core): rebaseline canonical form + normalization spec

### DIFF
--- a/plans/canonical-rebaseline.md
+++ b/plans/canonical-rebaseline.md
@@ -1,5 +1,6 @@
 ---
-status: in-progress
+status: done
+pr: https://github.com/JarvusInnovations/gitsheets/pull/206
 depends: [toml-canonical-core]
 specs:
   - specs/rust-core.md
@@ -39,12 +40,18 @@ re-baseline this repo's own fixtures/corpora. **Out:** the serializer itself
 
 ## Validation
 
-- [ ] `normalization.md` describes the new canonical form; the change is its own
-      reviewable commit.
-- [ ] The re-normalize routine is idempotent (second run produces no diff).
-- [ ] After re-baseline, the core serializer is byte-identical to on-disk for the
-      whole corpus (0 diff — the churn is now absorbed).
-- [ ] Documented consumer recipe for re-baselining an existing repo in one commit.
+- [x] `normalization.md` describes the new canonical form **including all three
+      reformat classes**; the change is its own reviewable commit
+      (`docs(specs): rebaseline normalization.md to the Rust canonical form`).
+- [x] The re-normalize routine is idempotent (second run produces no diff —
+      demonstrated below).
+- [x] After re-baseline, the core serializer is byte-identical to on-disk for the
+      fixtures touched (the re-normalized inputs match the goldens exactly);
+      no live corpus exists in-repo to re-base (see Notes).
+- [x] Documented consumer recipe for re-baselining an existing repo in one commit
+      (in `normalization.md`).
+- [x] `cargo build --workspace` + `cargo test` green; `npm run type-check`,
+      `npm run build`, `npm test` green (gitsheets 287/287, gitsheets-axi 66/66).
 
 ## Risks / unknowns
 
@@ -58,8 +65,67 @@ re-baseline this repo's own fixtures/corpora. **Out:** the serializer itself
 
 ## Notes
 
-(Populated at closeout.)
+**Spec change (the headline deliverable).** `specs/behaviors/normalization.md` now
+defines the canonical bytes by the Rust core serializer
+(`gitsheets-core::canonical::serialize` — the `toml` crate's default formatting
+over a deep-key-sorted value) instead of `@iarna/toml`. It documents **all three**
+value-preserving reformat classes (#196 predicted only the first; the
+[PR #205](https://github.com/JarvusInnovations/gitsheets/pull/205) corpus run over
+all 29,556 records — 0 data-loss / 0 non-idempotent / 0 parse errors — proved that
+incomplete):
+
+1. **Integer digit-group underscores dropped** (`31_618` → `31618`) — dominant,
+   originally-predicted class.
+2. **String requote** — a string holding both `"` and `'` moves from `@iarna`'s
+   escaped single-line basic string to the `toml` crate's readable `"""…"""`.
+3. **Multiline trailing-quote layout** — a multiline string ending in `"` uses
+   adjacent quotes before the delimiter (`…UAE""""`) vs `@iarna`'s
+   `\`-line-continuation.
+
+The spec also gained a *v1.0 substrate note* (Node still emits `@iarna` bytes; the
+live cutover is `node-binding-thin`) and a one-command consumer re-normalize
+recipe. Committed alone, spec-first.
+
+**Re-normalize routine.** `rust/gitsheets-core/examples/normalize_tree.rs` — a
+minimal one-shot reusing only the existing public canonical API (no new workspace
+deps, no new `lib.rs` modules, no edits to `canonical.rs`/`value.rs`/`error.rs`),
+so it merges cleanly alongside the sibling `definition-logic-core` work. It walks a
+directory, re-serializes every `.toml` in place, and guards against data loss
+(refuses to write if the fresh bytes don't re-parse to the same value).
+
+**Idempotence demonstration.** Over copies of the committed parity fixtures:
+
+- Pass 1 over the OLD `@iarna` `*.input.toml` bytes → re-normalized exactly the 3
+  divergent fixtures (one per class) and left the 2 already-canonical ones; the
+  results were **byte-identical to the `*.expected.toml` goldens**.
+- Pass 2 over the same dir → **0 files re-normalized** (idempotent fixpoint).
+- A pass over the already-canonical `*.expected.toml` copies → **0 changes**.
+
+**Re-baselined vs deferred.**
+
+- *Re-baselined in-repo: nothing* — the repo holds **no gitsheets-record corpora**
+  to re-base. The only on-disk `.toml` are `.holo/*` (hologit holomapping config,
+  not gitsheets records, not under the canonical-serialization regime) and the
+  rust parity fixtures.
+- *Deferred (with reason):*
+  - `rust/gitsheets-core/tests/fixtures/*.input.toml` — intentionally hold the OLD
+    `@iarna` bytes as parity input; the paired `*.expected.toml` goldens are
+    already the new canonical form. Re-basing the inputs would defeat the harness.
+  - The **main JS suite's** inline TOML expectations — the v1.0 Node substrate
+    still serializes via `@iarna/toml`, so its round-trip expectations remain
+    correct against `@iarna`. Re-baselining anything the JS suite compares against
+    `@iarna` output now would break the green suite; that is the live cutover,
+    sequenced with `node-binding-thin`.
+
+**JS suite stayed green** — no JS test was weakened to accommodate a premature
+re-baseline (a hard requirement): gitsheets 287/287, gitsheets-axi 66/66.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Deferred to `node-binding-thin`:** the live-repo *cutover* re-baseline — swap
+  the Node serializer from `@iarna/toml` to the core serializer and run the
+  one-time `normalize_tree` commit over a real repo, then re-base the JS suite's
+  inline TOML expectations onto the new canonical bytes. That closes the bounded,
+  documented spec↔substrate drift this plan records.
+- **None** for the spec/routine themselves — the three reformat classes are
+  enumerated and proven, and the routine is idempotent.

--- a/rust/gitsheets-core/examples/normalize_tree.rs
+++ b/rust/gitsheets-core/examples/normalize_tree.rs
@@ -1,0 +1,71 @@
+//! Re-normalize every `.toml` record under a directory, in place, through the
+//! canonical serializer (`gitsheets_core::serialize`). One-shot for the
+//! deliberate canonical-form re-baseline (#196): read each record, parse it,
+//! re-serialize it fresh, and write the result back. Idempotent — a second run
+//! produces zero changes.
+//!
+//! Usage: `cargo run -p gitsheets-core --example normalize_tree -- <dir>`
+//!
+//! Prints one line per file that changed plus a summary. Refuses to write any
+//! file whose fresh bytes don't re-parse to the same value (a data-loss guard),
+//! so a parse or serialize bug can never silently rewrite a record's meaning.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("usage: normalize_tree <dir>");
+    let mut files = Vec::new();
+    collect_toml(Path::new(&dir), &mut files);
+    files.sort();
+
+    let mut changed = 0usize;
+    let mut unchanged = 0usize;
+
+    for path in &files {
+        let original = std::fs::read_to_string(path).expect("read");
+        let value = gitsheets_core::parse(&original)
+            .unwrap_or_else(|e| panic!("{}: parse failed: {e}", path.display()));
+        let serialized = gitsheets_core::serialize(&value)
+            .unwrap_or_else(|e| panic!("{}: serialize failed: {e}", path.display()));
+
+        // Data-loss guard: the fresh bytes must carry the same value.
+        let reparsed = gitsheets_core::parse(&serialized)
+            .unwrap_or_else(|e| panic!("{}: reparse failed: {e}", path.display()));
+        assert!(
+            reparsed == value,
+            "{}: refusing to write — re-serialization changed the value",
+            path.display()
+        );
+
+        if serialized == original {
+            unchanged += 1;
+            continue;
+        }
+        std::fs::write(path, &serialized).expect("write");
+        changed += 1;
+        println!("normalized {}", path.display());
+    }
+
+    println!(
+        "\n{} file(s) re-normalized, {} already canonical ({} total)",
+        changed,
+        unchanged,
+        files.len()
+    );
+}
+
+fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_toml(&path, out);
+        } else if path.extension().is_some_and(|e| e == "toml") {
+            out.push(path);
+        }
+    }
+}

--- a/specs/behaviors/normalization.md
+++ b/specs/behaviors/normalization.md
@@ -100,10 +100,13 @@ Sorts an array of strings using locale-aware comparison (`localeCompare` with `s
 
 ### TOML serialization details
 
-- The library **parses** with `smol-toml` and **serializes** with `@iarna/toml` (see [architecture.md](../architecture.md) for why the two directions use different libraries). Dates, datetimes, and date-times round-trip correctly: `smol-toml` parses them to `TomlDate` (an `instanceof Date` subclass) and `@iarna/toml` serializes those back to the matching TOML date type, byte-identically.
-- Multi-line string formatting follows `@iarna/toml`'s serializer defaults — strings with newlines emit as triple-quoted; the library doesn't impose its own length threshold.
+- The **canonical serializer** is the Rust core's `gitsheets-core::canonical::serialize` — the [`toml` crate](https://docs.rs/toml)'s default formatting applied to a deep-key-sorted value. It defines the canonical bytes: a value is lowered to `toml::Value` (whose `Table` is a `BTreeMap`, so the deep key sort happens structurally) and emitted with the crate's default rendering (triple-quoted multiline strings, literal-quoted strings where possible). Parsing is the same crate's parser. See [architecture.md](../architecture.md) and [rust-core.md](../rust-core.md#canonical-form-rebaseline).
+- Dates, datetimes, and date-times round-trip by native TOML datetime type — all four kinds (offset date-time, local date-time, local date, local time) parse to the core `Datetime` and serialize back to the matching TOML type byte-faithfully.
+- Multi-line string formatting follows the `toml` crate's defaults — strings with newlines emit as triple-quoted (`"""…"""`); the library imposes no length threshold of its own.
 - Null values are *omitted* from the output. TOML can't represent `null`; absent fields read back as `undefined` and are treated as null by validation.
 - Empty arrays and empty objects are preserved (they have semantic meaning distinct from absent).
+
+> **v1.0 substrate note.** The v1.0 Node substrate still serializes through `@iarna/toml`, so its on-disk bytes differ from the canonical form above by exactly the three value-preserving reformat classes documented under [Canonical-form re-baseline](#canonical-form-re-baseline-the-rust-serializer). The cutover to the core serializer — and the one-time live re-normalization — is sequenced with the Node binding work (`node-binding-thin`), not performed implicitly. Until then this is a bounded, documented spec↔substrate drift.
 
 ### File bytes
 
@@ -111,10 +114,47 @@ After all of the above:
 
 1. Apply array sort rules (if declared)
 2. Sort object keys (deep)
-3. Serialize via `@iarna/toml`
+3. Serialize via the canonical serializer (`gitsheets-core::canonical::serialize`)
 4. The resulting bytes are what's written to the blob
 
 The same record always produces the same bytes, regardless of the order fields were set on the input object.
+
+## Canonical-form re-baseline (the Rust serializer)
+
+Adopting the Rust core's `gitsheets-core::canonical::serialize` **re-baselines the canonical bytes once**: a value that was already canonical under the previous `@iarna/toml` serializer may now serialize to different — but *value-identical* — bytes. This is a deliberate, one-time change, decided while gitsheets effectively has a single consumer (the blast radius of re-normalizing existing repos only grows with adoption). See [rust-core.md](../rust-core.md#canonical-form-rebaseline) and [#196](https://github.com/JarvusInnovations/gitsheets/issues/196).
+
+The decision is backed by a full-corpus parity run in [PR #205](https://github.com/JarvusInnovations/gitsheets/pull/205): the Rust serializer was run over the entire 29,556-record CodeForPhilly corpus with **0 data-loss, 0 non-idempotent serializations, and 0 parse errors**. Every byte divergence from the old `@iarna/toml` bytes falls into one of three reformat classes below.
+
+### The three sanctioned reformat classes
+
+[#196](https://github.com/JarvusInnovations/gitsheets/issues/196) originally predicted a *single* change (integer underscores). The corpus parity run proved that prediction incomplete: there are **three** value-preserving reformat classes relative to the old `@iarna/toml` bytes. All three are proven data-lossless (re-parsing the fresh bytes yields the same value) and idempotent (a second serialization is a no-op), and all move *toward* the readable form #196 endorses — never the single-line re-escaping it rejects.
+
+1. **Integer digit-group underscores dropped.** `legacyId = 31_618` → `legacyId = 31618`. gitsheets serializes fresh from a value, so digit-group separators are never re-emitted. This is the dominant class and the one #196 predicted.
+
+2. **String requote.** A string containing *both* `"` and `'` (so it cannot be a TOML literal string) moves from `@iarna`'s escaped single-line basic string (`"…\"…"`) to the `toml` crate's readable triple-quoted form (`"""…"""`). For example, a bio with embedded HTML — `<a href=\"…\">` inside a single-line basic string — becomes `<a href="…">` inside a `"""…"""` block, with the apostrophes and quotes no longer escaped.
+
+3. **Multiline trailing-quote layout.** A multiline string whose content ends in a `"` character: `@iarna` emits the `"` followed by a `\`-line-continuation and then the closing `"""` (two physical lines); the `toml` crate places adjacent quotes before the delimiter (`…UAE""""`, one line). Same string value, fewer lines.
+
+Because all three preserve the value, the canonical invariant — *logically-equal records produce byte-identical TOML* — still holds; only the specific byte image changed, once.
+
+### Re-normalizing an existing repo (consumer recipe)
+
+Adopting the new canonical form across an existing repo is a single re-serialize-everything commit. The routine reads every record, parses it, re-serializes it through the canonical serializer, and writes the result back. It is **idempotent** — a second run produces zero diff, which is the adoption check.
+
+The repo ships a minimal one-shot for this over a checked-out tree:
+
+```bash
+# Re-normalize every *.toml record under a directory, in place.
+cargo run -p gitsheets-core --example normalize_tree -- path/to/records
+
+git add path/to/records
+git commit -m "chore: re-baseline records to the Rust canonical form"
+
+# Verify idempotence — a second pass must report 0 files re-normalized:
+cargo run -p gitsheets-core --example normalize_tree -- path/to/records
+```
+
+The example refuses to write any file whose fresh bytes don't re-parse to the same value (a data-loss guard), so a parse or serialize bug can never silently rewrite a record's meaning.
 
 ## Validation order vs. normalization order
 
@@ -140,7 +180,7 @@ This is load-bearing for:
 
 ## Limits
 
-- **Float precision** — `@iarna/toml` preserves IEEE-754 doubles. For decimal arithmetic, consumers should use string representation or a decimal library; the canonical form is still byte-stable for any given input.
+- **Float precision** — the canonical serializer preserves IEEE-754 doubles (`1.0` stays `1.0`, distinct from the integer `1`). For decimal arithmetic, consumers should use string representation or a decimal library; the canonical form is still byte-stable for any given input.
 - **Custom classes** — only TOML-representable types round-trip. Anything else (functions, symbols, class instances beyond Date) should be omitted from records or stringified by the consumer's Standard Schema layer.
 
 ## Coordinates with


### PR DESCRIPTION
Executes the deliberate, one-time canonical-form re-baseline that adopting the Rust serializer (`gitsheets-core::canonical::serialize`, landed in #205) implies, and brings `specs/behaviors/normalization.md` into conformance.

Implements [`plans/canonical-rebaseline.md`](plans/canonical-rebaseline.md). Refs #196.

## Spec change (own commit, `docs(specs)`)

`normalization.md` now defines the canonical bytes by the Rust core serializer (the `toml` crate's default formatting over a deep-key-sorted value) instead of `@iarna/toml`. It documents **all three** value-preserving reformat classes the full-corpus parity run in **PR #205** surfaced — #196's original "integer-underscore only" prediction proved **incomplete** (it was measured on the smaller ~4,310-record corpus):

1. **Integer digit-group underscores dropped** — `31_618` → `31618` (the dominant, originally-predicted class).
2. **String requote** — a string holding *both* `"` and `'` moves from `@iarna`'s escaped single-line basic string to the `toml` crate's readable triple-quoted form.
3. **Multiline trailing-quote layout** — a multiline string ending in `"` uses adjacent quotes before the delimiter (`…UAE""""`) instead of `@iarna`'s `\`-line-continuation.

PR #205's gate: the Rust serializer over the full **29,556-record** CodeForPhilly corpus — **0 data-loss, 0 non-idempotent, 0 parse errors**. All three classes are value-preserving and move *toward* the readable form #196 endorses.

A `v1.0 substrate note` records that Node still emits `@iarna` bytes; the live-repo cutover is deferred to `node-binding-thin`. The spec also carries a one-command consumer re-normalize recipe.

## Re-normalize routine

`rust/gitsheets-core/examples/normalize_tree.rs` — a minimal one-shot that re-serializes every `.toml` under a directory in place via the existing public canonical API (no new deps, no new lib modules), with a data-loss guard. **Idempotent:** demonstrated converting the old `@iarna` fixture bytes to byte-identical goldens in pass 1, then 0 changes in pass 2.

## Re-baselined vs deferred

- **Re-baselined in-repo: nothing** — the repo holds no gitsheets-record corpora to re-base. The only `.toml` are `.holo/*` (hologit config, not records) and the rust parity fixtures.
- **Deferred (with reason):** `rust/gitsheets-core/tests/fixtures/*.input.toml` intentionally keep the OLD `@iarna` bytes; the `*.expected.toml` goldens are already the new canonical form. The JS suite's inline TOML expectations stay on `@iarna` until the `node-binding-thin` cutover — re-baselining them now would break the green JS suite.

## Validation

- `cargo build --workspace` + `cargo test` — green (17 unit + 4 corpus_parity).
- `npm run type-check`, `npm run build`, `npm test` — green: gitsheets **287/287**, gitsheets-axi **66/66**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd