### PR TITLE
feat(core): definition logic — path templates, validation, embedded boa engine

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -38,11 +38,16 @@ jobs:
 
       - name: Core unit + canonical-parity tests
         # Runs the value/error/canonical unit tests AND the corpus_parity
-        # integration test. CI exercises the committed fixture subset (golden
-        # canonical bytes); the full ~29.5k-record corpus parity is run locally
-        # against CodeForPhilly origin/published via GITSHEETS_PARITY_CORPUS —
-        # see plans/toml-canonical-core.md Notes.
+        # integration test, PLUS the definition-logic unit tests (path_template,
+        # validation, engine) added by plans/definition-logic-core.md. CI
+        # exercises the committed fixture subset (golden canonical bytes); the
+        # full ~29.5k-record corpus parity is run locally against CodeForPhilly
+        # origin/published via GITSHEETS_PARITY_CORPUS — see
+        # plans/toml-canonical-core.md Notes.
         run: cargo test -p gitsheets-core
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy -p gitsheets-core -- -D warnings
 
   napi:
     name: gitsheets-napi boundary (node ${{ matrix.node }})
@@ -64,7 +69,7 @@ jobs:
         with:
           workspaces: rust
 
-      - name: Install binding dev deps (@napi-rs/cli)
+      - name: Install binding dev deps (@napi-rs/cli, ajv for parity)
         working-directory: rust/gitsheets-napi
         run: npm install
 
@@ -72,6 +77,8 @@ jobs:
         working-directory: rust/gitsheets-napi
         run: npm run build
 
-      - name: Round-trip + error-mapping tests
+      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine)
+        # Explicit file paths (not a glob) so the suite runs identically on
+        # node 20 and 22 — `node --test "test/*.mjs"` does NOT expand on node 20.
         working-directory: rust/gitsheets-napi
         run: npm test

--- a/plans/definition-logic-core.md
+++ b/plans/definition-logic-core.md
@@ -1,11 +1,12 @@
 ---
-status: in-progress
+status: done
 depends: [gitsheets-core-foundation]
 specs:
   - specs/rust-core.md
   - specs/behaviors/path-templates.md
   - specs/behaviors/validation.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/207
 ---
 
 # Plan: definition-logic core — path templates, validation, embedded engine
@@ -48,14 +49,20 @@ in the binding — and record CRUD/query (downstream).
 
 ## Validation
 
-- [ ] Path rendering (incl. a partition-derivation case) is identical to the JS
-      implementation across the corpus.
-- [ ] Rust JSON-Schema validation matches `ajv` on a parity fixture set (valid +
-      invalid records, formats, edge cases).
-- [ ] An embedded-JS sort/derivation snippet produces the same result as today's
+- [x] Path rendering (incl. a partition-derivation case) is identical to the JS
+      implementation across the corpus. — `renderPathsBatch` vs a faithful
+      node:vm reference renderer, 11-case corpus incl. `getUTCFullYear`/
+      `getUTCMonth` date-parts (`test/path-template.mjs`).
+- [x] Rust JSON-Schema validation matches `ajv` on a parity fixture set (valid +
+      invalid records, formats, edge cases). — 15 records: exact validity parity
+      AND identical `(location, keyword)` sets, zero divergences
+      (`test/validation-parity.mjs`).
+- [x] An embedded-JS sort/derivation snippet produces the same result as today's
       `node:vm` path; the compiled context persists across operations (compiled
-      once per open, not per call).
-- [ ] Engine version is pinned and recorded as a behavior-contract input.
+      once per open, not per call). — 21 comparator pairs exact; `CompiledDefinition`
+      200 ops with constant `snippetCount` (`test/engine-parity.mjs`).
+- [x] Engine version is pinned and recorded as a behavior-contract input. —
+      `boa_engine = "=0.21.1"` in `rust/gitsheets-core/Cargo.toml`.
 
 ## Risks / unknowns
 
@@ -68,8 +75,74 @@ in the binding — and record CRUD/query (downstream).
 
 ## Notes
 
-(Populated at closeout.)
+**What was built.** Three modules added to `gitsheets-core`, all batch-first and
+exposed across the napi boundary for JS-side parity:
+
+- `path_template.rs` — a behavior-preserving port of the JS renderer
+  (`packages/gitsheets/src/path-template/index.ts`). Literal/field components
+  render natively over `Value`; **expression** components compile once into the
+  embedded engine. Ports `stringifyValue`, multi-variable segments (#105),
+  recursive `field/**`, invalid-char rejection, and the
+  `path_render_failed`/`path_invalid_chars` typed errors.
+- `validation.rs` — native JSON-Schema via the `jsonschema` crate, compiled once
+  per schema (`CompiledSchema`), mapping failures to `ValidationIssue`.
+- `engine.rs` — a persistent `boa_engine` `Context` with compile-once snippet
+  handles; core `Value` ⇄ boa marshalling (incl. real JS `Date` for datetime
+  fields, via a dependency-free `days_from_civil`); `!Send` / thread-confined.
+
+napi surface: `renderPathsBatch`, `validateBatch`, `runComparator`, and a
+stateful `CompiledDefinition` class (compile-once / reuse demonstrator).
+
+**Pinned engine version.** `boa_engine = "=0.21.1"` — exact pin, recorded as a
+canonical-behavior-contract input per `specs/rust-core.md`. `jsonschema 0.46.7`
+(default-features off — no remote-ref resolver).
+
+**ajv-parity result.** Over 15 valid+invalid records the Rust validator matched
+`ajv` (Draft 7, `should_validate_formats`, all-errors) with **exact validity
+parity AND identical `(instanceLocation, keyword)` sets** — pattern, format
+(email/uri), minLength, minimum, type, enum, maxItems, additionalProperties,
+required, and multi-error `allErrors` cases. **Zero `(location, keyword)`
+divergences.** Issue *message text* is excluded from the assertion (library-
+specific prose). Enumerated structural divergences vs ajv, by design:
+
+  1. **Strict-mode unknown keywords.** ajv `strict:true` rejects a typo'd/unknown
+     keyword at *compile* (`config_invalid`); the `jsonschema` crate silently
+     ignores unknown keywords, so such a schema compiles here. (Follow-up below.)
+  2. **Datetime as JSON.** A `Value::Datetime` marshals to a JSON *string* for
+     validation, whereas ajv validates the host record with a JS `Date`
+     *object*. Datetime-typed schema fields are uncommon; the parity fixtures
+     stay JSON-representable. Resolved properly when the binding marshals records
+     for validation in the record engine.
+
+**node:vm-parity result.** All 21 realistic raw-JS sort-comparator `(rule, input)`
+pairs (subtraction, relational, length, `Math.sign`, multi-key object directive)
+match `node:vm` exactly. `CompiledDefinition` ran 200 render/compare operations
+with `snippetCount` constant at 2 — proof snippets compile once on open, never
+per call. A **`localeCompare` Intl-boundary probe diverged 1/4** (`["B","a"]`:
+node:vm collates `1`, boa code-unit-compares `-1`) — this is the documented boa
+trade-off (boa default-features exclude `intl`). It is **non-gating**: gitsheets'
+locale-aware sort is the declarative `sort = true` path, evaluated *natively in
+the binding*, not an embedded raw-JS snippet. The snippets gitsheets actually
+runs through the engine all pass.
+
+**Independence.** Changes touch only `rust/` + `.github/workflows/rust-core.yml`.
+The main JS package imports no `.node` addon; the rust-core workflow stays
+separate from `ci.yml`.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Strict-mode unknown-keyword rejection (Issue).** To fully match ajv's
+  `strict:true`, the core could walk a `[gitsheet.schema]` for unrecognized
+  keywords at compile and raise `config_invalid`. Deferred — track as a hardening
+  issue; current behavior is *more* lenient, not unsafe.
+- **Datetime validation marshalling (Deferred to plan: `record-engine-core`).**
+  How a datetime-typed field is presented to shape-validation (string vs Date)
+  is settled when the record engine owns the write path; revisit there.
+- **Query-tree traversal/pruning (Deferred to plan: `record-engine-core`).** This
+  plan ported parse + render only; the path template's *query pruning* half is a
+  record-engine concern.
+- **`getFieldNames` for query auto-derivation (Deferred to plan:
+  `record-engine-core`).** Not needed for rendering parity; lands with query.
+- **boa engine upgrades (Tracked as: contract discipline).** The `=0.21.1` pin is
+  upgraded deliberately, re-running the node:vm parity gate — same discipline as
+  a normalization change.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +24,21 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -21,10 +50,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -33,10 +83,183 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "boa_ast"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+dependencies = [
+ "bitflags",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
+ "indexmap",
+ "num-bigint",
+ "rustc-hash",
+]
+
+[[package]]
+name = "boa_engine"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+dependencies = [
+ "aligned-vec",
+ "arrayvec",
+ "bitflags",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_string",
+ "bytemuck",
+ "cfg-if",
+ "cow-utils",
+ "dashmap",
+ "dynify",
+ "fast-float2",
+ "float16",
+ "futures-channel",
+ "futures-concurrency",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
+ "indexmap",
+ "intrusive-collections",
+ "itertools",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "portable-atomic",
+ "rand",
+ "regress",
+ "rustc-hash",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "small_btree",
+ "static_assertions",
+ "tag_ptr",
+ "tap",
+ "thin-vec",
+ "thiserror",
+ "time",
+ "xsum",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
+dependencies = [
+ "boa_macros",
+ "boa_string",
+ "hashbrown 0.16.1",
+ "thin-vec",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+dependencies = [
+ "boa_gc",
+ "boa_macros",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+dependencies = [
+ "cfg-if",
+ "cow-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "boa_parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+dependencies = [
+ "bitflags",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "fast-float2",
+ "icu_properties",
+ "num-bigint",
+ "num-traits",
+ "regress",
+ "rustc-hash",
+]
+
+[[package]]
+name = "boa_string"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+dependencies = [
+ "fast-float2",
+ "itoa",
+ "paste",
+ "rustc-hash",
+ "ryu-js",
+ "static_assertions",
+]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cc"
@@ -81,11 +304,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynify"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
+dependencies = [
+ "dynify-macros",
+]
+
+[[package]]
+name = "dynify-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -97,16 +424,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "float16"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
+dependencies = [
+ "cfg-if",
+ "rustc_version",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-task"
@@ -127,10 +561,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gitsheets-core"
 version = "0.0.0"
 dependencies = [
+ "boa_engine",
  "indexmap",
+ "jsonschema",
+ "serde_json",
  "toml",
 ]
 
@@ -145,6 +596,23 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "toml",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -178,14 +646,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -197,6 +799,39 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185abd1edcef44ac028ec6588ad1360155fbd0a8baa20243a28f5b2a05537a48"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -215,6 +850,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +875,21 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "napi"
@@ -270,7 +935,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver",
+ "semver 1.0.28",
  "syn",
 ]
 
@@ -284,6 +949,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,16 +1035,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -320,6 +1241,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c335a4796e6081e384712c269f29ed8d2f6613e7afdd54a8467bb7d48f99859f"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -352,10 +1354,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
 
 [[package]]
 name = "semver"
@@ -364,12 +1412,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -393,6 +1448,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,10 +1476,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "small_btree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -425,6 +1526,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tag_ptr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,8 +1625,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -446,6 +1639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,9 +1656,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -464,6 +1687,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -476,6 +1705,49 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -589,3 +1861,141 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xsum"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -15,3 +15,18 @@ indexmap = "2"
 # This is the same crate the serializer will use, so the datetime kinds the
 # value type carries are exactly the ones that re-serialize.
 toml = "0.8"
+
+# ── definition-logic-core (path templates, validation, embedded engine) ──────
+# Embedded JS engine for definition escape-hatch snippets (path-template
+# expressions + raw-JS sort comparators). PURE-RUST, so the whole core stays
+# C-free for trivial cross-platform prebuilds. Its JS semantics are part of the
+# canonical-behavior contract, so the version is PINNED EXACTLY (`=`) and
+# upgraded deliberately — see specs/rust-core.md "Embedded code execution".
+boa_engine = "=0.21.1"
+# JSON-Schema validation of the persisted record shape (the `[gitsheet.schema]`
+# block), replacing `ajv`. default-features off drops the reqwest/TLS remote-ref
+# resolver the core doesn't use (inline schemas only for v1.0).
+jsonschema = { version = "0.46.7", default-features = false }
+# JSON value type the `jsonschema` crate validates against; the core marshals
+# its `Value` to/from it for the shape-validation pass.
+serde_json = "1"

--- a/rust/gitsheets-core/src/engine.rs
+++ b/rust/gitsheets-core/src/engine.rs
@@ -1,0 +1,358 @@
+//! The embedded JS engine for definition escape-hatch snippets.
+//!
+//! Per [`specs/rust-core.md`](../../../specs/rust-core.md) ("Embedded code
+//! execution"), gitsheets is **declarative-first**: the common cases
+//! (`${{ field }}` substitution, `{field: dir}` sort directives, JSON-Schema
+//! validation, built-in partition derivations) are evaluated natively over the
+//! core [`Value`]. The one thing that genuinely needs arbitrary logic — a
+//! definition-embedded raw-JS snippet (a path-template *expression* component
+//! like `${{ publishedAt.getUTCFullYear() }}`, or a raw-JS sort comparator) —
+//! runs in a JS engine **embedded in the core**, never the host binding's JS
+//! runtime. Running it in the core is what keeps it portable: a Python consumer
+//! gets the *core's* engine, so Node and Python produce identical results.
+//!
+//! ## Engine choice & contract
+//!
+//! The engine is [`boa_engine`] (pure-Rust). Its JS semantics determine sort
+//! order and partition paths, so it is part of the **canonical-behavior
+//! contract**: the version is pinned EXACTLY in `Cargo.toml` (`=0.21.1`) and
+//! upgraded as deliberately as a normalization change. The `node:vm` parity
+//! gate (the binding's `engine-parity.mjs` boundary suite) is what catches any
+//! real divergence on an actual snippet before adoption.
+//!
+//! ## Compile-once, reuse-across-operations
+//!
+//! Each definition's snippets are compiled **once** (on sheet-open) into
+//! persistent callable handles held on the [`Engine`], then reused across every
+//! operation — never re-parsed per call. This mirrors the host's `node:vm`
+//! comparators being built once in `buildSorter` and the path template being
+//! parsed once per sheet.
+//!
+//! ## Thread-confinement
+//!
+//! A boa [`Context`] is single-threaded (`!Send`), so [`Engine`] is `!Send`
+//! too. It is pinned to its owning thread — the same discipline holo-tree's
+//! thread-local cache already needs. Bindings construct and call it on the
+//! thread that owns the `Store`.
+
+use boa_engine::object::builtins::JsArray;
+use boa_engine::{js_string, Context, JsNativeErrorKind, JsValue as BoaValue, Source};
+
+use crate::error::{Error, Result};
+use crate::value::{Datetime, Value};
+
+/// An opaque handle to a snippet compiled into the engine, returned by
+/// [`Engine::compile`] and reused across operations.
+pub type SnippetHandle = usize;
+
+/// The outcome of a JS exception raised while *calling* a compiled snippet.
+/// Path rendering distinguishes the two: an undefined-identifier reference is
+/// "this component is un-renderable" (expected at query time, when only some
+/// fields are bound), while any other exception is a genuine failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnippetError {
+    /// A `ReferenceError` — an identifier the snippet names is not defined on
+    /// the record. Mirrors the host renderer treating `… is not defined` as an
+    /// un-renderable component rather than a throw.
+    UndefinedReference(String),
+    /// Any other JS exception (TypeError, SyntaxError at call, …).
+    Other(String),
+}
+
+/// A persistent embedded JS engine: one boa [`Context`] plus the definition's
+/// compiled snippet callables, held for the lifetime of the owning handle.
+///
+/// `!Send` (boa's `Context` is): construct and use on one thread.
+pub struct Engine {
+    context: Context,
+    /// `(ms) => new Date(ms)` — builds a real JS `Date` for datetime fields, so
+    /// a snippet like `publishedAt.getUTCFullYear()` sees a `Date`, matching the
+    /// host where the record's datetime is a JS `Date` of the same epoch ms.
+    make_date: BoaValue,
+    /// Compiled snippet callables, indexed by [`SnippetHandle`].
+    snippets: Vec<BoaValue>,
+}
+
+impl Engine {
+    /// Build a fresh engine. Evaluates the one bootstrap helper (`make_date`).
+    pub fn new() -> Result<Self> {
+        let mut context = Context::default();
+        let make_date = context
+            .eval(Source::from_bytes("(ms) => new Date(ms)"))
+            .map_err(|e| Error::ConfigInvalid {
+                message: format!("embedded engine bootstrap failed: {e}"),
+            })?;
+        Ok(Self {
+            context,
+            make_date,
+            snippets: Vec::new(),
+        })
+    }
+
+    /// Compile a JS source that must evaluate to a **callable**, returning a
+    /// reusable [`SnippetHandle`]. Callers pass the fully-wrapped source — e.g.
+    /// `(record) => { with (record) { return (EXPR) } }` for a path expression,
+    /// or `(a, b) => { RULE }` for a sort comparator — exactly as the host's
+    /// `node:vm` path does. A snippet that fails to parse, or that doesn't
+    /// evaluate to a function, is a [`Error::ConfigInvalid`] (a definition
+    /// problem surfaced at sheet-open, not per-record).
+    pub fn compile(&mut self, source: &str) -> Result<SnippetHandle> {
+        let value =
+            self.context
+                .eval(Source::from_bytes(source))
+                .map_err(|e| Error::ConfigInvalid {
+                    message: format!("embedded snippet failed to compile: {e}"),
+                })?;
+        if !value.is_callable() {
+            return Err(Error::ConfigInvalid {
+                message: format!(
+                    "embedded snippet did not evaluate to a function: {source:?}"
+                ),
+            });
+        }
+        self.snippets.push(value);
+        Ok(self.snippets.len() - 1)
+    }
+
+    /// Call a compiled snippet with `args` (marshalled from core values), and
+    /// return the raw boa result for the caller to interpret (stringify for a
+    /// path component; coerce to a number for a comparator).
+    pub fn call(
+        &mut self,
+        handle: SnippetHandle,
+        args: &[Value],
+    ) -> std::result::Result<BoaValue, SnippetError> {
+        let func = self
+            .snippets
+            .get(handle)
+            .cloned()
+            .ok_or_else(|| SnippetError::Other(format!("unknown snippet handle {handle}")))?;
+        let callable = func
+            .as_callable()
+            .ok_or_else(|| SnippetError::Other("snippet is not callable".into()))?;
+
+        let mut boa_args = Vec::with_capacity(args.len());
+        for arg in args {
+            boa_args.push(
+                self.marshal_to_boa(arg)
+                    .map_err(|e| SnippetError::Other(e.message().to_string()))?,
+            );
+        }
+
+        match callable.call(&BoaValue::undefined(), &boa_args, &mut self.context) {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                let kind = err
+                    .try_native(&mut self.context)
+                    .map(|n| n.kind.clone())
+                    .ok();
+                let message = err.to_string();
+                match kind {
+                    Some(JsNativeErrorKind::Reference) => {
+                        Err(SnippetError::UndefinedReference(message))
+                    }
+                    _ => Err(SnippetError::Other(message)),
+                }
+            }
+        }
+    }
+
+    /// Stringify a boa value the way the host renderer's `stringifyValue` does:
+    /// primitives (string / number / boolean / bigint) → their JS `String(...)`
+    /// form; `null` / `undefined` / functions / objects → `None` (the component
+    /// is un-renderable). Matches `packages/gitsheets/src/path-template`.
+    pub fn to_path_string(&mut self, value: &BoaValue) -> Option<String> {
+        if value.is_null_or_undefined() || value.is_callable() || value.is_object() {
+            return None;
+        }
+        if value.is_string() || value.is_number() || value.is_boolean() || value.is_bigint() {
+            // ECMAScript ToString — JS-accurate number formatting (`2026`, `1.5`).
+            return value
+                .to_string(&mut self.context)
+                .ok()
+                .map(|s| s.to_std_string_escaped());
+        }
+        None
+    }
+
+    /// Coerce a boa value to a number via ECMAScript `ToNumber` — what
+    /// `Array.prototype.sort` does with a comparator's return value.
+    pub fn to_number(&mut self, value: &BoaValue) -> Result<f64> {
+        value.to_number(&mut self.context).map_err(|e| Error::ConfigInvalid {
+            message: format!("comparator did not return a number: {e}"),
+        })
+    }
+
+    // ── core Value -> boa JsValue marshalling ────────────────────────────────
+
+    fn marshal_to_boa(&mut self, value: &Value) -> Result<BoaValue> {
+        Ok(match value {
+            Value::String(s) => js_string!(s.as_str()).into(),
+            // JS has a single `number`; an i64 projects to f64 exactly as the
+            // host record's integers already are (the binding marshalled them to
+            // JS numbers). Beyond 2^53 this loses precision — same as the host.
+            Value::Integer(i) => (*i as f64).into(),
+            Value::Float(f) => (*f).into(),
+            Value::Boolean(b) => (*b).into(),
+            Value::Datetime(dt) => {
+                let ms = datetime_to_unix_millis(dt);
+                let make_date = self
+                    .make_date
+                    .as_callable()
+                    .expect("make_date is callable");
+                make_date
+                    .call(&BoaValue::undefined(), &[(ms as f64).into()], &mut self.context)
+                    .map_err(|e| Error::ConfigInvalid {
+                        message: format!("failed to build JS Date: {e}"),
+                    })?
+            }
+            Value::Array(items) => {
+                let arr = JsArray::new(&mut self.context);
+                for item in items {
+                    let v = self.marshal_to_boa(item)?;
+                    arr.push(v, &mut self.context).map_err(|e| Error::ConfigInvalid {
+                        message: format!("failed to build JS array: {e}"),
+                    })?;
+                }
+                arr.into()
+            }
+            Value::Table(map) => {
+                let obj = boa_engine::object::JsObject::with_object_proto(self.context.intrinsics());
+                for (k, val) in map {
+                    let v = self.marshal_to_boa(val)?;
+                    obj.set(js_string!(k.as_str()), v, false, &mut self.context)
+                        .map_err(|e| Error::ConfigInvalid {
+                            message: format!("failed to build JS object: {e}"),
+                        })?;
+                }
+                obj.into()
+            }
+        })
+    }
+}
+
+/// Epoch milliseconds for any of the four TOML datetime kinds, computed without
+/// a calendar dependency (Howard Hinnant's `days_from_civil`). Local kinds (no
+/// offset) are interpreted at UTC — the same least-lossy projection the Node
+/// binding's `datetime_to_unix_millis` uses, so a datetime field reaches the
+/// engine as the same instant the host's JS `Date` would carry.
+fn datetime_to_unix_millis(dt: &Datetime) -> i64 {
+    let Datetime(inner) = dt;
+    let (year, month, day) = match inner.date {
+        Some(d) => (d.year as i64, d.month as i64, d.day as i64),
+        None => (1970, 1, 1),
+    };
+    let (hour, minute, second, nanos) = match inner.time {
+        Some(t) => (
+            t.hour as i64,
+            t.minute as i64,
+            t.second as i64,
+            t.nanosecond as i64,
+        ),
+        None => (0, 0, 0, 0),
+    };
+    let offset_minutes: i64 = match inner.offset {
+        Some(toml::value::Offset::Z) => 0,
+        Some(toml::value::Offset::Custom { minutes }) => minutes as i64,
+        None => 0,
+    };
+    let days = days_from_civil(year, month, day);
+    let wall_ms = (((days * 24 + hour) * 60 + minute) * 60 + second) * 1000 + nanos / 1_000_000;
+    // Components are wall-clock at `offset`; the instant is components − offset.
+    wall_ms - offset_minutes * 60_000
+}
+
+/// Days since the Unix epoch (1970-01-01) for a proleptic-Gregorian civil date.
+/// Howard Hinnant's algorithm (<http://howardhinnant.github.io/date_algorithms.html>).
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146097 + doe - 719468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn dt(s: &str) -> Value {
+        Value::Datetime(s.parse::<Datetime>().expect("parse datetime"))
+    }
+
+    #[test]
+    fn days_from_civil_matches_known_anchors() {
+        assert_eq!(days_from_civil(1970, 1, 1), 0);
+        assert_eq!(days_from_civil(1969, 12, 31), -1);
+        assert_eq!(days_from_civil(2000, 1, 1), 10957);
+    }
+
+    #[test]
+    fn datetime_to_millis_matches_known_instant() {
+        // 1979-05-27T07:32:00Z is 296_638_320_000 ms since epoch.
+        let v = dt("1979-05-27T07:32:00Z");
+        let Value::Datetime(d) = &v else { unreachable!() };
+        assert_eq!(datetime_to_unix_millis(d), 296_638_320_000);
+    }
+
+    #[test]
+    fn compiles_and_calls_a_comparator_reused_across_calls() {
+        let mut eng = Engine::new().expect("engine");
+        let h = eng
+            .compile("(a, b) => { return a - b; }")
+            .expect("compile");
+        // Reused across operations — same handle, many calls.
+        let r1 = eng.call(h, &[Value::Integer(1), Value::Integer(2)]).unwrap();
+        let r2 = eng.call(h, &[Value::Integer(5), Value::Integer(3)]).unwrap();
+        assert_eq!(eng.to_number(&r1).unwrap(), -1.0);
+        assert_eq!(eng.to_number(&r2).unwrap(), 2.0);
+    }
+
+    #[test]
+    fn path_expression_over_a_date_field_derives_partitions() {
+        let mut eng = Engine::new().expect("engine");
+        let h = eng
+            .compile("(record) => { with (record) { return (publishedAt.getUTCFullYear()) } }")
+            .expect("compile");
+        let mut rec = IndexMap::new();
+        rec.insert("publishedAt".to_string(), dt("1979-05-27T07:32:00Z"));
+        let out = eng.call(h, &[Value::Table(rec)]).unwrap();
+        assert_eq!(eng.to_path_string(&out).as_deref(), Some("1979"));
+    }
+
+    #[test]
+    fn undefined_identifier_is_an_unrenderable_reference() {
+        let mut eng = Engine::new().expect("engine");
+        let h = eng
+            .compile("(record) => { with (record) { return (missing.toLowerCase()) } }")
+            .expect("compile");
+        let rec = IndexMap::new();
+        let err = eng.call(h, &[Value::Table(rec)]).unwrap_err();
+        assert!(matches!(err, SnippetError::UndefinedReference(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn string_method_expression_renders() {
+        let mut eng = Engine::new().expect("engine");
+        let h = eng
+            .compile("(record) => { with (record) { return (slug.toLowerCase()) } }")
+            .expect("compile");
+        let mut rec = IndexMap::new();
+        rec.insert("slug".to_string(), Value::String("HELLO".into()));
+        let out = eng.call(h, &[Value::Table(rec)]).unwrap();
+        assert_eq!(eng.to_path_string(&out).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn objects_and_null_are_unrenderable() {
+        let mut eng = Engine::new().expect("engine");
+        let h = eng.compile("(record) => { with (record) { return (x) } }").unwrap();
+        // null → None
+        let mut rec = IndexMap::new();
+        rec.insert("x".to_string(), Value::Array(vec![Value::Integer(1)]));
+        let out = eng.call(h, &[Value::Table(rec)]).unwrap();
+        assert_eq!(eng.to_path_string(&out), None, "array result is un-renderable");
+    }
+}

--- a/rust/gitsheets-core/src/engine.rs
+++ b/rust/gitsheets-core/src/engine.rs
@@ -114,6 +114,13 @@ impl Engine {
         Ok(self.snippets.len() - 1)
     }
 
+    /// How many snippets have been compiled into this engine. Bindings expose
+    /// this to prove snippets are compiled **once on open** and never per call:
+    /// the count is set at compile time and never grows as operations run.
+    pub fn snippet_count(&self) -> usize {
+        self.snippets.len()
+    }
+
     /// Call a compiled snippet with `args` (marshalled from core values), and
     /// return the raw boa result for the caller to interpret (stringify for a
     /// path component; coerce to a number for a comparator).

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -18,7 +18,10 @@
 //! top of this substrate. See [`specs/rust-core.md`](../../../specs/rust-core.md).
 
 pub mod canonical;
+pub mod engine;
 pub mod error;
+pub mod path_template;
+pub mod validation;
 pub mod value;
 
 pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};

--- a/rust/gitsheets-core/src/path_template.rs
+++ b/rust/gitsheets-core/src/path_template.rs
@@ -1,0 +1,477 @@
+//! Path-template parsing + rendering — record → on-disk path.
+//!
+//! A behavior-preserving Rust port of the host renderer
+//! (`packages/gitsheets/src/path-template/index.ts`), per
+//! [`specs/behaviors/path-templates.md`](../../../specs/behaviors/path-templates.md).
+//! The template determines where each record's file lives in the data tree, so
+//! it is bytes-determining and belongs in the core (every binding must render
+//! the same path for the same record).
+//!
+//! ## What's native vs engine-backed
+//!
+//! - **Literal** and **field-reference** (`${{ slug }}`) components render
+//!   **natively** over the core [`Value`] — the declarative-first common case.
+//! - **Expression** components (`${{ publishedAt.getUTCFullYear() }}`) are the
+//!   escape hatch: compiled once into the embedded [`Engine`] and evaluated per
+//!   record. This is where partition derivations (date-parts, etc.) live, and
+//!   it is the path-template half of the `node:vm` parity gate.
+//!
+//! Query-tree traversal/pruning (the *other* job of a parsed template) is a
+//! record-engine concern and lands downstream; this module owns parse + render.
+
+use crate::engine::{Engine, SnippetError, SnippetHandle};
+use crate::error::{Error, Result};
+use crate::value::Value;
+
+/// One parsed path component (a slash-separated segment), made of one or more
+/// parts. A pure field-reference / literal component renders natively; a
+/// component containing an expression part consults the engine.
+#[derive(Debug)]
+struct Component {
+    parts: Vec<Part>,
+    /// True iff this component is exactly one recursive (`field/**`) field part.
+    recursive: bool,
+}
+
+#[derive(Debug)]
+enum Part {
+    Literal(String),
+    Field { name: String, recursive: bool },
+    Expression { handle: SnippetHandle },
+}
+
+/// A parsed, compiled path template. Built once per template string (with its
+/// expression parts compiled into the shared [`Engine`]); rendered many times.
+#[derive(Debug)]
+pub struct Template {
+    source: String,
+    components: Vec<Component>,
+}
+
+impl Template {
+    /// Parse `source` and compile any expression components into `engine`,
+    /// returning a reusable template. Expression compile failures surface as
+    /// [`Error::PathRenderFailed`] (matching the host's `compileExpression`,
+    /// which raises `path_render_failed` on a bad expression).
+    pub fn compile(source: &str, engine: &mut Engine) -> Result<Self> {
+        let components = parse_template(source, engine)?;
+        Ok(Template {
+            source: source.to_string(),
+            components,
+        })
+    }
+
+    /// The original template string.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Number of slash-separated components.
+    pub fn component_count(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Render the template against a full record into a slash-joined path
+    /// (without the trailing file extension — the caller appends `.toml`/`.md`).
+    ///
+    /// Mirrors the host `Template.render`:
+    /// - any component that can't render (a required field/expression is absent
+    ///   or yields `null`/`undefined`/non-primitive) → [`Error::PathRenderFailed`]
+    ///   naming the component;
+    /// - a rendered segment containing a filesystem-illegal character →
+    ///   [`Error::PathInvalidChars`].
+    pub fn render(&self, record: &Value, engine: &mut Engine) -> Result<String> {
+        let mut segments = Vec::with_capacity(self.components.len());
+        for (i, component) in self.components.iter().enumerate() {
+            let rendered = self.render_component(component, record, engine)?;
+            let Some(rendered) = rendered else {
+                return Err(Error::PathRenderFailed {
+                    message: format!(
+                        "cannot render component {i} of \"{}\" — a required field or expression returned undefined",
+                        self.source
+                    ),
+                });
+            };
+            reject_invalid_chars(&rendered, component.recursive, &self.source, i)?;
+            segments.push(rendered);
+        }
+        Ok(segments.join("/"))
+    }
+
+    /// Render a single component to `Some(text)` or `None` (un-renderable).
+    /// Returns `Err` only for a genuine engine failure (a non-reference JS
+    /// exception while evaluating an expression).
+    fn render_component(
+        &self,
+        component: &Component,
+        record: &Value,
+        engine: &mut Engine,
+    ) -> Result<Option<String>> {
+        let mut out = String::new();
+        for part in &component.parts {
+            let piece = match part {
+                Part::Literal(text) => Some(text.clone()),
+                Part::Field { name, .. } => field_to_string(record, name),
+                Part::Expression { handle } => match engine.call(*handle, std::slice::from_ref(record)) {
+                    Ok(value) => engine.to_path_string(&value),
+                    // An undefined identifier is "un-renderable", not fatal —
+                    // lets a partial query walk the tree fully (host parity).
+                    Err(SnippetError::UndefinedReference(_)) => None,
+                    Err(SnippetError::Other(message)) => {
+                        return Err(Error::PathRenderFailed {
+                            message: format!(
+                                "expression in component of \"{}\" failed: {message}",
+                                self.source
+                            ),
+                        });
+                    }
+                },
+            };
+            match piece {
+                Some(p) => out.push_str(&p),
+                None => return Ok(None),
+            }
+        }
+        Ok(Some(out))
+    }
+}
+
+/// Native stringification of a field value, matching the host `stringifyValue`:
+/// strings as-is; numbers/booleans via their JS `String(...)` form; everything
+/// that has no unambiguous path representation (`null`/absent, arrays, tables,
+/// and — see the divergence note in the plan — datetimes) → `None`.
+fn field_to_string(record: &Value, name: &str) -> Option<String> {
+    let Value::Table(map) = record else {
+        return None;
+    };
+    match map.get(name) {
+        None => None,
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(Value::Integer(i)) => Some(i.to_string()),
+        Some(Value::Float(f)) => Some(format_js_number(*f)),
+        Some(Value::Boolean(b)) => Some(if *b { "true".into() } else { "false".into() }),
+        // Datetime / Array / Table have no native path form here (a host Date
+        // field would stringify to a locale/TZ-dependent string — see the plan's
+        // enumerated divergence; nobody uses a raw Date as a path segment).
+        Some(_) => None,
+    }
+}
+
+/// Format an f64 the way JS `String(n)` does for the common cases: an integral
+/// float prints without a decimal (`1.0` → `"1"`), `1.5` → `"1.5"`. (Exotic
+/// scientific-notation thresholds differ from V8; an edge for a float used
+/// directly as a path segment, which is itself unusual.)
+fn format_js_number(f: f64) -> String {
+    if f.is_finite() && f.fract() == 0.0 && f.abs() < 1e21 {
+        format!("{}", f as i64)
+    } else {
+        format!("{f}")
+    }
+}
+
+// ── invalid-character rejection ───────────────────────────────────────────────
+
+fn is_windows_invalid(c: char) -> bool {
+    matches!(c, '<' | '>' | ':' | '"' | '|' | '?' | '*') || (c as u32) < 0x20
+}
+
+fn reject_invalid_chars(
+    rendered: &str,
+    recursive: bool,
+    source: &str,
+    component_index: usize,
+) -> Result<()> {
+    for c in rendered.chars() {
+        // Non-recursive components additionally forbid `/` (it would silently
+        // expand the path structure); recursive `field/**` components allow it.
+        let invalid = is_windows_invalid(c) || (!recursive && c == '/');
+        if invalid {
+            return Err(Error::PathInvalidChars {
+                message: format!(
+                    "component {component_index} of \"{source}\" rendered to {rendered:?}, which contains disallowed character {:?}",
+                    c
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+// ── parser (port of parseTemplateString / buildComponent) ─────────────────────
+
+/// A bare field reference: identifier chars optionally followed by the `/**`
+/// recursive suffix. Anything else inside `${{ }}` is an expression.
+fn is_field_name(s: &str) -> bool {
+    let body = s.strip_suffix("/**").unwrap_or(s);
+    !body.is_empty()
+        && body
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+fn parse_template(source: &str, engine: &mut Engine) -> Result<Vec<Component>> {
+    let normalized = source.trim_matches('/');
+    if normalized.is_empty() {
+        return Err(Error::PathRenderFailed {
+            message: "path template is empty".into(),
+        });
+    }
+
+    let chars: Vec<char> = normalized.chars().collect();
+    let mut segments: Vec<Vec<Part>> = vec![Vec::new()];
+    let mut pending_literal = String::new();
+    let mut i = 0;
+
+    let starts_with = |chars: &[char], idx: usize, pat: &str| -> bool {
+        let pat: Vec<char> = pat.chars().collect();
+        idx + pat.len() <= chars.len() && chars[idx..idx + pat.len()] == pat[..]
+    };
+
+    while i < chars.len() {
+        if starts_with(&chars, i, "${{") {
+            flush_literal(&mut pending_literal, &mut segments);
+            i += 3;
+            let mut expr = String::new();
+            while !starts_with(&chars, i, "}}") {
+                if i >= chars.len() {
+                    return Err(Error::PathRenderFailed {
+                        message: format!(
+                            "expression \"${{{{{expr}\" in template \"{source}\" was not closed with }}}}"
+                        ),
+                    });
+                }
+                expr.push(chars[i]);
+                i += 1;
+            }
+            let expr = expr.trim().to_string();
+            i += 2;
+
+            if is_field_name(&expr) {
+                let recursive = expr.ends_with("/**");
+                let name = if recursive {
+                    expr[..expr.len() - 3].to_string()
+                } else {
+                    expr.clone()
+                };
+                segments
+                    .last_mut()
+                    .unwrap()
+                    .push(Part::Field { name, recursive });
+            } else {
+                let wrapped = format!("(record) => {{ with (record) {{ return ({expr}) }} }}");
+                let handle = engine.compile(&wrapped).map_err(|e| Error::PathRenderFailed {
+                    message: format!(
+                        "expression {expr:?} failed to compile: {}",
+                        e.message()
+                    ),
+                })?;
+                segments.last_mut().unwrap().push(Part::Expression { handle });
+            }
+        } else if chars[i] == '/' {
+            flush_literal(&mut pending_literal, &mut segments);
+            segments.push(Vec::new());
+            i += 1;
+        } else {
+            pending_literal.push(chars[i]);
+            i += 1;
+        }
+    }
+    flush_literal(&mut pending_literal, &mut segments);
+
+    let mut components = Vec::with_capacity(segments.len());
+    for (idx, parts) in segments.into_iter().enumerate() {
+        components.push(build_component(parts, idx, source)?);
+    }
+
+    // Recursive (`/**`) must be the last component if present.
+    for c in &components[..components.len().saturating_sub(1)] {
+        if c.recursive {
+            return Err(Error::PathRenderFailed {
+                message: "recursive component (${{ ... /** }}) must be the final component of the template".into(),
+            });
+        }
+    }
+
+    Ok(components)
+}
+
+fn flush_literal(pending: &mut String, segments: &mut [Vec<Part>]) {
+    if !pending.is_empty() {
+        segments
+            .last_mut()
+            .unwrap()
+            .push(Part::Literal(std::mem::take(pending)));
+    }
+}
+
+fn build_component(parts: Vec<Part>, index: usize, source: &str) -> Result<Component> {
+    if parts.is_empty() {
+        return Err(Error::PathRenderFailed {
+            message: format!(
+                "empty component at index {index} of \"{source}\" — consecutive slashes are not allowed"
+            ),
+        });
+    }
+
+    let only_recursive = parts.len() == 1
+        && matches!(&parts[0], Part::Field { recursive: true, .. });
+
+    if !only_recursive {
+        for part in &parts {
+            if let Part::Field {
+                recursive: true,
+                name,
+            } = part
+            {
+                return Err(Error::PathRenderFailed {
+                    message: format!(
+                        "recursive field reference (${{{{ {name}/** }}}}) must be the only part of its component"
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(Component {
+        parts,
+        recursive: only_recursive,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn table(pairs: &[(&str, Value)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Value::Table(m)
+    }
+
+    fn render(template: &str, record: &Value) -> Result<String> {
+        let mut eng = Engine::new().unwrap();
+        let t = Template::compile(template, &mut eng)?;
+        t.render(record, &mut eng)
+    }
+
+    #[test]
+    fn simple_field() {
+        let r = table(&[("slug", Value::String("jane".into()))]);
+        assert_eq!(render("${{ slug }}", &r).unwrap(), "jane");
+    }
+
+    #[test]
+    fn composite_two_level() {
+        let r = table(&[
+            ("domain", Value::String("af.mil".into())),
+            ("username", Value::String("grandma".into())),
+        ]);
+        assert_eq!(
+            render("${{ domain }}/${{ username }}", &r).unwrap(),
+            "af.mil/grandma"
+        );
+    }
+
+    #[test]
+    fn multi_variable_per_segment_issue_105() {
+        let r = table(&[
+            ("year", Value::Integer(2026)),
+            ("status", Value::String("active".into())),
+            ("id", Value::Integer(12345)),
+        ]);
+        assert_eq!(
+            render("${{ year }}/${{ status }}--${{ id }}", &r).unwrap(),
+            "2026/active--12345"
+        );
+    }
+
+    #[test]
+    fn expression_partition_by_date_parts() {
+        let dt = Value::Datetime("2026-03-09T12:00:00Z".parse().unwrap());
+        let r = table(&[("publishedAt", dt), ("slug", Value::String("hi".into()))]);
+        let out = render(
+            "${{ publishedAt.getUTCFullYear() }}/${{ publishedAt.getUTCMonth() }}/${{ slug }}",
+            &r,
+        )
+        .unwrap();
+        // getUTCMonth is 0-based, exactly like JS.
+        assert_eq!(out, "2026/2/hi");
+    }
+
+    #[test]
+    fn missing_field_fails_render() {
+        let r = table(&[("other", Value::String("x".into()))]);
+        let err = render("${{ slug }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_render_failed");
+    }
+
+    #[test]
+    fn invalid_char_is_rejected() {
+        let r = table(&[("slug", Value::String("a:b".into()))]);
+        let err = render("${{ slug }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_invalid_chars");
+    }
+
+    #[test]
+    fn slash_in_nonrecursive_segment_is_rejected() {
+        let r = table(&[("slug", Value::String("a/b".into()))]);
+        let err = render("${{ slug }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_invalid_chars");
+    }
+
+    #[test]
+    fn recursive_component_allows_slashes() {
+        let r = table(&[("contentPath", Value::String("docs/guides/intro".into()))]);
+        assert_eq!(
+            render("${{ contentPath/** }}", &r).unwrap(),
+            "docs/guides/intro"
+        );
+    }
+
+    #[test]
+    fn recursive_must_be_last() {
+        let mut eng = Engine::new().unwrap();
+        let err = Template::compile("${{ a/** }}/${{ b }}", &mut eng).unwrap_err();
+        assert_eq!(err.code(), "path_render_failed");
+    }
+
+    #[test]
+    fn empty_template_is_rejected() {
+        let mut eng = Engine::new().unwrap();
+        assert!(Template::compile("///", &mut eng).is_err());
+    }
+
+    #[test]
+    fn consecutive_slashes_rejected() {
+        let mut eng = Engine::new().unwrap();
+        assert!(Template::compile("${{ a }}//${{ b }}", &mut eng).is_err());
+    }
+
+    #[test]
+    fn expression_with_undefined_identifier_is_unrenderable() {
+        // At full-record render time a missing identifier means the path can't
+        // be produced → path_render_failed (the component is un-renderable).
+        let r = table(&[("slug", Value::String("x".into()))]);
+        let err = render("${{ missing.toLowerCase() }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_render_failed");
+    }
+
+    #[test]
+    fn integer_and_boolean_fields_stringify_like_js() {
+        let r = table(&[("n", Value::Integer(42)), ("b", Value::Boolean(true))]);
+        assert_eq!(render("${{ n }}/${{ b }}", &r).unwrap(), "42/true");
+    }
+
+    #[test]
+    fn template_compiles_once_renders_many() {
+        let mut eng = Engine::new().unwrap();
+        let t = Template::compile("${{ slug.toUpperCase() }}", &mut eng).unwrap();
+        let r1 = table(&[("slug", Value::String("a".into()))]);
+        let r2 = table(&[("slug", Value::String("b".into()))]);
+        assert_eq!(t.render(&r1, &mut eng).unwrap(), "A");
+        assert_eq!(t.render(&r2, &mut eng).unwrap(), "B");
+    }
+}

--- a/rust/gitsheets-core/src/validation.rs
+++ b/rust/gitsheets-core/src/validation.rs
@@ -1,0 +1,248 @@
+//! Persisted-shape validation — JSON Schema, natively in the core.
+//!
+//! A behavior-preserving Rust port of the host's `ajv`-based first validation
+//! layer (`packages/gitsheets/src/validation.ts`), per
+//! [`specs/behaviors/validation.md`](../../../specs/behaviors/validation.md).
+//! The `[gitsheet.schema]` block is **persisted with the data**, so the shape
+//! contract it expresses must be enforced identically by every binding — hence
+//! it lives in the core. The *second* layer (the consumer-supplied Standard
+//! Schema / Zod / Pydantic validator) legitimately stays in the binding and is
+//! out of scope here.
+//!
+//! ## Engine & ajv-parity
+//!
+//! Validation runs through the pure-Rust [`jsonschema`] crate, configured to
+//! mirror the host `ajv` setup as closely as a different library allows:
+//!
+//! - **Draft 7** — `ajv` v8's default meta-schema (the gitsheets schemas don't
+//!   declare `$schema`), so we pin `Draft::Draft7` rather than let the crate
+//!   auto-detect 2020-12.
+//! - **Formats asserted** — `ajv-formats` makes `email`/`date-time`/`uri`/`uuid`
+//!   assertions; we enable `should_validate_formats(true)` to match (formats are
+//!   annotation-only by default in the crate).
+//! - **All errors** — `ajv` runs with `allErrors: true`; the crate's
+//!   `iter_errors` is likewise exhaustive.
+//!
+//! Each failure maps to a [`ValidationIssue`] with `source = json-schema`, the
+//! instance path split like `ajv`'s `instancePath`, the `schemaPath` (`#`-
+//! prefixed to match `ajv`), and a `code` taken from the failing keyword (the
+//! last `schemaPath` segment — exactly `ajv`'s `keyword`). Issue *message text*
+//! is the one field that legitimately differs between the two libraries; the
+//! binding's `ajv-parity.mjs` suite asserts validity + path + keyword parity and
+//! excludes prose. Enumerated divergences live in the plan's Notes.
+
+use jsonschema::{Draft, Validator};
+use serde_json::Value as Json;
+
+use crate::error::{Error, IssueSource, Result, ValidationIssue};
+use crate::value::Value;
+
+/// A schema compiled once (on sheet-open) and reused to validate every record.
+pub struct CompiledSchema {
+    validator: Validator,
+}
+
+impl CompiledSchema {
+    /// Compile a `[gitsheet.schema]` block (carried as a core [`Value`]) into a
+    /// reusable validator. A schema the crate can't build (bad regex, malformed
+    /// structure, …) is a [`Error::ConfigInvalid`] — the config-time failure
+    /// bucket, matching the host raising `ConfigError(config_invalid)` when
+    /// `ajv.compile` throws.
+    ///
+    /// **Strict-mode divergence (enumerated):** `ajv` runs `strict: true`, which
+    /// rejects *unknown keywords* at compile with `config_invalid`. The
+    /// `jsonschema` crate silently ignores unknown keywords instead, so a schema
+    /// with a typo'd keyword compiles here where `ajv` would reject it. See the
+    /// plan Notes.
+    pub fn compile(schema: &Value) -> Result<Self> {
+        let json = value_to_json(schema);
+        let validator = jsonschema::options()
+            .with_draft(Draft::Draft7)
+            .should_validate_formats(true)
+            .should_ignore_unknown_formats(true)
+            .build(&json)
+            .map_err(|e| Error::ConfigInvalid {
+                message: format!("[gitsheet.schema] failed to compile: {e}"),
+            })?;
+        Ok(CompiledSchema { validator })
+    }
+
+    /// Validate one record, returning every issue (empty ⇒ valid). The caller
+    /// wraps a non-empty result in [`Error::ValidationFailed`] (the host's
+    /// `ValidationError`); see [`validate_or_error`].
+    pub fn validate(&self, record: &Value) -> Vec<ValidationIssue> {
+        let json = value_to_json(record);
+        let mut issues = Vec::new();
+        for err in self.validator.iter_errors(&json) {
+            let instance_path = err.instance_path().as_str().to_string();
+            let schema_path = err.schema_path().as_str().to_string();
+            issues.push(ValidationIssue {
+                path: split_pointer(&instance_path),
+                message: err.to_string(),
+                source: IssueSource::JsonSchema,
+                schema_path: Some(format!("#{schema_path}")),
+                // ajv's `keyword` is the last schemaPath segment — same here.
+                code: keyword_from_schema_path(&schema_path),
+            });
+        }
+        issues
+    }
+
+    /// Validate, returning `Ok(())` when valid or [`Error::ValidationFailed`]
+    /// carrying all issues — the shape the host surfaces as `ValidationError`.
+    pub fn validate_or_error(&self, record: &Value) -> Result<()> {
+        let issues = self.validate(record);
+        if issues.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::ValidationFailed {
+                message: "record failed JSON Schema validation".into(),
+                issues,
+            })
+        }
+    }
+}
+
+/// Split a JSON-Pointer instance path (`/address/city`, `/tags/0`) into segment
+/// strings, exactly like the host's `instancePath.split('/').slice(1)` with
+/// `~1`/`~0` unescaping.
+fn split_pointer(pointer: &str) -> Vec<String> {
+    if pointer.is_empty() {
+        return Vec::new();
+    }
+    pointer
+        .split('/')
+        .skip(1)
+        .map(|seg| seg.replace("~1", "/").replace("~0", "~"))
+        .collect()
+}
+
+/// The failing keyword — the last segment of the schema path. `ajv` reports
+/// exactly this in `err.keyword`.
+fn keyword_from_schema_path(schema_path: &str) -> Option<String> {
+    schema_path
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Marshal a core [`Value`] into a `serde_json::Value` for validation.
+///
+/// **Datetime divergence (enumerated):** a [`Value::Datetime`] becomes its TOML
+/// string form here, whereas the host validates the record with a JS `Date`
+/// *object*. So a schema asserting `type: 'string'` + `format: 'date-time'` on a
+/// datetime field passes here but the host would see an object. Datetime-typed
+/// schema fields are uncommon (the spec's example schemas are string/number);
+/// the parity fixtures stay JSON-representable and this case is enumerated.
+fn value_to_json(value: &Value) -> Json {
+    match value {
+        Value::String(s) => Json::String(s.clone()),
+        Value::Integer(i) => Json::Number((*i).into()),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(Json::Number)
+            .unwrap_or(Json::Null),
+        Value::Boolean(b) => Json::Bool(*b),
+        Value::Datetime(dt) => Json::String(dt.to_toml_string()),
+        Value::Array(items) => Json::Array(items.iter().map(value_to_json).collect()),
+        Value::Table(map) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in map {
+                obj.insert(k.clone(), value_to_json(v));
+            }
+            Json::Object(obj)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical::parse;
+
+    fn schema() -> Value {
+        // The validation.md example, encoded as TOML for convenience.
+        parse(
+            r#"
+type = 'object'
+required = ['slug', 'email', 'fullName']
+additionalProperties = false
+
+[properties.slug]
+type = 'string'
+pattern = '^[a-z0-9][a-z0-9-]{1,49}$'
+
+[properties.email]
+type = 'string'
+format = 'email'
+
+[properties.fullName]
+type = 'string'
+minLength = 1
+maxLength = 120
+"#,
+        )
+        .expect("schema parses")
+    }
+
+    fn record(toml: &str) -> Value {
+        parse(toml).expect("record parses")
+    }
+
+    #[test]
+    fn valid_record_has_no_issues() {
+        let s = CompiledSchema::compile(&schema()).unwrap();
+        let r = record("slug = 'jane'\nemail = 'jane@example.org'\nfullName = 'Jane'\n");
+        assert!(s.validate(&r).is_empty());
+    }
+
+    #[test]
+    fn pattern_violation_reports_keyword_and_path() {
+        let s = CompiledSchema::compile(&schema()).unwrap();
+        let r = record("slug = 'JANE!'\nemail = 'jane@example.org'\nfullName = 'Jane'\n");
+        let issues = s.validate(&r);
+        let pattern = issues
+            .iter()
+            .find(|i| i.code.as_deref() == Some("pattern"))
+            .expect("a pattern issue");
+        assert_eq!(pattern.path, vec!["slug".to_string()]);
+        assert_eq!(pattern.source, IssueSource::JsonSchema);
+        assert!(pattern.schema_path.as_deref().unwrap().starts_with('#'));
+    }
+
+    #[test]
+    fn missing_required_reports_required_keyword() {
+        let s = CompiledSchema::compile(&schema()).unwrap();
+        let r = record("slug = 'jane'\nfullName = 'Jane'\n");
+        let issues = s.validate(&r);
+        assert!(issues.iter().any(|i| i.code.as_deref() == Some("required")));
+    }
+
+    #[test]
+    fn additional_property_is_rejected() {
+        let s = CompiledSchema::compile(&schema()).unwrap();
+        let r = record(
+            "slug = 'jane'\nemail = 'jane@example.org'\nfullName = 'Jane'\nextra = 'nope'\n",
+        );
+        let issues = s.validate(&r);
+        assert!(issues
+            .iter()
+            .any(|i| i.code.as_deref() == Some("additionalProperties")));
+    }
+
+    #[test]
+    fn bad_email_format_is_rejected() {
+        let s = CompiledSchema::compile(&schema()).unwrap();
+        let r = record("slug = 'jane'\nemail = 'not-an-email'\nfullName = 'Jane'\n");
+        let issues = s.validate(&r);
+        assert!(issues.iter().any(|i| i.code.as_deref() == Some("format")));
+    }
+
+    #[test]
+    fn validate_or_error_wraps_issues() {
+        let s = CompiledSchema::compile(&schema()).unwrap();
+        let r = record("slug = 'jane'\n");
+        let err = s.validate_or_error(&r).unwrap_err();
+        assert_eq!(err.code(), "validation_failed");
+        assert!(!err.issues().is_empty());
+    }
+}

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -109,6 +109,14 @@ module.exports = {
   // structured core error (`config_invalid`), surfaced as its typed class.
   parseRecords: wrap(addon.parseRecords),
   serializeRecords: wrap(addon.serializeRecords),
+  // Definition logic (batch-first). Path rendering raises a typed
+  // PathTemplateError; schema compilation raises a typed ConfigError.
+  renderPathsBatch: wrap(addon.renderPathsBatch),
+  validateBatch: wrap(addon.validateBatch),
+  runComparator: wrap(addon.runComparator),
+  // Stateful compiled definition (compile-once / reuse). Raw class — its
+  // structured errors carry `gitsheetsClass`; map with `mapCoreError` if needed.
+  CompiledDefinition: addon.CompiledDefinition,
   // Boundary-test entry: throws the typed class for a given stable code.
   simulateCoreError: wrap(addon.simulateCoreError),
   // Error machinery.

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -23,9 +23,76 @@ export declare function parseRecords(documents: Array<string>): Array<JsValue>
  */
 export declare function serializeRecords(records: Array<JsValue>): Array<string>
 /**
+ * One JSON-Schema validation failure, marshalled to the `ValidationIssue`
+ * shape the host surface uses (`source`/`schemaPath`/`code`, with snake fields
+ * rendered camelCase by napi). Returned by [`validate_batch`].
+ */
+export interface JsValidationIssue {
+  path: Array<string>
+  message: string
+  source: string
+  schemaPath?: string
+  code?: string
+}
+/**
+ * Render a path template against a **batch** of records, returning one path per
+ * record (no file extension; the caller appends `.toml`/`.md`). The template is
+ * parsed and its expression components compiled into the embedded engine
+ * **once**, then reused across the whole batch — the bulk path crosses the FFI
+ * a single time. A render failure surfaces as a structured, typed
+ * `PathTemplateError` (`path_render_failed` / `path_invalid_chars`). This is the
+ * path-template half of the `node:vm` parity gate.
+ */
+export declare function renderPathsBatch(template: string, records: Array<JsValue>): Array<string>
+/**
+ * Validate a **batch** of records against a JSON Schema, returning the issues
+ * for each record (an empty inner array ⇒ that record is valid). The schema is
+ * compiled **once**, then reused across the batch. Unlike the host's throwing
+ * `validateRecord`, this returns issues per record so a parity harness can diff
+ * the full pass/fail + path/keyword picture against `ajv`. A schema that won't
+ * compile surfaces as a structured, typed `ConfigError` (`config_invalid`).
+ */
+export declare function validateBatch(schema: JsValue, records: Array<JsValue>): Array<Array<JsValidationIssue>>
+/**
+ * Compile a raw-JS sort comparator (`rule`, the body of `(a, b) => { … }`) and
+ * run it once against `a`/`b`, returning its numeric result. The direct
+ * comparator-parity entry point: a harness asserts this equals the same rule
+ * run through `node:vm` for identical inputs.
+ */
+export declare function runComparator(rule: string, a: JsValue, b: JsValue): number
+/**
  * Throw the core error for a given stable `code`, surfaced as a **structured,
  * matchable** JS error (own `code`, `status`, `gitsheetsClass`, and any
  * `issues`/`conflictingPaths`). Boundary-test entry point: it exercises the
  * error-variant → typed-class mapping without standing up real engine paths.
  */
 export declare function simulateCoreError(code: string): void
+/**
+ * A compiled sheet definition: the embedded engine plus the definition's
+ * path template (and optional raw-JS sort comparator), **compiled once** at
+ * construction and reused across every method call. Holds a `!Send` boa
+ * context, so it is constructed and used on its owning JS thread — the
+ * thread-confinement the spec requires. Exists to demonstrate the
+ * compile-once-per-open / reuse-across-operations contract from JS.
+ */
+export declare class CompiledDefinition {
+  /**
+   * Compile a definition once: parse the path template (compiling its
+   * expression snippets into the engine) and, if given, compile a raw-JS sort
+   * comparator. All snippet compilation happens here — never per operation.
+   */
+  constructor(pathTemplate: string, sortRule?: string | undefined | null)
+  /** Render one record's path using the already-compiled template. */
+  renderPath(record: JsValue): string
+  /**
+   * Run the compiled sort comparator on two values, returning its numeric
+   * result. Errors if the definition was built without a sort rule.
+   */
+  compare(a: JsValue, b: JsValue): number
+  /**
+   * How many snippets were compiled into this definition's engine. Constant
+   * across operations — proof that compilation happened once at construction,
+   * not per `render_path` / `compare` call.
+   */
+  snippetCount(): number
+}

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,9 +310,13 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, simulateCoreError } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, simulateCoreError } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
 module.exports.serializeRecords = serializeRecords
+module.exports.renderPathsBatch = renderPathsBatch
+module.exports.validateBatch = validateBatch
+module.exports.runComparator = runComparator
+module.exports.CompiledDefinition = CompiledDefinition
 module.exports.simulateCoreError = simulateCoreError

--- a/rust/gitsheets-napi/package-lock.json
+++ b/rust/gitsheets-napi/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@napi-rs/cli": "^2.18.4"
+        "@napi-rs/cli": "^2.18.4",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -30,6 +32,82 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs"
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -39,6 +39,8 @@
     "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^2.18.4"
+    "@napi-rs/cli": "^2.18.4",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   }
 }

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -24,6 +24,9 @@
 //! paths never bake in per-record FFI crossings.
 
 use chrono::{Datelike, Timelike};
+use gitsheets_core::engine::Engine;
+use gitsheets_core::path_template::Template;
+use gitsheets_core::validation::CompiledSchema;
 use gitsheets_core::{Datetime, Value};
 use napi::bindgen_prelude::*;
 use napi::{Env, JsDate, JsFunction, JsObject, JsString, JsUnknown, NapiRaw, ValueType};
@@ -259,6 +262,182 @@ pub fn serialize_records(env: Env, records: Vec<JsValue>) -> Result<Vec<String>>
     match gitsheets_core::serialize_batch(&values) {
         Ok(bytes) => Ok(bytes),
         Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+// ── definition logic: path templates, validation, embedded engine ────────────
+
+/// One JSON-Schema validation failure, marshalled to the `ValidationIssue`
+/// shape the host surface uses (`source`/`schemaPath`/`code`, with snake fields
+/// rendered camelCase by napi). Returned by [`validate_batch`].
+#[napi(object)]
+pub struct JsValidationIssue {
+    pub path: Vec<String>,
+    pub message: String,
+    pub source: String,
+    pub schema_path: Option<String>,
+    pub code: Option<String>,
+}
+
+/// Render a path template against a **batch** of records, returning one path per
+/// record (no file extension; the caller appends `.toml`/`.md`). The template is
+/// parsed and its expression components compiled into the embedded engine
+/// **once**, then reused across the whole batch — the bulk path crosses the FFI
+/// a single time. A render failure surfaces as a structured, typed
+/// `PathTemplateError` (`path_render_failed` / `path_invalid_chars`). This is the
+/// path-template half of the `node:vm` parity gate.
+#[napi]
+pub fn render_paths_batch(env: Env, template: String, records: Vec<JsValue>) -> Result<Vec<String>> {
+    let mut engine = match Engine::new() {
+        Ok(e) => e,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+    let compiled = match Template::compile(&template, &mut engine) {
+        Ok(t) => t,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+    let mut out = Vec::with_capacity(records.len());
+    for record in records {
+        match compiled.render(&record.0, &mut engine) {
+            Ok(path) => out.push(path),
+            Err(err) => return Err(raise_core_error(&env, &err)),
+        }
+    }
+    Ok(out)
+}
+
+/// Validate a **batch** of records against a JSON Schema, returning the issues
+/// for each record (an empty inner array ⇒ that record is valid). The schema is
+/// compiled **once**, then reused across the batch. Unlike the host's throwing
+/// `validateRecord`, this returns issues per record so a parity harness can diff
+/// the full pass/fail + path/keyword picture against `ajv`. A schema that won't
+/// compile surfaces as a structured, typed `ConfigError` (`config_invalid`).
+#[napi]
+pub fn validate_batch(
+    env: Env,
+    schema: JsValue,
+    records: Vec<JsValue>,
+) -> Result<Vec<Vec<JsValidationIssue>>> {
+    let compiled = match CompiledSchema::compile(&schema.0) {
+        Ok(c) => c,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+    let mut out = Vec::with_capacity(records.len());
+    for record in records {
+        let issues = compiled
+            .validate(&record.0)
+            .into_iter()
+            .map(|issue| JsValidationIssue {
+                path: issue.path,
+                message: issue.message,
+                source: issue.source.as_str().to_string(),
+                schema_path: issue.schema_path,
+                code: issue.code,
+            })
+            .collect();
+        out.push(issues);
+    }
+    Ok(out)
+}
+
+/// Compile a raw-JS sort comparator (`rule`, the body of `(a, b) => { … }`) and
+/// run it once against `a`/`b`, returning its numeric result. The direct
+/// comparator-parity entry point: a harness asserts this equals the same rule
+/// run through `node:vm` for identical inputs.
+#[napi]
+pub fn run_comparator(env: Env, rule: String, a: JsValue, b: JsValue) -> Result<f64> {
+    let mut engine = match Engine::new() {
+        Ok(e) => e,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+    let wrapped = format!("(a, b) => {{ {rule} }}");
+    let handle = match engine.compile(&wrapped) {
+        Ok(h) => h,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+    let result = engine
+        .call(handle, &[a.0, b.0])
+        .map_err(|e| Error::new(Status::GenericFailure, format!("{e:?}")))?;
+    engine
+        .to_number(&result)
+        .map_err(|err| raise_core_error(&env, &err))
+}
+
+/// A compiled sheet definition: the embedded engine plus the definition's
+/// path template (and optional raw-JS sort comparator), **compiled once** at
+/// construction and reused across every method call. Holds a `!Send` boa
+/// context, so it is constructed and used on its owning JS thread — the
+/// thread-confinement the spec requires. Exists to demonstrate the
+/// compile-once-per-open / reuse-across-operations contract from JS.
+#[napi]
+pub struct CompiledDefinition {
+    engine: Engine,
+    template: Template,
+    sort_handle: Option<usize>,
+}
+
+#[napi]
+impl CompiledDefinition {
+    /// Compile a definition once: parse the path template (compiling its
+    /// expression snippets into the engine) and, if given, compile a raw-JS sort
+    /// comparator. All snippet compilation happens here — never per operation.
+    #[napi(constructor)]
+    pub fn new(env: Env, path_template: String, sort_rule: Option<String>) -> Result<Self> {
+        let mut engine = match Engine::new() {
+            Ok(e) => e,
+            Err(err) => return Err(raise_core_error(&env, &err)),
+        };
+        let template = match Template::compile(&path_template, &mut engine) {
+            Ok(t) => t,
+            Err(err) => return Err(raise_core_error(&env, &err)),
+        };
+        let sort_handle = match sort_rule {
+            Some(rule) => {
+                let wrapped = format!("(a, b) => {{ {rule} }}");
+                match engine.compile(&wrapped) {
+                    Ok(h) => Some(h),
+                    Err(err) => return Err(raise_core_error(&env, &err)),
+                }
+            }
+            None => None,
+        };
+        Ok(CompiledDefinition {
+            engine,
+            template,
+            sort_handle,
+        })
+    }
+
+    /// Render one record's path using the already-compiled template.
+    #[napi]
+    pub fn render_path(&mut self, env: Env, record: JsValue) -> Result<String> {
+        self.template
+            .render(&record.0, &mut self.engine)
+            .map_err(|err| raise_core_error(&env, &err))
+    }
+
+    /// Run the compiled sort comparator on two values, returning its numeric
+    /// result. Errors if the definition was built without a sort rule.
+    #[napi]
+    pub fn compare(&mut self, a: JsValue, b: JsValue) -> Result<f64> {
+        let handle = self
+            .sort_handle
+            .ok_or_else(|| Error::new(Status::InvalidArg, "definition has no sort rule"))?;
+        let result = self
+            .engine
+            .call(handle, &[a.0, b.0])
+            .map_err(|e| Error::new(Status::GenericFailure, format!("{e:?}")))?;
+        self.engine
+            .to_number(&result)
+            .map_err(|e| Error::new(Status::GenericFailure, e.message().to_string()))
+    }
+
+    /// How many snippets were compiled into this definition's engine. Constant
+    /// across operations — proof that compilation happened once at construction,
+    /// not per `render_path` / `compare` call.
+    #[napi]
+    pub fn snippet_count(&self) -> u32 {
+        self.engine.snippet_count() as u32
     }
 }
 

--- a/rust/gitsheets-napi/test/_ref-path-template.mjs
+++ b/rust/gitsheets-napi/test/_ref-path-template.mjs
@@ -1,0 +1,161 @@
+// Faithful JS reference renderer — a transcription of the PRODUCTION path
+// renderer (`packages/gitsheets/src/path-template/index.ts`), kept standalone so
+// the napi boundary suite stays independent of the main TS package.
+//
+// The point of the transcription: expression components evaluate through
+// `node:vm` (`runInNewContext`) exactly as production does. That is the
+// `node:vm` baseline the embedded boa engine is diffed against in
+// `path-template.mjs`. The parser, `stringifyValue`, and invalid-char rules are
+// copied verbatim in behavior from index.ts. If the production renderer changes,
+// this copy must change in lockstep (it is the reference, not a second impl).
+
+import { runInNewContext } from 'node:vm';
+
+const WINDOWS_INVALID = /[<>:"|?*\x00-\x1f]/;
+const SEGMENT_INVALID = /[<>:"|?*\x00-\x1f/]/;
+const FIELD_NAME_RE = /^[a-zA-Z0-9_-]+(\/\*\*)?$/;
+const NOT_DEFINED_RE = / is not defined$/;
+
+class RefPathError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function compileExpression(source) {
+  let compiled;
+  try {
+    compiled = runInNewContext(`(record) => { with (record) { return (${source}) } }`);
+  } catch (err) {
+    throw new RefPathError('path_render_failed', `expression failed to compile: ${err.message}`);
+  }
+  return (record) => {
+    try {
+      return compiled(record);
+    } catch (err) {
+      if (err instanceof ReferenceError && NOT_DEFINED_RE.test(err.message)) return undefined;
+      throw err;
+    }
+  };
+}
+
+function stringifyValue(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'function') return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (value instanceof Date) return value.toString();
+  return undefined;
+}
+
+function parseTemplate(source) {
+  const normalized = source.replace(/^\/+/, '').replace(/\/+$/, '');
+  if (normalized === '') throw new RefPathError('path_render_failed', 'path template is empty');
+
+  const segments = [[]];
+  let pendingLiteral = '';
+  let i = 0;
+  const flushLiteral = () => {
+    if (pendingLiteral) {
+      segments[segments.length - 1].push({ kind: 'literal', text: pendingLiteral });
+      pendingLiteral = '';
+    }
+  };
+
+  while (i < normalized.length) {
+    if (normalized.startsWith('${{', i)) {
+      flushLiteral();
+      i += 3;
+      let exprSource = '';
+      while (!normalized.startsWith('}}', i)) {
+        if (i >= normalized.length) throw new RefPathError('path_render_failed', 'unclosed expression');
+        exprSource += normalized[i];
+        i++;
+      }
+      exprSource = exprSource.trim();
+      i += 2;
+      if (FIELD_NAME_RE.test(exprSource)) {
+        const recursive = exprSource.endsWith('/**');
+        const name = recursive ? exprSource.slice(0, -3) : exprSource;
+        segments[segments.length - 1].push({ kind: 'field', name, recursive });
+      } else {
+        segments[segments.length - 1].push({
+          kind: 'expression',
+          source: exprSource,
+          evaluate: compileExpression(exprSource),
+        });
+      }
+    } else if (normalized[i] === '/') {
+      flushLiteral();
+      segments.push([]);
+      i++;
+    } else {
+      pendingLiteral += normalized[i];
+      i++;
+    }
+  }
+  flushLiteral();
+
+  const components = segments.map((parts, idx) => {
+    if (parts.length === 0) throw new RefPathError('path_render_failed', `empty component ${idx}`);
+    const onlyPart = parts.length === 1 ? parts[0] : null;
+    const recursive = onlyPart && onlyPart.kind === 'field' && onlyPart.recursive;
+    if (!recursive) {
+      for (const part of parts) {
+        if (part.kind === 'field' && part.recursive) {
+          throw new RefPathError('path_render_failed', 'recursive field must be sole part');
+        }
+      }
+    }
+    return { parts, recursive };
+  });
+
+  for (let k = 0; k < components.length - 1; k++) {
+    if (components[k].recursive) throw new RefPathError('path_render_failed', 'recursive must be last');
+  }
+  return components;
+}
+
+function renderPart(part, record) {
+  switch (part.kind) {
+    case 'literal':
+      return part.text;
+    case 'field':
+      return stringifyValue(record[part.name]);
+    case 'expression':
+      return stringifyValue(part.evaluate(record));
+  }
+}
+
+function renderComponent(c, record) {
+  let out = '';
+  for (const part of c.parts) {
+    const piece = renderPart(part, record);
+    if (piece === undefined) return undefined;
+    out += piece;
+  }
+  return out;
+}
+
+// Render a template against a record, mirroring Template.render. Throws
+// RefPathError with `.code` of 'path_render_failed' / 'path_invalid_chars'.
+export function refRender(templateString, record) {
+  const components = parseTemplate(templateString);
+  const segments = [];
+  for (let i = 0; i < components.length; i++) {
+    const c = components[i];
+    const rendered = renderComponent(c, record);
+    if (rendered === undefined) {
+      throw new RefPathError('path_render_failed', `cannot render component ${i}`);
+    }
+    const pattern = c.recursive ? WINDOWS_INVALID : SEGMENT_INVALID;
+    if (pattern.test(rendered)) {
+      throw new RefPathError('path_invalid_chars', `component ${i} has invalid char`);
+    }
+    segments.push(rendered);
+  }
+  return segments.join('/');
+}

--- a/rust/gitsheets-napi/test/engine-parity.mjs
+++ b/rust/gitsheets-napi/test/engine-parity.mjs
@@ -1,0 +1,118 @@
+// Embedded-engine parity: the boa engine in the Rust core must produce the same
+// results as today's `node:vm` path for the same definition snippets. This is
+// THE gate for the engine choice (specs/rust-core.md "Embedded code execution").
+//
+//   1. Raw-JS sort comparators (the snippets gitsheets actually runs through
+//      node:vm in buildSorter) — strict parity, asserted.
+//   2. CompiledDefinition: compile-once-on-open / reuse-across-operations — the
+//      snippet count stays constant across many renderPath/compare calls.
+//   3. An Intl/locale PROBE (localeCompare) — characterizes boa's documented
+//      divergence boundary; reported, not asserted (gitsheets' declarative
+//      locale sort is native in the binding, not an embedded snippet).
+//
+// Requires the addon built first (`npm run build:debug`). Run: `npm test`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { runInNewContext } from 'node:vm';
+
+const require = createRequire(import.meta.url);
+const { runComparator, CompiledDefinition } = require('../binding.cjs');
+
+// The node:vm baseline: buildSorter compiles a raw rule as `(a, b) => { rule }`.
+function vmComparator(rule) {
+  return runInNewContext(`(a, b) => { ${rule} }`);
+}
+
+// Realistic raw-JS sort comparators (the escape-hatch snippets gitsheets runs).
+const COMPARATORS = [
+  { rule: 'return a - b;', pairs: [[1, 2], [5, 3], [0, 0], [-4, 4], [2.5, 2.4]] },
+  { rule: 'return b - a;', pairs: [[1, 2], [5, 3], [10, 10]] },
+  { rule: 'return a < b ? -1 : a > b ? 1 : 0;', pairs: [['a', 'b'], ['z', 'a'], ['m', 'm'], [3, 30]] },
+  { rule: 'return a.length - b.length;', pairs: [['aa', 'bbb'], ['x', 'x'], ['hello', 'hi']] },
+  { rule: 'return Math.sign(a - b);', pairs: [[7, 2], [2, 7], [4, 4]] },
+  // Multi-key directive comparator over object records (what the {field:dir}
+  // sort lowering produces) — exercises object marshalling into the engine.
+  {
+    rule: "if ((a[\"rank\"]) < (b[\"rank\"])) return -1; if ((a[\"rank\"]) > (b[\"rank\"])) return 1; return 0;",
+    pairs: [
+      [{ rank: 1 }, { rank: 2 }],
+      [{ rank: 5 }, { rank: 5 }],
+      [{ rank: 9 }, { rank: 3 }],
+    ],
+  },
+];
+
+test('raw-JS sort comparators match node:vm exactly', () => {
+  let checked = 0;
+  for (const { rule, pairs } of COMPARATORS) {
+    const vm = vmComparator(rule);
+    for (const [a, b] of pairs) {
+      const expected = vm(a, b);
+      const actual = runComparator(rule, a, b);
+      assert.equal(actual, expected, `rule ${JSON.stringify(rule)} on ${JSON.stringify([a, b])}`);
+      checked++;
+    }
+  }
+  console.log(`\n  comparator parity (boa === node:vm): ${checked} (rule,input) pairs OK`);
+});
+
+test('compiled definition reuses snippets across operations (compile once)', () => {
+  const def = new CompiledDefinition('${{ slug.toUpperCase() }}', 'return a - b;');
+  // One path-expression snippet + one comparator snippet.
+  assert.equal(def.snippetCount(), 2, 'two snippets compiled at construction');
+
+  const vmRender = vmComparator; // not used here; render compares to node:vm below
+  const vmExpr = runInNewContext('(record) => { with (record) { return (slug.toUpperCase()) } }');
+  const vmCmp = vmComparator('return a - b;');
+
+  for (let i = 0; i < 100; i++) {
+    const record = { slug: `item-${i}` };
+    assert.equal(def.renderPath(record), vmExpr(record));
+    assert.equal(def.compare(i, i + 1), vmCmp(i, i + 1));
+  }
+  // The decisive check: NO recompilation happened across 200 operations.
+  assert.equal(def.snippetCount(), 2, 'snippet count constant — compiled once, not per call');
+  console.log('\n  CompiledDefinition: 200 operations, snippetCount stayed 2 (compiled once on open)');
+  void vmRender;
+});
+
+test('separate definitions hold independent persistent engines', () => {
+  const a = new CompiledDefinition('${{ id }}');
+  const b = new CompiledDefinition('${{ slug }}/${{ id }}');
+  assert.equal(a.renderPath({ id: 1 }), '1');
+  assert.equal(b.renderPath({ slug: 'x', id: 2 }), 'x/2');
+  assert.equal(a.snippetCount(), 0); // pure field template, no engine snippets
+  assert.equal(b.snippetCount(), 0);
+});
+
+// PROBE (reported, not asserted): localeCompare is Intl-adjacent — exactly the
+// boa-vs-node:vm divergence boundary the spec flags. gitsheets' locale-aware
+// sort is the declarative `sort = true` path, evaluated NATIVELY in the binding,
+// not an embedded snippet — so a divergence here is not a gate failure. We
+// surface it so the boundary is documented honestly.
+test('PROBE: localeCompare boundary (Intl) — reported, not gating', () => {
+  const rule = 'return String(a).localeCompare(String(b));';
+  const vm = vmComparator(rule);
+  const pairs = [['a', 'b'], ['B', 'a'], ['10', '9'], ['é', 'e']];
+  const rows = [];
+  let diverged = 0;
+  for (const [a, b] of pairs) {
+    const expected = Math.sign(vm(a, b));
+    let actual;
+    try {
+      actual = Math.sign(runComparator(rule, a, b));
+    } catch (err) {
+      actual = `ERR(${err.message})`;
+    }
+    const same = actual === expected;
+    if (!same) diverged++;
+    rows.push({ pair: [a, b], vm: expected, boa: actual, same });
+  }
+  console.log('\n  PROBE localeCompare (boa vs node:vm sign):');
+  for (const r of rows) {
+    console.log(`    ${r.same ? 'match' : 'DIVERGE'}  ${JSON.stringify(r.pair)}  vm=${r.vm} boa=${r.boa}`);
+  }
+  console.log(`  -> ${diverged}/${pairs.length} diverged (informational; not a gate)`);
+});

--- a/rust/gitsheets-napi/test/path-template.mjs
+++ b/rust/gitsheets-napi/test/path-template.mjs
@@ -1,0 +1,103 @@
+// Path-template parity: the Rust `renderPathsBatch` (native fields + boa engine
+// for expressions) must render identically to the production JS renderer
+// (`_ref-path-template.mjs`, whose expression components evaluate through
+// `node:vm`). This is the path-rendering half of the engine parity gate.
+//
+// Requires the addon built first (`npm run build:debug`). Run: `npm test`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { refRender } from './_ref-path-template.mjs';
+
+const require = createRequire(import.meta.url);
+const { renderPathsBatch, PathTemplateError } = require('../binding.cjs');
+
+// A corpus of (template, record) cases. Expression cases use getUTC* (TZ-
+// independent) so the boa-vs-node:vm comparison is deterministic across
+// machines; getFullYear (local-time) is exercised separately and reported.
+const CORPUS = [
+  ['${{ slug }}', { slug: 'jane' }],
+  ['${{ domain }}/${{ username }}', { domain: 'af.mil', username: 'grandma' }],
+  // Multi-variable per segment (#105).
+  ['${{ year }}/${{ status }}--${{ id }}', { year: 2026, status: 'active', id: 12345 }],
+  // Integer + boolean field stringification.
+  ['${{ n }}/${{ flag }}', { n: 42, flag: true }],
+  // Literal prefix/suffix around an expression.
+  ['user-${{ id }}.draft', { id: 7 }],
+  // Expression: string methods.
+  ['${{ slug.toLowerCase() }}', { slug: 'HELLO-World' }],
+  ['${{ name.toUpperCase() }}/${{ slug }}', { name: 'jane', slug: 'x' }],
+  // Expression: partition by date-parts (TZ-independent UTC accessors).
+  [
+    '${{ publishedAt.getUTCFullYear() }}/${{ publishedAt.getUTCMonth() }}/${{ slug }}',
+    { publishedAt: new Date('2026-03-09T12:00:00Z'), slug: 'post' },
+  ],
+  // Expression: arithmetic / string building.
+  ['shard-${{ id % 4 }}/${{ id }}', { id: 39 }],
+  ['${{ (slug || legacyId) }}', { slug: 'realslug', legacyId: 'abc' }],
+  // Recursive (field/**) component — value contains slashes.
+  ['${{ contentPath/** }}', { contentPath: 'docs/guides/intro' }],
+];
+
+test('renderPathsBatch matches the node:vm reference renderer across the corpus', () => {
+  const comparisons = [];
+  for (const [template, record] of CORPUS) {
+    const expected = refRender(template, record);
+    const [actual] = renderPathsBatch(template, [record]);
+    comparisons.push({ template, expected, actual });
+    assert.equal(actual, expected, `template ${JSON.stringify(template)}`);
+  }
+  // Surface the comparison so the parity is visible in test output.
+  console.log('\n  path-template parity (rust === node:vm):');
+  for (const c of comparisons) {
+    console.log(`    ${c.actual === c.expected ? 'OK ' : 'DIFF'}  ${c.template}  ->  ${c.actual}`);
+  }
+});
+
+test('a whole batch renders in one FFI crossing', () => {
+  const records = [{ slug: 'a' }, { slug: 'b' }, { slug: 'c' }];
+  assert.deepEqual(renderPathsBatch('${{ slug }}', records), ['a', 'b', 'c']);
+});
+
+test('missing field fails identically (path_render_failed)', () => {
+  const record = { other: 'x' };
+  assert.throws(() => refRender('${{ slug }}', record), (e) => e.code === 'path_render_failed');
+  assert.throws(
+    () => renderPathsBatch('${{ slug }}', [record]),
+    (err) => {
+      assert.ok(err instanceof PathTemplateError, 'typed PathTemplateError');
+      assert.equal(err.code, 'path_render_failed');
+      return true;
+    },
+  );
+});
+
+test('invalid character fails identically (path_invalid_chars)', () => {
+  const record = { slug: 'a:b' };
+  assert.throws(() => refRender('${{ slug }}', record), (e) => e.code === 'path_invalid_chars');
+  assert.throws(
+    () => renderPathsBatch('${{ slug }}', [record]),
+    (err) => {
+      assert.equal(err.code, 'path_invalid_chars');
+      return true;
+    },
+  );
+});
+
+test('a slash in a non-recursive segment fails identically', () => {
+  const record = { slug: 'a/b' };
+  assert.throws(() => refRender('${{ slug }}', record), (e) => e.code === 'path_invalid_chars');
+  assert.throws(() => renderPathsBatch('${{ slug }}', [record]), (e) => e.code === 'path_invalid_chars');
+});
+
+test('getFullYear (local-time) parity is reported (TZ-sensitive)', () => {
+  // Local-time date accessors depend on the process TZ in BOTH node:vm and boa.
+  // In the same process they should agree; we assert that and surface the value.
+  const record = { publishedAt: new Date('2026-03-09T12:00:00Z') };
+  const template = '${{ publishedAt.getFullYear() }}';
+  const expected = refRender(template, record);
+  const [actual] = renderPathsBatch(template, [record]);
+  console.log(`\n  getFullYear local-time parity: node:vm=${expected} boa=${actual} (TZ=${process.env.TZ ?? 'system'})`);
+  assert.equal(actual, expected, 'boa local-time year matches node:vm in-process');
+});

--- a/rust/gitsheets-napi/test/validation-parity.mjs
+++ b/rust/gitsheets-napi/test/validation-parity.mjs
@@ -1,0 +1,137 @@
+// JSON-Schema validation parity: the Rust validator (`validateBatch`, jsonschema
+// crate) vs `ajv` configured exactly like the production layer
+// (`packages/gitsheets/src/validation.ts`: strict + allErrors + $data:false +
+// ajv-formats). Over a corpus of valid + invalid records we assert:
+//
+//   1. VALIDITY parity is exact — every record passes/fails the same way.
+//   2. The set of failing (instanceLocation, keyword) pairs matches.
+//
+// Issue MESSAGE TEXT is intentionally excluded (it is library-specific prose).
+// Any enumerated divergence is logged and lives in the plan Notes.
+//
+// Requires the addon built first (`npm run build:debug`). Run: `npm test`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { Ajv } = require('ajv');
+const addFormats = require('ajv-formats');
+const { validateBatch } = require('../binding.cjs');
+
+// Mirror validation.ts exactly.
+const ajv = new Ajv({ strict: true, allErrors: true, $data: false });
+addFormats(ajv);
+
+const SCHEMA = {
+  type: 'object',
+  required: ['slug', 'email', 'fullName', 'age'],
+  additionalProperties: false,
+  properties: {
+    slug: { type: 'string', pattern: '^[a-z0-9][a-z0-9-]{1,49}$' },
+    email: { type: 'string', format: 'email' },
+    fullName: { type: 'string', minLength: 1, maxLength: 120 },
+    age: { type: 'integer', minimum: 0, maximum: 200 },
+    role: { type: 'string', enum: ['admin', 'member', 'guest'] },
+    website: { type: 'string', format: 'uri' },
+    tags: { type: 'array', items: { type: 'string' }, maxItems: 3 },
+  },
+};
+
+const RECORDS = [
+  // valid
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: 30 },
+  { slug: 'bob-99', email: 'bob@x.io', fullName: 'Bob', age: 0, role: 'admin', tags: ['a', 'b'] },
+  { slug: 'k8s', email: 'k@k.dev', fullName: 'K', age: 200, website: 'https://k.dev' },
+  // invalid — single violations
+  { slug: 'JANE!', email: 'jane@example.org', fullName: 'Jane', age: 30 }, // pattern
+  { slug: 'jane', email: 'nope', fullName: 'Jane', age: 30 }, // format(email)
+  { slug: 'jane', email: 'jane@example.org', fullName: '', age: 30 }, // minLength
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: -1 }, // minimum
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: 1.5 }, // type integer
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: 30, role: 'root' }, // enum
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: 30, website: 'not a uri' }, // format(uri)
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: 30, tags: ['a', 'b', 'c', 'd'] }, // maxItems
+  { slug: 'jane', email: 'jane@example.org', fullName: 'Jane', age: 30, extra: 'x' }, // additionalProperties
+  // invalid — multiple violations (allErrors)
+  { slug: 'BAD', email: 'nope', fullName: 'Jane', age: 30 }, // pattern + format
+  { fullName: 'Jane', age: 30 }, // required slug + required email
+  {}, // all required missing
+];
+
+const ajvValidate = ajv.compile(SCHEMA);
+
+function ajvResult(record) {
+  const ok = ajvValidate(record);
+  const issues = ok
+    ? []
+    : ajvValidate.errors.map((e) => ({
+        loc: e.instancePath, // '' | '/age' | ...
+        keyword: e.keyword,
+      }));
+  return { valid: ok, issues };
+}
+
+function rustResult(issuesForRecord) {
+  return {
+    valid: issuesForRecord.length === 0,
+    issues: issuesForRecord.map((i) => ({
+      loc: i.path.length ? `/${i.path.join('/')}` : '',
+      keyword: i.code,
+    })),
+  };
+}
+
+function keySet(issues) {
+  return new Set(issues.map((i) => `${i.loc}|${i.keyword}`));
+}
+
+test('validity parity is exact across the corpus', () => {
+  const rust = validateBatch(SCHEMA, RECORDS);
+  const rows = [];
+  for (let i = 0; i < RECORDS.length; i++) {
+    const a = ajvResult(RECORDS[i]);
+    const r = rustResult(rust[i]);
+    rows.push({ i, ajv: a.valid, rust: r.valid });
+    assert.equal(r.valid, a.valid, `record ${i} validity: ajv=${a.valid} rust=${r.valid}`);
+  }
+  console.log('\n  validation validity parity (ajv vs rust):');
+  for (const row of rows) {
+    console.log(`    #${row.i}  ajv=${row.ajv ? 'valid' : 'INVALID'}  rust=${row.rust ? 'valid' : 'INVALID'}`);
+  }
+});
+
+test('failing (location, keyword) sets match ajv', () => {
+  const rust = validateBatch(SCHEMA, RECORDS);
+  const divergences = [];
+  for (let i = 0; i < RECORDS.length; i++) {
+    const a = keySet(ajvResult(RECORDS[i]).issues);
+    const r = keySet(rustResult(rust[i]).issues);
+    const onlyAjv = [...a].filter((k) => !r.has(k));
+    const onlyRust = [...r].filter((k) => !a.has(k));
+    if (onlyAjv.length || onlyRust.length) {
+      divergences.push({ i, onlyAjv, onlyRust });
+    }
+  }
+  if (divergences.length) {
+    console.log('\n  (location,keyword) divergences:');
+    for (const d of divergences) {
+      console.log(`    #${d.i}  onlyAjv=${JSON.stringify(d.onlyAjv)}  onlyRust=${JSON.stringify(d.onlyRust)}`);
+    }
+  }
+  assert.equal(divergences.length, 0, 'no (location,keyword) divergences');
+});
+
+test('validateBatch compiles the schema once for the whole batch', () => {
+  // A 200-record batch validates in a single FFI crossing with one compile.
+  const many = Array.from({ length: 200 }, (_, k) => ({
+    slug: `u${k}`,
+    email: `u${k}@x.io`,
+    fullName: `U${k}`,
+    age: k % 200,
+  }));
+  const out = validateBatch(SCHEMA, many);
+  assert.equal(out.length, 200);
+  assert.ok(out.every((issues) => issues.length === 0));
+});


### PR DESCRIPTION
Implements [`plans/definition-logic-core.md`](plans/definition-logic-core.md) — moving sheet-definition-DERIVED behavior into `gitsheets-core` so it produces identical results under every binding. Part of the Rust-core evolution (issue #127, `specs/rust-core.md` "Embedded code execution").

## What's in the core now

- **Path templates** (`path_template.rs`) — behavior-preserving port of the JS renderer. Literal/field components render natively over `Value`; expression components (`${{ publishedAt.getUTCFullYear() }}`) compile once into the embedded engine. Matches `stringifyValue`, multi-variable segments (#105), recursive `field/**` components, invalid-char rejection, and the `path_render_failed`/`path_invalid_chars` typed errors.
- **Shape validation** (`validation.rs`) — native JSON-Schema via the `jsonschema` crate, configured to mirror `ajv` (Draft 7, formats asserted, all errors). Failures map to `ValidationIssue` (`source`/`path`/`schemaPath`/keyword-`code`).
- **Embedded engine** (`engine.rs`) — a persistent pure-Rust `boa_engine` context. Snippets compile **once on open** into reusable callable handles and run across every operation; `!Send`, thread-confined. Core `Value` ⇄ boa marshalling incl. real JS `Date` for datetime fields.

Out of scope (correctly): the consumer-supplied runtime validator (Zod/Pydantic — stays in the binding) and record CRUD/query (downstream `record-engine-core`).

## Parity results

- **Path rendering vs node:vm** — `renderPathsBatch` matches a faithful node:vm-backed reference renderer across an 11-case corpus incl. a date-parts partition derivation; error parity holds. ✅
- **JSON-Schema vs `ajv`** — over 15 valid+invalid records: **exact validity parity** AND **identical `(location, keyword)` sets** (pattern/format/minLength/minimum/type/enum/maxItems/additionalProperties/required, incl. multi-error `allErrors` cases). Zero divergences. Enumerated structural divergences (strict-mode unknown-keyword, datetime-as-JSON) documented in the plan Notes. ✅
- **Embedded boa vs node:vm** — 21 `(comparator, input)` pairs match exactly; `CompiledDefinition` proves compile-once (200 ops, `snippetCount` constant). A `localeCompare` Intl-boundary probe is reported **non-gating** (the documented boa trade-off; gitsheets' locale sort is the native declarative path, not an embedded snippet). ✅

## Engine version (contract)

`boa_engine` pinned **exactly** at `=0.21.1` in `Cargo.toml` and recorded as a behavior-contract input.

## CI

`rust-core.yml` core job runs the new unit tests + a `clippy -D warnings` gate; the napi job's `npm test` runs the path-template/ajv/node:vm parity suites via explicit file paths (node 20 + 22 safe). The main JS suite stays independent — these changes touch only `rust/` and the rust-core workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
