### PR TITLE
feat(core): record CRUD + diff/patch over holo-tree

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -7,6 +7,10 @@
 # Modeled on hologit's holo-tree-napi.yml (build + node --test round-trip), minus
 # the per-platform prebuild matrix and npm publish — this foundation only needs
 # to prove the boundary builds and round-trips on a native runner.
+#
+# Network note: gitsheets-core now depends on holo-tree as a *git* dependency
+# (the hologit repo, pinned via Cargo.lock). Cargo fetches it over https on the
+# first build — the runner allows this; no extra auth or config is needed.
 name: rust-core
 
 on:
@@ -39,15 +43,20 @@ jobs:
       - name: Core unit + canonical-parity tests
         # Runs the value/error/canonical unit tests AND the corpus_parity
         # integration test, PLUS the definition-logic unit tests (path_template,
-        # validation, engine) added by plans/definition-logic-core.md. CI
-        # exercises the committed fixture subset (golden canonical bytes); the
-        # full ~29.5k-record corpus parity is run locally against CodeForPhilly
+        # validation, engine), PLUS the record-engine tests added by
+        # plans/record-engine-core.md: diff/patch (RFC 6902 + 7396) units and the
+        # holo-tree CRUD + diff integration tests, which spin up throwaway
+        # gix-init repos in-process (no external git binary needed). CI exercises
+        # the committed fixture subset (golden canonical bytes); the full
+        # ~29.5k-record corpus parity is run locally against CodeForPhilly
         # origin/published via GITSHEETS_PARITY_CORPUS — see
         # plans/toml-canonical-core.md Notes.
         run: cargo test -p gitsheets-core
 
       - name: Clippy (deny warnings)
-        run: cargo clippy -p gitsheets-core -- -D warnings
+        # Whole workspace + all targets: the core (incl. its record/diff tests)
+        # and the napi crate both lint clean.
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   napi:
     name: gitsheets-napi boundary (node ${{ matrix.node }})
@@ -77,8 +86,11 @@ jobs:
         working-directory: rust/gitsheets-napi
         run: npm run build
 
-      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine)
+      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, record CRUD + diff/patch)
         # Explicit file paths (not a glob) so the suite runs identically on
         # node 20 and 22 — `node --test "test/*.mjs"` does NOT expand on node 20.
+        # record-crud.mjs uses `git init` for its temp repos, so git must be on
+        # PATH (it is, on ubuntu-latest), and diffs the core's createPatch against
+        # the `rfc6902` package installed above.
         working-directory: rust/gitsheets-napi
         run: npm test

--- a/plans/record-engine-core.md
+++ b/plans/record-engine-core.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: [toml-canonical-core, definition-logic-core]
 specs:
   - specs/rust-core.md
   - specs/behaviors/patch-semantics.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/208
 ---
 
 # Plan: record engine in the core — CRUD + diff/patch (the substrate seam)
@@ -46,12 +47,21 @@ original scope-creep note), the `Sheet`/`Transaction`/`Store` orchestration
 
 ## Validation
 
-- [ ] CRUD round-trips records byte-identically to the (re-baselined) on-disk form.
-- [ ] Diff + patch outputs match the JS `Sheet.diffFrom` / patch behavior on a
-      fixture corpus.
-- [ ] holo-tree is wired and exercised (a write produces the expected tree/blob).
-- [ ] `cargo build/test` + clippy clean; napi boundary suite passes; the main JS
-      suite stays green and independent.
+- [x] CRUD round-trips records byte-identically to the (re-baselined) on-disk form.
+      Rust integration test asserts holo-tree writes the *expected git blob hash*
+      (computed independently via sha1) of the canonical bytes, and read-back
+      returns the identical `Value`; the napi `record-crud.mjs` round-trips through
+      a real `git init` repo.
+- [x] Diff + patch outputs match the JS `Sheet.diffFrom` / patch behavior on a
+      fixture corpus. `createPatch` matches the `rfc6902` package **op-for-op**
+      across 17 fixtures; `applyMergePatch` matches `patch.ts`'s `mergePatch`
+      across the `patch-semantics.md` examples. Two divergences enumerated below.
+- [x] holo-tree is wired and exercised (a write produces the expected tree/blob).
+- [x] `cargo build/test` + clippy clean (`cargo clippy --workspace --all-targets
+      -- -D warnings`); napi boundary suite passes (43 tests, node 20/22 via
+      explicit file paths); the main JS suite stays green (`npm test`: 287 + 66)
+      and independent (`npm run type-check` clean; the main build never imports
+      the `.node` addon).
 
 ## Risks / unknowns
 
@@ -72,8 +82,73 @@ original scope-creep note), the `Sheet`/`Transaction`/`Store` orchestration
 
 ## Notes
 
-(Populated at closeout.)
+**What was built.** A `record` module (CRUD over holo-tree, batch-first) and a
+`diff` module (RFC 6902 `create_patch` + RFC 7396 `apply_merge_patch`) in
+`gitsheets-core`, plus a thin napi surface (`recordRead/Write/Delete/List`,
+`diffRecords`, `createPatch`, `applyMergePatch`). The binding never touches a
+`gix::Repository` or holo-tree node — core `*_at_ref` wrappers open the repo and
+resolve a ref/hash to a tree internally.
+
+**holo-tree dep pin.** `holo-tree = { git = "https://github.com/JarvusInnovations/hologit", branch = "develop" }`,
+pinned in the committed `Cargo.lock` to commit `e3750660`. **Deviation from the
+plan's `master` suggestion, deliberate and required:** `master` (`bcef9b59`) lacks
+the merged spike fixes this layer relies on — `delete_child_deep`'s
+dirty-propagation (hologit#473) is on `develop` and not yet on `master`. The
+mission's "verify the resolved holo-tree includes the merged spike fixes"
+overrides the `master` default. `gix` is pinned to the same 0.83 holo-tree uses so
+the `Repository` handle unifies.
+
+**Diff/patch parity result.** `createPatch` matches the `rfc6902` package
+op-for-op (verified live in `record-crud.mjs` over 17 fixtures, and against
+captured golden outputs in Rust units) — the array diff is a faithful port of
+rfc6902's memoized Levenshtein incl. its cost/stable-tie-break and `/-` padding.
+`applyMergePatch` matches `patch.ts`'s `mergePatch` verbatim-copied into the test.
+**Two enumerated divergences, both theoretical (parity fixtures stay
+JSON-representable):** (1) a changed *datetime* field emits a `replace` here vs
+nothing in `rfc6902` (which sees a `Date` object with no own keys — a latent JS
+quirk); (2) no `-M` rename detection — a moved record is a delete + add, not a
+`renamed`. `1` vs `1.0` is a no-op in both (numerically equal, as in JS).
+
+**Representational note.** The core `Value` has no null, but both algorithms need
+one (RFC 6902's top-level deleted-record `replace "" null`; RFC 7396's per-key
+delete marker). Modeled out-of-band: `create_patch` takes `Option<&Value>` and a
+`PatchValue::{Absent,Null,Value}`; the merge patch is a `MergePatch` tree whose
+`Delete` is the null marker, marshalled from JS by a dedicated `JsMergePatch`.
+
+**Inbound deferrals — resolved.**
+
+- *(a) record-specific parse error code* — **No new code.** Resolved as "keep
+  `config_invalid`." The existing JS `Sheet.#readRecordFromBlob` already throws
+  `ConfigError('config_invalid')` for an unparseable record blob, and the
+  canonical layer maps TOML failures the same way. Matching it preserves the
+  no-consumer-visible-change non-negotiable; introducing a `record_invalid` code
+  would be a behavior change. **No `errors.md` spec change.** (See Follow-ups for
+  a possible post-1.0 cleanup.)
+- *(b) datetime-for-validation marshalling* — **Settled: string form.** Already
+  decided in `validation.rs` (`value_to_json` lowers `Value::Datetime` to its
+  canonical TOML string, divergence enumerated there). Confirmed it holds for the
+  engine-owned write path: shape-validation runs over the `Value` with datetimes
+  presented as strings (so a `type: string, format: date-time` field validates),
+  before `serialize`. No change needed; recorded here as the resolution.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **`record-query-index`** (Deferred to plan): query traversal/filtering +
+  secondary indexing build on this layer's CRUD + list primitives. The
+  read-heavy perf headroom (hologit#464: per-call `to_thread_local`, object
+  cache, per-read clone) first surfaces here; the bulk benchmark that measures it
+  lives in that plan.
+- **`sheet-store-core`** (Deferred to plan): the `Sheet`/`Transaction`/`Store`
+  orchestration that composes these primitives (path-template-driven record→path
+  rendering on writes, the markdown/frontmatter format, `Sheet.diffFrom`'s
+  scoping + `BlobHandle`s, rename detection if wanted). This plan kept the write
+  primitive path-explicit (caller supplies the rendered path + extension); the
+  full render-and-write pipeline is that plan's.
+- **`record_invalid` error code** (Issue, post-1.0): a dedicated code for an
+  unparseable *record* (vs config) blob would be semantically cleaner than reusing
+  `config_invalid` (500). Deferred because adding it now is a consumer-visible
+  behavior change; revisit after 1.0 as a deliberate `errors.md` addition.
+- **holo-tree `master` lag** (Tracked as): the spike fixes (incl. hologit#473)
+  are on hologit `develop` but not `master`. When they merge to `master`, the dep
+  can move to `branch = "master"`; until then `develop` is required. No action
+  needed beyond the pinned `Cargo.lock`.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,9 +87,24 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "boa_ast"
@@ -88,7 +112,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -105,7 +129,7 @@ checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags",
+ "bitflags 2.13.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -197,7 +221,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -228,6 +252,17 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -262,6 +297,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "bytesize"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,10 +372,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "ctor"
@@ -346,10 +445,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -361,6 +502,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dynify"
@@ -398,6 +545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +580,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,10 +607,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -478,6 +664,12 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -561,6 +753,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,9 +781,12 @@ name = "gitsheets-core"
 version = "0.0.0"
 dependencies = [
  "boa_engine",
+ "gix",
+ "holo-tree",
  "indexmap",
  "jsonschema",
  "serde_json",
+ "tempfile",
  "toml",
 ]
 
@@ -596,6 +801,948 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "toml",
+]
+
+[[package]]
+name = "gix"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-mailmap",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "parking_lot",
+ "regex",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+dependencies = [
+ "bytes",
+ "bytesize",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.17.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195fd20808055824531be2fd0d34136d900e5fbca3ffb0a3c07e8beeefb9c828"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-path",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -620,6 +1767,34 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "holo-tree"
+version = "0.1.0"
+source = "git+https://github.com/JarvusInnovations/hologit?branch=develop#e3750660b373ffa4767de347989fa63f322e9b31"
+dependencies = [
+ "gix",
+ "globset",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "human_format"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
 
 [[package]]
 name = "iana-time-zone"
@@ -775,6 +1950,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +1973,48 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -828,6 +2055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +2084,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -871,10 +2113,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -897,7 +2159,7 @@ version = "2.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -947,6 +2209,12 @@ checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "num"
@@ -1193,6 +2461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,12 +2503,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "bytesize",
+ "human_format",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1284,7 +2594,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1379,6 +2689,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +2712,15 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1470,10 +2802,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "siphasher"
@@ -1549,6 +2928,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thin-vec"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +3008,21 @@ dependencies = [
  "serde_core",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -1689,6 +3096,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +3127,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1739,6 +3176,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasip2"
@@ -1795,6 +3242,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,6 +3327,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -1993,6 +3480,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -30,3 +30,21 @@ jsonschema = { version = "0.46.7", default-features = false }
 # JSON value type the `jsonschema` crate validates against; the core marshals
 # its `Value` to/from it for the shape-validation pass.
 serde_json = "1"
+
+# ── record-engine-core (the holo-tree substrate seam) ────────────────────────
+# Mutable in-memory git trees (read/write/delete blobs, commit, ref CAS). Not on
+# crates.io, so a git dependency on the hologit repo (the form decided in
+# gitsheets-core-foundation). `branch = "develop"`, NOT `master`: the merged
+# spike fixes this layer relies on — notably `delete_child_deep`'s
+# dirty-propagation (hologit#473) — live on develop and are not yet on master.
+# `Cargo.lock` is committed so the exact commit is pinned and reproducible.
+holo-tree = { git = "https://github.com/JarvusInnovations/hologit", branch = "develop" }
+# The git object layer holo-tree drives. Pinned to the SAME version holo-tree
+# depends on (0.83) so the `gix::Repository` handle this crate opens and passes
+# into holo-tree is one unified type. Default features (matching holo-tree) cover
+# rev-parse, object read/write, and repo open/init.
+gix = "0.83"
+
+[dev-dependencies]
+# Throwaway git repos for the record-CRUD + diff integration tests.
+tempfile = "3"

--- a/rust/gitsheets-core/src/diff.rs
+++ b/rust/gitsheets-core/src/diff.rs
@@ -1,0 +1,571 @@
+//! Record diff + patch semantics — RFC 6902 (JSON Patch) generation and
+//! RFC 7396 (JSON Merge Patch) application, natively in the core.
+//!
+//! Per [`specs/rust-core.md`](../../../specs/rust-core.md), "diff + patch
+//! semantics" lives in the core so every binding agrees. This is the
+//! **behavior-preserving** Rust port of the two JS implementations:
+//!
+//! - **RFC 6902 `create_patch`** mirrors the `rfc6902` npm package's
+//!   `createPatch`, which `Sheet.diffFrom` uses to turn a src/dst record pair
+//!   into a JSON Patch. The object diff, the Levenshtein array diff (with its
+//!   exact cost/tie-break and `/-` append-token padding), the wholesale-replace
+//!   fallback, and the top-level null handling (added ⇒ `replace "" <record>`,
+//!   deleted ⇒ `replace "" null`) all match the library op-for-op.
+//! - **RFC 7396 `apply_merge_patch`** mirrors `packages/gitsheets/src/patch.ts`
+//!   (`mergePatch`), the inline merge `Sheet.patch` applies: `null` deletes a
+//!   key, an object merges recursively, anything else replaces wholesale; see
+//!   [`specs/behaviors/patch-semantics.md`](../../../specs/behaviors/patch-semantics.md).
+//!
+//! ## The one representational wrinkle: JSON null
+//!
+//! The core [`Value`] has no null (TOML has none), but both algorithms need a
+//! null sentinel — RFC 6902 at the top level (a deleted record diffs to
+//! `replace "" null`), RFC 7396 as the per-key delete marker. So:
+//!
+//! - `create_patch` takes `Option<&Value>` (`None` = JSON null) and a [`PatchOp`]
+//!   carries a [`PatchValue`] that distinguishes *absent* (a `remove` op, no
+//!   `value` key), *null* (a `replace`/`add` whose value is JSON null), and a
+//!   real [`Value`].
+//! - the merge patch is a dedicated [`MergePatch`] tree whose `Delete` variant
+//!   is the null marker; a binding marshals a host partial (which *can* hold
+//!   nulls) into it.
+//!
+//! ## Enumerated divergences vs the JS libraries
+//!
+//! - **Datetimes in a diff.** `Value::Datetime` is compared by its canonical
+//!   TOML string here, so a changed datetime field emits a `replace`. The JS
+//!   `rfc6902` sees a `Date` *object*, finds no own-enumerable keys, and emits
+//!   *nothing* on a change (a latent quirk). Equal datetimes produce no op in
+//!   both. Parity fixtures stay JSON-representable, so this is theoretical.
+//! - **Int vs float.** `1` and `1.0` are numerically equal here (as in JS,
+//!   where both parse to the single `number` 1), so a `1` ⇒ `1.0` change emits
+//!   no op in either.
+
+use indexmap::IndexMap;
+
+use crate::value::Value;
+
+// ── RFC 6902: createPatch ────────────────────────────────────────────────────
+
+/// The op kinds `createPatch` produces (it never emits move/copy/test).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PatchOpKind {
+    Add,
+    Remove,
+    Replace,
+}
+
+impl PatchOpKind {
+    /// The wire string (`"add"` / `"remove"` / `"replace"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PatchOpKind::Add => "add",
+            PatchOpKind::Remove => "remove",
+            PatchOpKind::Replace => "replace",
+        }
+    }
+}
+
+/// The `value` of a [`PatchOp`], distinguishing the three JSON shapes a binding
+/// must reproduce: a `remove` carries no `value` key ([`PatchValue::Absent`]),
+/// a `replace`/`add` to JSON null carries `value: null` ([`PatchValue::Null`]),
+/// and everything else carries a real [`Value`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum PatchValue {
+    /// No `value` key — only on `remove`.
+    Absent,
+    /// `value: null` — a deleted record's top-level `replace`.
+    Null,
+    /// A concrete value.
+    Value(Value),
+}
+
+/// One RFC 6902 operation. `path` is a JSON Pointer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatchOp {
+    pub op: PatchOpKind,
+    pub path: String,
+    pub value: PatchValue,
+}
+
+/// A node in the diff: a real [`Value`] or JSON `null`. `null` only ever appears
+/// at the top level (a record that is absent on one side); record *fields* are
+/// always real values, since the core has no null.
+#[derive(Clone, Copy)]
+enum Node<'a> {
+    Null,
+    Val(&'a Value),
+}
+
+/// Generate an RFC 6902 JSON Patch transforming `src` into `dst`, matching the
+/// `rfc6902` package's `createPatch`. `None` on either side is JSON null — so
+/// `create_patch(None, Some(r))` is an "added" record (`replace "" <r>`) and
+/// `create_patch(Some(r), None)` is "deleted" (`replace "" null`).
+pub fn create_patch(src: Option<&Value>, dst: Option<&Value>) -> Vec<PatchOp> {
+    let a = src.map_or(Node::Null, Node::Val);
+    let b = dst.map_or(Node::Null, Node::Val);
+    diff_any(a, b, "")
+}
+
+/// A JSON-Pointer "type" tag, matching `rfc6902`'s `objectType` (`null` is its
+/// own type, distinct from `object`).
+enum JsonType {
+    Null,
+    Array,
+    Object,
+    Scalar,
+}
+
+fn node_type(node: Node<'_>) -> JsonType {
+    match node {
+        Node::Null => JsonType::Null,
+        Node::Val(Value::Array(_)) => JsonType::Array,
+        Node::Val(Value::Table(_)) => JsonType::Object,
+        Node::Val(_) => JsonType::Scalar,
+    }
+}
+
+/// `===`-equivalent equality (the `input === output` short-circuit in
+/// `diffAny`): primitives by value, with numbers cross-comparing int/float and
+/// datetimes compared by their canonical string. Compound values are never
+/// strict-equal (they recurse and yield `[]` when deeply equal).
+fn nodes_strict_equal(a: Node<'_>, b: Node<'_>) -> bool {
+    match (a, b) {
+        (Node::Null, Node::Null) => true,
+        (Node::Val(x), Node::Val(y)) => match (x, y) {
+            (Value::String(p), Value::String(q)) => p == q,
+            (Value::Boolean(p), Value::Boolean(q)) => p == q,
+            (Value::Integer(p), Value::Integer(q)) => p == q,
+            (Value::Float(p), Value::Float(q)) => p == q,
+            (Value::Integer(p), Value::Float(q)) | (Value::Float(q), Value::Integer(p)) => {
+                (*p as f64) == *q
+            }
+            (Value::Datetime(p), Value::Datetime(q)) => p.to_toml_string() == q.to_toml_string(),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn node_to_patch_value(node: Node<'_>) -> PatchValue {
+    match node {
+        Node::Null => PatchValue::Null,
+        Node::Val(v) => PatchValue::Value(v.clone()),
+    }
+}
+
+fn diff_any(input: Node<'_>, output: Node<'_>, ptr: &str) -> Vec<PatchOp> {
+    if nodes_strict_equal(input, output) {
+        return Vec::new();
+    }
+    match (node_type(input), node_type(output)) {
+        (JsonType::Array, JsonType::Array) => {
+            let (Node::Val(Value::Array(a)), Node::Val(Value::Array(b))) = (input, output) else {
+                unreachable!()
+            };
+            diff_arrays(a, b, ptr)
+        }
+        (JsonType::Object, JsonType::Object) => {
+            let (Node::Val(Value::Table(a)), Node::Val(Value::Table(b))) = (input, output) else {
+                unreachable!()
+            };
+            diff_objects(a, b, ptr)
+        }
+        // Materially different and not both-array / both-object: replace whole.
+        _ => vec![PatchOp {
+            op: PatchOpKind::Replace,
+            path: ptr.to_string(),
+            value: node_to_patch_value(output),
+        }],
+    }
+}
+
+/// JSON-Pointer append: `ptr.add(token)`, escaping `~`→`~0` and `/`→`~1`.
+fn ptr_add(ptr: &str, token: &str) -> String {
+    let escaped = token.replace('~', "~0").replace('/', "~1");
+    format!("{ptr}/{escaped}")
+}
+
+fn diff_objects(input: &IndexMap<String, Value>, output: &IndexMap<String, Value>, ptr: &str) -> Vec<PatchOp> {
+    let mut ops = Vec::new();
+    // keys in input but not output -> remove
+    for key in input.keys() {
+        if !output.contains_key(key) {
+            ops.push(PatchOp {
+                op: PatchOpKind::Remove,
+                path: ptr_add(ptr, key),
+                value: PatchValue::Absent,
+            });
+        }
+    }
+    // keys in output but not input -> add
+    for (key, val) in output {
+        if !input.contains_key(key) {
+            ops.push(PatchOp {
+                op: PatchOpKind::Add,
+                path: ptr_add(ptr, key),
+                value: PatchValue::Value(val.clone()),
+            });
+        }
+    }
+    // keys in both -> recurse (input iteration order, matching rfc6902)
+    for (key, in_val) in input {
+        if let Some(out_val) = output.get(key) {
+            ops.extend(diff_any(Node::Val(in_val), Node::Val(out_val), &ptr_add(ptr, key)));
+        }
+    }
+    ops
+}
+
+/// Intermediate (index-relative) array operation from the Levenshtein DP, before
+/// the padding pass rewrites indices into JSON-Pointer paths.
+#[derive(Clone)]
+enum ArrayOp {
+    Remove { index: i64 },
+    Add { index: i64, value: Value },
+    Replace { index: i64, original: Value, value: Value },
+}
+
+/// Levenshtein array diff — a faithful port of `rfc6902`'s `diffArrays`,
+/// including the memoized `dist`, the cost/stable-tie-break (`remove` < `add` <
+/// `replace`), and the padding pass that turns add indices into the `/-`
+/// append token at the tail.
+fn diff_arrays(input: &[Value], output: &[Value], ptr: &str) -> Vec<PatchOp> {
+    let input_len = input.len() as i64;
+    let output_len = output.len() as i64;
+    let max_length = input.len().max(output.len()).max(1) as i64;
+
+    let mut memo: std::collections::HashMap<i64, (Vec<ArrayOp>, i64)> = std::collections::HashMap::new();
+
+    let array_operations = dist(input_len, output_len, input, output, max_length, &mut memo).0;
+
+    // Padding pass: rewrite index-relative ops into pointer-pathed PatchOps.
+    let mut padding: i64 = 0;
+    let mut ops: Vec<PatchOp> = Vec::new();
+    for aop in array_operations {
+        match aop {
+            ArrayOp::Add { index, value } => {
+                let padded_index = index + 1 + padding;
+                let token = if padded_index < input_len + padding {
+                    padded_index.to_string()
+                } else {
+                    "-".to_string()
+                };
+                ops.push(PatchOp {
+                    op: PatchOpKind::Add,
+                    path: ptr_add(ptr, &token),
+                    value: PatchValue::Value(value),
+                });
+                padding += 1;
+            }
+            ArrayOp::Remove { index } => {
+                ops.push(PatchOp {
+                    op: PatchOpKind::Remove,
+                    path: ptr_add(ptr, &(index + padding).to_string()),
+                    value: PatchValue::Absent,
+                });
+                padding -= 1;
+            }
+            ArrayOp::Replace { index, original, value } => {
+                let replace_ptr = ptr_add(ptr, &(index + padding).to_string());
+                ops.extend(diff_any(Node::Val(&original), Node::Val(&value), &replace_ptr));
+            }
+        }
+    }
+    ops
+}
+
+/// Cheapest op sequence from `input[0..i]` to `output[0..j]` (rfc6902 `dist`).
+fn dist(
+    i: i64,
+    j: i64,
+    input: &[Value],
+    output: &[Value],
+    max_length: i64,
+    memo: &mut std::collections::HashMap<i64, (Vec<ArrayOp>, i64)>,
+) -> (Vec<ArrayOp>, i64) {
+    if i == 0 && j == 0 {
+        return (Vec::new(), 0);
+    }
+    let key = i * max_length + j;
+    if let Some(cached) = memo.get(&key) {
+        return cached.clone();
+    }
+
+    let result = if i > 0
+        && j > 0
+        && diff_any(
+            Node::Val(&input[(i - 1) as usize]),
+            Node::Val(&output[(j - 1) as usize]),
+            "",
+        )
+        .is_empty()
+    {
+        // equal element -> no op, diagonal step
+        dist(i - 1, j - 1, input, output, max_length, memo)
+    } else {
+        let mut alternatives: Vec<(Vec<ArrayOp>, i64)> = Vec::new();
+        if i > 0 {
+            let (mut ops, cost) = dist(i - 1, j, input, output, max_length, memo);
+            ops.push(ArrayOp::Remove { index: i - 1 });
+            alternatives.push((ops, cost + 1));
+        }
+        if j > 0 {
+            let (mut ops, cost) = dist(i, j - 1, input, output, max_length, memo);
+            ops.push(ArrayOp::Add {
+                index: i - 1,
+                value: output[(j - 1) as usize].clone(),
+            });
+            alternatives.push((ops, cost + 1));
+        }
+        if i > 0 && j > 0 {
+            let (mut ops, cost) = dist(i - 1, j - 1, input, output, max_length, memo);
+            ops.push(ArrayOp::Replace {
+                index: i - 1,
+                original: input[(i - 1) as usize].clone(),
+                value: output[(j - 1) as usize].clone(),
+            });
+            alternatives.push((ops, cost + 1));
+        }
+        // stable sort by cost; first lowest wins (remove < add < replace on ties)
+        alternatives.sort_by_key(|(_, cost)| *cost);
+        alternatives.into_iter().next().expect("at least one alternative when i>0 or j>0")
+    };
+
+    memo.insert(key, result.clone());
+    result
+}
+
+// ── RFC 7396: merge patch ────────────────────────────────────────────────────
+
+/// A JSON Merge Patch (RFC 7396), the structured form of `Sheet.patch`'s
+/// `partial`. `Delete` is the `null` marker (remove the key); `Replace` swaps a
+/// value wholesale (scalars, arrays, datetimes); `Merge` recurses into a table.
+/// A binding marshals a host partial — which *can* carry nulls — into this tree.
+#[derive(Clone, Debug, PartialEq)]
+pub enum MergePatch {
+    Delete,
+    Replace(Value),
+    Merge(IndexMap<String, MergePatch>),
+}
+
+/// Apply an RFC 7396 merge patch to `target` (`None` ⇒ the key/record is
+/// absent), returning the merged value or `None` when the result is a deletion.
+/// Faithful to `patch.ts`'s `mergePatch`: `Delete` removes, `Merge` recurses
+/// into a fresh copy of the target table (or `{}` when absent/non-table), and
+/// `Replace` swaps wholesale.
+pub fn apply_merge_patch(target: Option<&Value>, patch: &MergePatch) -> Option<Value> {
+    match patch {
+        MergePatch::Delete => None,
+        MergePatch::Replace(v) => Some(v.clone()),
+        MergePatch::Merge(fields) => {
+            let mut base: IndexMap<String, Value> = match target {
+                Some(Value::Table(t)) => t.clone(),
+                _ => IndexMap::new(),
+            };
+            for (key, sub) in fields {
+                match sub {
+                    MergePatch::Delete => {
+                        base.shift_remove(key);
+                    }
+                    _ => {
+                        // Non-delete always yields a value (mergePatch only
+                        // returns null for a null patch, handled above).
+                        let merged = apply_merge_patch(base.get(key), sub)
+                            .expect("non-delete merge patch yields a value");
+                        base.insert(key.clone(), merged);
+                    }
+                }
+            }
+            Some(Value::Table(base))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical::parse;
+
+    fn rec(toml: &str) -> Value {
+        parse(toml).expect("parse record")
+    }
+
+    /// Compact JSON-ish rendering of a patch for golden assertions against the
+    /// captured `rfc6902` output.
+    fn render(ops: &[PatchOp]) -> String {
+        let parts: Vec<String> = ops
+            .iter()
+            .map(|op| {
+                let val = match &op.value {
+                    PatchValue::Absent => String::new(),
+                    PatchValue::Null => ",value:null".into(),
+                    PatchValue::Value(v) => format!(",value:{}", render_value(v)),
+                };
+                format!("{{{},{}{}}}", op.op.as_str(), op.path, val)
+            })
+            .collect();
+        format!("[{}]", parts.join(","))
+    }
+
+    fn render_value(v: &Value) -> String {
+        match v {
+            Value::String(s) => format!("\"{s}\""),
+            Value::Integer(i) => i.to_string(),
+            Value::Float(f) => f.to_string(),
+            Value::Boolean(b) => b.to_string(),
+            Value::Datetime(d) => format!("\"{}\"", d.to_toml_string()),
+            Value::Array(a) => {
+                let items: Vec<String> = a.iter().map(render_value).collect();
+                format!("[{}]", items.join(","))
+            }
+            Value::Table(t) => {
+                let items: Vec<String> =
+                    t.iter().map(|(k, v)| format!("{k}:{}", render_value(v))).collect();
+                format!("{{{}}}", items.join(","))
+            }
+        }
+    }
+
+    #[test]
+    fn create_patch_added_is_top_level_replace() {
+        let dst = rec("email = 'j@x.org'\nslug = 'jane'\n");
+        assert_eq!(render(&create_patch(None, Some(&dst))), "[{replace,,value:{email:\"j@x.org\",slug:\"jane\"}}]");
+    }
+
+    #[test]
+    fn create_patch_deleted_is_replace_null() {
+        let src = rec("email = 'j@x.org'\nslug = 'jane'\n");
+        assert_eq!(render(&create_patch(Some(&src), None)), "[{replace,,value:null}]");
+    }
+
+    #[test]
+    fn create_patch_field_change_add_remove() {
+        // change
+        let a = rec("email = 'old'\nname = 'Jane'\nslug = 'jane'\n");
+        let b = rec("email = 'new'\nname = 'Jane'\nslug = 'jane'\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&b))), "[{replace,/email,value:\"new\"}]");
+        // add
+        let a = rec("slug = 'jane'\n");
+        let b = rec("email = 'new'\nslug = 'jane'\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&b))), "[{add,/email,value:\"new\"}]");
+        // remove
+        let a = rec("email = 'x'\nslug = 'jane'\n");
+        let b = rec("slug = 'jane'\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&b))), "[{remove,/email}]");
+    }
+
+    #[test]
+    fn create_patch_nested_objects() {
+        let a = rec("[a]\ncity = 'P'\nzip = '1'\n");
+        let b = rec("[a]\ncity = 'P'\nzip = '2'\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&b))), "[{replace,/a/zip,value:\"2\"}]");
+    }
+
+    #[test]
+    fn create_patch_arrays_match_rfc6902() {
+        // append
+        let a = rec("tags = ['a', 'b']\n");
+        let b = rec("tags = ['a', 'b', 'c']\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&b))), "[{add,/tags/-,value:\"c\"}]");
+        // replace element
+        let b = rec("tags = ['a', 'x']\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&b))), "[{replace,/tags/1,value:\"x\"}]");
+        // remove (a,b,c -> a): two removes both at /tags/1
+        let a3 = rec("tags = ['a', 'b', 'c']\n");
+        let b1 = rec("tags = ['a']\n");
+        assert_eq!(render(&create_patch(Some(&a3), Some(&b1))), "[{remove,/tags/1},{remove,/tags/1}]");
+        // whole replace (a,b -> x): replace /tags/0, remove /tags/1
+        let bx = rec("tags = ['x']\n");
+        assert_eq!(render(&create_patch(Some(&a), Some(&bx))), "[{replace,/tags/0,value:\"x\"},{remove,/tags/1}]");
+    }
+
+    #[test]
+    fn create_patch_noop_is_empty() {
+        let a = rec("a = 1\nb = 2\n");
+        let b = rec("a = 1\nb = 2\n");
+        assert!(create_patch(Some(&a), Some(&b)).is_empty());
+    }
+
+    #[test]
+    fn create_patch_int_float_equal_is_noop() {
+        let a = rec("x = 1\n");
+        let b = rec("x = 1.0\n");
+        assert!(create_patch(Some(&a), Some(&b)).is_empty());
+    }
+
+    // ── RFC 7396 ──
+
+    fn merge(fields: &[(&str, MergePatch)]) -> MergePatch {
+        let mut m = IndexMap::new();
+        for (k, v) in fields {
+            m.insert((*k).to_string(), v.clone());
+        }
+        MergePatch::Merge(m)
+    }
+
+    #[test]
+    fn merge_patch_updates_a_field() {
+        let target = rec("email = 'jane@old.org'\nfullName = 'Jane'\nslug = 'jane'\n");
+        let patch = merge(&[("email", MergePatch::Replace(Value::String("jane@new.org".into())))]);
+        let out = apply_merge_patch(Some(&target), &patch).unwrap();
+        let expected = rec("email = 'jane@new.org'\nfullName = 'Jane'\nslug = 'jane'\n");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn merge_patch_deletes_a_field() {
+        let target = rec("bio = 'Hello!'\nemail = 'jane@x.org'\nslug = 'jane'\n");
+        let patch = merge(&[("bio", MergePatch::Delete)]);
+        let out = apply_merge_patch(Some(&target), &patch).unwrap();
+        let expected = rec("email = 'jane@x.org'\nslug = 'jane'\n");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn merge_patch_replaces_array_atomically() {
+        let target = rec("slug = 'jane'\ntags = ['foo', 'bar']\n");
+        let patch = merge(&[(
+            "tags",
+            MergePatch::Replace(Value::Array(vec![Value::String("baz".into())])),
+        )]);
+        let out = apply_merge_patch(Some(&target), &patch).unwrap();
+        let expected = rec("slug = 'jane'\ntags = ['baz']\n");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn merge_patch_merges_nested_objects() {
+        let target = rec("slug = 'jane'\n[address]\ncity = 'Philly'\nzip = '19103'\n");
+        let patch = merge(&[(
+            "address",
+            merge(&[("zip", MergePatch::Replace(Value::String("19104".into())))]),
+        )]);
+        let out = apply_merge_patch(Some(&target), &patch).unwrap();
+        let expected = rec("slug = 'jane'\n[address]\ncity = 'Philly'\nzip = '19104'\n");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn merge_patch_deletes_a_nested_field() {
+        let target = rec("slug = 'jane'\n[address]\ncity = 'Philly'\nzip = '19103'\n");
+        let patch = merge(&[("address", merge(&[("zip", MergePatch::Delete)]))]);
+        let out = apply_merge_patch(Some(&target), &patch).unwrap();
+        let expected = rec("slug = 'jane'\n[address]\ncity = 'Philly'\n");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn merge_patch_partial_object_merges_not_replaces() {
+        // The patch-semantics.md "surprising" case: a sub-object merges, so the
+        // sibling key survives.
+        let target = rec("slug = 'jane'\n[address]\ncity = 'Philly'\nzip = '19103'\n");
+        let patch = merge(&[(
+            "address",
+            merge(&[("city", MergePatch::Replace(Value::String("Pittsburgh".into())))]),
+        )]);
+        let out = apply_merge_patch(Some(&target), &patch).unwrap();
+        let expected = rec("slug = 'jane'\n[address]\ncity = 'Pittsburgh'\nzip = '19103'\n");
+        assert_eq!(out, expected);
+    }
+}

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -18,14 +18,21 @@
 //! top of this substrate. See [`specs/rust-core.md`](../../../specs/rust-core.md).
 
 pub mod canonical;
+pub mod diff;
 pub mod engine;
 pub mod error;
 pub mod path_template;
+pub mod record;
 pub mod validation;
 pub mod value;
 
 pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};
+pub use diff::{apply_merge_patch, create_patch, MergePatch, PatchOp, PatchOpKind, PatchValue};
 pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
+pub use record::{
+    DeleteOutcome, RecordChange, RecordDiff, RecordStatus, WriteOutcome, EMPTY_TREE_HASH,
+    TOML_EXTENSION,
+};
 pub use value::{Datetime, DatetimeKind, Value};
 
 /// Identity over a batch of records — the minimal exercise of the value type

--- a/rust/gitsheets-core/src/record.rs
+++ b/rust/gitsheets-core/src/record.rs
@@ -462,6 +462,84 @@ fn read_one(
     }
 }
 
+// ── ref-string wrappers (the thin-binding surface) ───────────────────────────
+//
+// These open the repo + resolve a ref/hash to a tree and run a batch primitive,
+// so a binding crosses the FFI once with strings + a `Vec<Value>` and never
+// handles a `gix::Repository` or `MutableTree` itself. Each opens its own repo
+// handle (cheap relative to the batch it drives), keeping the thread-confinement
+// contract trivially satisfied: the handle and its trees never outlive the call.
+
+/// Open the repo, resolve `tree_ref`, and read a batch of records. See
+/// [`read_records`].
+pub fn read_records_at_ref(
+    git_dir: &str,
+    tree_ref: &str,
+    base: &str,
+    paths: &[String],
+    extension: &str,
+) -> Result<Vec<Option<Value>>> {
+    let repo = open_repo(git_dir)?;
+    let mut tree = resolve_tree(&repo, tree_ref)?;
+    read_records(&repo, &mut tree, base, paths, extension)
+}
+
+/// Open the repo, resolve `base_ref` to a starting tree, write a batch, and
+/// flush — returning the new root tree hash + blob hashes. See [`write_records`].
+pub fn write_records_at_ref(
+    git_dir: &str,
+    base_ref: &str,
+    base: &str,
+    items: &[(String, Value)],
+    extension: &str,
+) -> Result<WriteOutcome> {
+    let repo = open_repo(git_dir)?;
+    let mut tree = resolve_tree(&repo, base_ref)?;
+    write_records(&repo, &mut tree, base, items, extension)
+}
+
+/// Open the repo, resolve `base_ref`, delete a batch, and flush. See
+/// [`delete_records`].
+pub fn delete_records_at_ref(
+    git_dir: &str,
+    base_ref: &str,
+    base: &str,
+    paths: &[String],
+    extension: &str,
+) -> Result<DeleteOutcome> {
+    let repo = open_repo(git_dir)?;
+    let mut tree = resolve_tree(&repo, base_ref)?;
+    delete_records(&repo, &mut tree, base, paths, extension)
+}
+
+/// Open the repo, resolve `tree_ref`, and list every record under `base`. See
+/// [`list_records`].
+pub fn list_records_at_ref(
+    git_dir: &str,
+    tree_ref: &str,
+    base: &str,
+    extension: &str,
+) -> Result<Vec<(String, Value)>> {
+    let repo = open_repo(git_dir)?;
+    let mut tree = resolve_tree(&repo, tree_ref)?;
+    list_records(&repo, &mut tree, base, extension)
+}
+
+/// Open the repo, resolve both refs, and diff records (with parsed src/dst +
+/// RFC 6902 patches). See [`diff_records`].
+pub fn diff_records_at_refs(
+    git_dir: &str,
+    src_ref: &str,
+    dst_ref: &str,
+    base: &str,
+    extension: &str,
+) -> Result<Vec<RecordDiff>> {
+    let repo = open_repo(git_dir)?;
+    let mut src = resolve_tree(&repo, src_ref)?;
+    let mut dst = resolve_tree(&repo, dst_ref)?;
+    diff_records(&repo, &mut src, &mut dst, base, extension)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/gitsheets-core/src/record.rs
+++ b/rust/gitsheets-core/src/record.rs
@@ -1,0 +1,635 @@
+//! Record CRUD over the holo-tree substrate — the seam wiring git trees into
+//! the core.
+//!
+//! This is the first core layer to touch git objects. It composes the
+//! bytes-authority ([`canonical`](crate::canonical)) with holo-tree's mutable
+//! in-memory trees: a **read** is `tree.read_blob` → [`canonical::parse`] → a
+//! core [`Value`]; a **write** is [`canonical::serialize`] → `tree.write_child`;
+//! **delete** is `tree.delete_child_deep`; **list** is `tree.get_blob_map` +
+//! parse. A record-level **diff** between two trees replaces the JS
+//! `git diff-tree` shell-out with a holo-tree blob-map comparison, and pairs
+//! each change with an RFC 6902 patch via [`crate::diff`].
+//!
+//! ## Scope (the substrate seam, not the orchestration)
+//!
+//! These are batch-first **primitives** over an explicit record path + a TOML
+//! record [`Value`]. The sheet-level concerns — path-template rendering of the
+//! record→path mapping, the markdown/frontmatter format, query traversal +
+//! filtering, secondary indexing, and the `Sheet`/`Transaction`/`Store` state
+//! machine — are owned by later plans (`record-query-index`,
+//! `sheet-store-core`). A record path here is relative to a `base` subtree and
+//! carries no extension; callers append `.toml`. See
+//! [`specs/rust-core.md`](../../../specs/rust-core.md).
+//!
+//! ## Thread-confinement
+//!
+//! holo-tree keeps a thread-local tree/object cache, so a [`gix::Repository`]
+//! handle and the trees navigated through it stay on one thread — the same
+//! discipline the embedded engine ([`crate::engine`]) already requires.
+
+use holo_tree::{MutableTree, ObjectId};
+
+use crate::canonical;
+use crate::diff::{create_patch, PatchOp};
+use crate::error::{Error, Result};
+use crate::value::Value;
+
+/// Git's canonical empty-tree hash — the conventional "src" of a from-scratch
+/// diff, and a valid base for a write into an empty tree.
+pub const EMPTY_TREE_HASH: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/// The default record file extension. Records are canonical TOML blobs.
+pub const TOML_EXTENSION: &str = ".toml";
+
+// ── error mapping ────────────────────────────────────────────────────────────
+
+/// Map a `holo_tree::Error` onto the core's typed taxonomy. A record-blob TOML
+/// failure is `config_invalid` (matching the host's `#readRecordFromBlob`, and
+/// the canonical layer's own mapping — see this plan's inbound-deferral note); a
+/// navigation miss is `record_not_found`; other substrate failures surface as
+/// `commit_failed`, the closest substrate-op bucket in `errors.md`.
+fn map_ht(e: holo_tree::Error) -> Error {
+    match e {
+        holo_tree::Error::Toml { path, message } => Error::ConfigInvalid {
+            message: format!("TOML parse error in {path}: {message}"),
+        },
+        holo_tree::Error::PathNotFound { component } => Error::RecordNotFound {
+            message: format!("path component '{component}' not found in tree"),
+        },
+        holo_tree::Error::NotATree(s) => Error::ConfigInvalid {
+            message: format!("not a tree: {s}"),
+        },
+        other => Error::CommitFailed {
+            message: format!("holo-tree substrate error: {other}"),
+        },
+    }
+}
+
+// ── repo + tree handles ──────────────────────────────────────────────────────
+
+/// Open a [`gix::Repository`] at a git directory. Failures (missing/corrupt
+/// repo) surface as `config_invalid` — a setup problem, not a record one.
+pub fn open_repo(git_dir: &str) -> Result<gix::Repository> {
+    gix::open(git_dir).map_err(|e| Error::ConfigInvalid {
+        message: format!("could not open git repo at {git_dir}: {e}"),
+    })
+}
+
+/// Resolve a ref / rev-spec / tree-or-commit hash to a [`MutableTree`]. Accepts
+/// the same inputs `Sheet.diffFrom` passes `git diff-tree`: a commit hash, a
+/// ref name, a tag (peeled), or a bare tree hash — plus the empty-tree hash,
+/// which loads an empty tree without an ODB lookup. A spec that doesn't resolve
+/// is `ref_not_found`.
+pub fn resolve_tree(repo: &gix::Repository, spec: &str) -> Result<MutableTree> {
+    if spec == EMPTY_TREE_HASH {
+        return Ok(MutableTree::empty());
+    }
+    let id = repo.rev_parse_single(spec).map_err(|e| Error::RefNotFound {
+        message: format!("could not resolve '{spec}': {e}"),
+    })?;
+    let mut obj = id.object().map_err(|e| Error::RefNotFound {
+        message: format!("could not load object for '{spec}': {e}"),
+    })?;
+
+    use gix::object::Kind;
+    loop {
+        match obj.kind {
+            Kind::Tag => {
+                let tag = obj.try_into_tag().map_err(|_| Error::RefNotFound {
+                    message: format!("'{spec}' tag could not be parsed"),
+                })?;
+                let target = tag
+                    .target_id()
+                    .map_err(|e| Error::RefNotFound {
+                        message: format!("tag '{spec}' has no target: {e}"),
+                    })?
+                    .detach();
+                obj = repo.find_object(target).map_err(|e| Error::RefNotFound {
+                    message: format!("tag target for '{spec}' not found: {e}"),
+                })?;
+            }
+            Kind::Commit => {
+                let commit = obj.try_into_commit().map_err(|_| Error::RefNotFound {
+                    message: format!("'{spec}' commit could not be parsed"),
+                })?;
+                let tree_id = commit
+                    .tree_id()
+                    .map_err(|e| Error::RefNotFound {
+                        message: format!("commit '{spec}' has no tree: {e}"),
+                    })?
+                    .detach();
+                return Ok(MutableTree::new(tree_id));
+            }
+            Kind::Tree => return Ok(MutableTree::new(obj.id)),
+            Kind::Blob => {
+                return Err(Error::RefNotFound {
+                    message: format!("'{spec}' resolves to a blob, not a tree"),
+                })
+            }
+        }
+    }
+}
+
+fn hex(id: ObjectId) -> String {
+    id.to_string()
+}
+
+// ── join / path helpers ──────────────────────────────────────────────────────
+
+/// Join a base subtree path with a record path + extension into the deep path
+/// holo-tree navigates from the tree root. Empty/`.`/stray-slash segments drop.
+fn full_path(base: &str, record_path: &str, extension: &str) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for seg in [base, record_path] {
+        for p in seg.split('/') {
+            let p = p.trim_matches('/');
+            if !p.is_empty() && p != "." {
+                parts.push(p);
+            }
+        }
+    }
+    let joined = parts.join("/");
+    format!("{joined}{extension}")
+}
+
+fn base_arg(base: &str) -> String {
+    let cleaned: Vec<&str> = base
+        .split('/')
+        .map(|p| p.trim_matches('/'))
+        .filter(|p| !p.is_empty() && *p != ".")
+        .collect();
+    if cleaned.is_empty() {
+        ".".to_string()
+    } else {
+        cleaned.join("/")
+    }
+}
+
+// ── CRUD over an in-memory tree (the primitives) ─────────────────────────────
+
+/// Read a batch of records by path (relative to `base`, no extension). Returns
+/// `None` for a path with no blob; a present-but-unparseable blob is
+/// `config_invalid`. The whole batch shares one tree traversal.
+pub fn read_records(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    paths: &[String],
+    extension: &str,
+) -> Result<Vec<Option<Value>>> {
+    let mut out = Vec::with_capacity(paths.len());
+    for path in paths {
+        let full = full_path(base, path, extension);
+        match tree.read_blob(repo, &full).map_err(map_ht)? {
+            Some(bytes) => {
+                let text = String::from_utf8(bytes).map_err(|e| Error::ConfigInvalid {
+                    message: format!("record at {full} is not valid UTF-8: {e}"),
+                })?;
+                out.push(Some(canonical::parse(&text)?));
+            }
+            None => out.push(None),
+        }
+    }
+    Ok(out)
+}
+
+/// Result of a write/delete batch: the new root tree hash plus per-record output.
+#[derive(Clone, Debug)]
+pub struct WriteOutcome {
+    /// The root tree hash after the batch (and `write()`).
+    pub tree_hash: String,
+    /// The blob hash written for each input record, in order.
+    pub blob_hashes: Vec<String>,
+}
+
+/// Write a batch of `(record_path, value)` pairs as canonical TOML blobs under
+/// `base`, then flush. Each value is serialized through the bytes-authority
+/// (deep key-sort + canonical form), so two bindings writing the same record
+/// produce identical blobs. Returns the new root tree hash and each blob hash.
+pub fn write_records(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    items: &[(String, Value)],
+    extension: &str,
+) -> Result<WriteOutcome> {
+    let mut blob_hashes = Vec::with_capacity(items.len());
+    for (record_path, value) in items {
+        let text = canonical::serialize(value)?;
+        let full = full_path(base, record_path, extension);
+        let blob_id = tree.write_child(repo, &full, &text).map_err(map_ht)?;
+        blob_hashes.push(hex(blob_id));
+    }
+    let tree_hash = hex(tree.write(repo).map_err(map_ht)?);
+    Ok(WriteOutcome {
+        tree_hash,
+        blob_hashes,
+    })
+}
+
+/// Outcome of a delete batch: the new root tree hash and whether each path
+/// existed (was actually removed).
+#[derive(Clone, Debug)]
+pub struct DeleteOutcome {
+    pub tree_hash: String,
+    pub existed: Vec<bool>,
+}
+
+/// Delete a batch of records by path (deep delete), then flush. A path that
+/// didn't exist reports `false` (not an error — matching the permissive
+/// substrate primitive; the `record_not_found` guard is a sheet-level concern).
+pub fn delete_records(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    paths: &[String],
+    extension: &str,
+) -> Result<DeleteOutcome> {
+    let mut existed = Vec::with_capacity(paths.len());
+    for path in paths {
+        let full = full_path(base, path, extension);
+        existed.push(tree.delete_child_deep(repo, &full).map_err(map_ht)?);
+    }
+    let tree_hash = hex(tree.write(repo).map_err(map_ht)?);
+    Ok(DeleteOutcome { tree_hash, existed })
+}
+
+/// List every record under `base`: enumerate the subtree's blobs, keep those
+/// ending in `extension`, strip the extension, and parse each into a [`Value`].
+/// Paths are relative to `base` and returned in sorted (git-canonical) order. An
+/// unparseable record blob is `config_invalid`.
+pub fn list_records(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    extension: &str,
+) -> Result<Vec<(String, Value)>> {
+    let barg = base_arg(base);
+    let subtree = match tree.get_subtree(repo, &barg).map_err(map_ht)? {
+        Some(t) => t,
+        None => return Ok(Vec::new()),
+    };
+    let blob_map = subtree.get_blob_map(repo).map_err(map_ht)?;
+    let mut out = Vec::new();
+    for (path, info) in blob_map {
+        if !path.ends_with(extension) {
+            continue;
+        }
+        let record_path = path[..path.len() - extension.len()].to_string();
+        let bytes = repo
+            .find_object(info.hash)
+            .map_err(|e| Error::CommitFailed {
+                message: format!("could not read blob {} : {e}", info.hash),
+            })?
+            .data
+            .to_vec();
+        let text = String::from_utf8(bytes).map_err(|e| Error::ConfigInvalid {
+            message: format!("record at {path} is not valid UTF-8: {e}"),
+        })?;
+        out.push((record_path, canonical::parse(&text)?));
+    }
+    Ok(out)
+}
+
+// ── record-level diff (replacing git diff-tree) ──────────────────────────────
+
+/// The status of one record between two trees. No `renamed`: this primitive does
+/// not do similarity-based rename detection (`git diff-tree -M`); a moved record
+/// surfaces as a `Deleted` + an `Added`. See the plan Notes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecordStatus {
+    Added,
+    Modified,
+    Deleted,
+}
+
+impl RecordStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecordStatus::Added => "added",
+            RecordStatus::Modified => "modified",
+            RecordStatus::Deleted => "deleted",
+        }
+    }
+}
+
+/// One record-level change between two trees. `path` is relative to `base`,
+/// without the extension; hashes are `None` on the side where the record is
+/// absent.
+#[derive(Clone, Debug)]
+pub struct RecordChange {
+    pub path: String,
+    pub status: RecordStatus,
+    pub src_hash: Option<String>,
+    pub dst_hash: Option<String>,
+}
+
+fn record_blob_map(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    extension: &str,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let barg = base_arg(base);
+    let mut out = std::collections::BTreeMap::new();
+    let subtree = match tree.get_subtree(repo, &barg).map_err(map_ht)? {
+        Some(t) => t,
+        None => return Ok(out),
+    };
+    for (path, info) in subtree.get_blob_map(repo).map_err(map_ht)? {
+        if !path.ends_with(extension) {
+            continue;
+        }
+        let record_path = path[..path.len() - extension.len()].to_string();
+        out.insert(record_path, hex(info.hash));
+    }
+    Ok(out)
+}
+
+/// Diff records between two trees under `base`: added (only in dst), deleted
+/// (only in src), modified (present in both, blob hash differs). Identical
+/// blobs are skipped. Yielded in sorted path order (git-canonical), matching
+/// `git diff-tree -r`'s ordering for the add/modify/delete cases.
+pub fn diff_record_changes(
+    repo: &gix::Repository,
+    src_tree: &mut MutableTree,
+    dst_tree: &mut MutableTree,
+    base: &str,
+    extension: &str,
+) -> Result<Vec<RecordChange>> {
+    let src_map = record_blob_map(repo, src_tree, base, extension)?;
+    let dst_map = record_blob_map(repo, dst_tree, base, extension)?;
+
+    let mut paths: std::collections::BTreeSet<&String> = std::collections::BTreeSet::new();
+    paths.extend(src_map.keys());
+    paths.extend(dst_map.keys());
+
+    let mut out = Vec::new();
+    for path in paths {
+        let src = src_map.get(path);
+        let dst = dst_map.get(path);
+        let change = match (src, dst) {
+            (Some(s), Some(d)) => {
+                if s == d {
+                    continue;
+                }
+                RecordChange {
+                    path: path.clone(),
+                    status: RecordStatus::Modified,
+                    src_hash: Some(s.clone()),
+                    dst_hash: Some(d.clone()),
+                }
+            }
+            (None, Some(d)) => RecordChange {
+                path: path.clone(),
+                status: RecordStatus::Added,
+                src_hash: None,
+                dst_hash: Some(d.clone()),
+            },
+            (Some(s), None) => RecordChange {
+                path: path.clone(),
+                status: RecordStatus::Deleted,
+                src_hash: Some(s.clone()),
+                dst_hash: None,
+            },
+            (None, None) => unreachable!(),
+        };
+        out.push(change);
+    }
+    Ok(out)
+}
+
+/// A record change plus its RFC 6902 patch (and the parsed src/dst records). The
+/// patch is `create_patch(src, dst)` with `None` for the absent side, so an
+/// added record's patch is `replace "" <record>` and a deleted record's is
+/// `replace "" null` — matching `Sheet.diffFrom` + `rfc6902`.
+#[derive(Clone, Debug)]
+pub struct RecordDiff {
+    pub change: RecordChange,
+    pub src: Option<Value>,
+    pub dst: Option<Value>,
+    pub patch: Vec<PatchOp>,
+}
+
+/// Diff records between two trees and pair each change with its parsed src/dst
+/// records and RFC 6902 patch — the full `Sheet.diffFrom(opts: {records,
+/// patches})` payload, computed in the core.
+pub fn diff_records(
+    repo: &gix::Repository,
+    src_tree: &mut MutableTree,
+    dst_tree: &mut MutableTree,
+    base: &str,
+    extension: &str,
+) -> Result<Vec<RecordDiff>> {
+    let changes = diff_record_changes(repo, src_tree, dst_tree, base, extension)?;
+    let mut out = Vec::with_capacity(changes.len());
+    for change in changes {
+        let src = match &change.src_hash {
+            Some(_) => read_one(repo, src_tree, base, &change.path, extension)?,
+            None => None,
+        };
+        let dst = match &change.dst_hash {
+            Some(_) => read_one(repo, dst_tree, base, &change.path, extension)?,
+            None => None,
+        };
+        let patch = create_patch(src.as_ref(), dst.as_ref());
+        out.push(RecordDiff {
+            change,
+            src,
+            dst,
+            patch,
+        });
+    }
+    Ok(out)
+}
+
+fn read_one(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    path: &str,
+    extension: &str,
+) -> Result<Option<Value>> {
+    let full = full_path(base, path, extension);
+    match tree.read_blob(repo, &full).map_err(map_ht)? {
+        Some(bytes) => {
+            let text = String::from_utf8(bytes).map_err(|e| Error::ConfigInvalid {
+                message: format!("record at {full} is not valid UTF-8: {e}"),
+            })?;
+            Ok(Some(canonical::parse(&text)?))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn rec(pairs: &[(&str, Value)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Value::Table(m)
+    }
+
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+
+    /// A throwaway git repo (init bare-ish working dir) for integration tests.
+    fn temp_repo() -> (tempfile::TempDir, gix::Repository) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = gix::init(dir.path()).expect("git init");
+        (dir, repo)
+    }
+
+    /// Git blob hash of canonical bytes, computed independently of holo-tree:
+    /// sha1("blob <len>\0<bytes>"). Proves holo-tree wrote the *expected* object.
+    fn git_blob_hash(bytes: &[u8]) -> String {
+        let header = format!("blob {}\0", bytes.len());
+        let mut hasher = gix::hash::hasher(gix::hash::Kind::Sha1);
+        hasher.update(header.as_bytes());
+        hasher.update(bytes);
+        hasher.try_finalize().unwrap().to_string()
+    }
+
+    #[test]
+    fn write_then_read_round_trips_byte_identically() {
+        let (_dir, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        let record = rec(&[("email", s("jane@x.org")), ("slug", s("jane"))]);
+        let out = write_records(&repo, &mut tree, "people", &[("jane".into(), record.clone())], TOML_EXTENSION)
+            .expect("write");
+
+        // The blob hash holo-tree produced is the git blob hash of the canonical
+        // bytes — the substrate is wired and writing the expected object.
+        let canonical_bytes = canonical::serialize(&record).unwrap();
+        assert_eq!(out.blob_hashes[0], git_blob_hash(canonical_bytes.as_bytes()));
+
+        // Read back from the same tree: identical value.
+        let read = read_records(&repo, &mut tree, "people", &["jane".into()], TOML_EXTENSION).unwrap();
+        assert_eq!(read[0].as_ref().unwrap(), &record);
+
+        // And from the persisted tree hash, via a fresh tree handle.
+        let mut reloaded = resolve_tree(&repo, &out.tree_hash).unwrap();
+        let read2 = read_records(&repo, &mut reloaded, "people", &["jane".into()], TOML_EXTENSION).unwrap();
+        assert_eq!(read2[0].as_ref().unwrap(), &record);
+    }
+
+    #[test]
+    fn read_missing_record_is_none() {
+        let (_dir, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        let read = read_records(&repo, &mut tree, "people", &["nobody".into()], TOML_EXTENSION).unwrap();
+        assert!(read[0].is_none());
+    }
+
+    #[test]
+    fn list_records_returns_all_under_base_sorted() {
+        let (_dir, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_records(
+            &repo,
+            &mut tree,
+            "people",
+            &[
+                ("zoe".into(), rec(&[("slug", s("zoe"))])),
+                ("amy".into(), rec(&[("slug", s("amy"))])),
+            ],
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        let listed = list_records(&repo, &mut tree, "people", TOML_EXTENSION).unwrap();
+        let paths: Vec<&str> = listed.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["amy", "zoe"]);
+        assert_eq!(listed[0].1, rec(&[("slug", s("amy"))]));
+    }
+
+    #[test]
+    fn delete_removes_record_and_reports_existed() {
+        let (_dir, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_records(&repo, &mut tree, "people", &[("jane".into(), rec(&[("slug", s("jane"))]))], TOML_EXTENSION)
+            .unwrap();
+        let del = delete_records(&repo, &mut tree, "people", &["jane".into(), "ghost".into()], TOML_EXTENSION)
+            .unwrap();
+        assert_eq!(del.existed, vec![true, false]);
+        let read = read_records(&repo, &mut tree, "people", &["jane".into()], TOML_EXTENSION).unwrap();
+        assert!(read[0].is_none());
+    }
+
+    #[test]
+    fn diff_classifies_added_modified_deleted_with_patches() {
+        let (_dir, repo) = temp_repo();
+
+        // src tree: jane + bob
+        let mut src = MutableTree::empty();
+        write_records(
+            &repo,
+            &mut src,
+            "people",
+            &[
+                ("jane".into(), rec(&[("email", s("old")), ("slug", s("jane"))])),
+                ("bob".into(), rec(&[("slug", s("bob"))])),
+            ],
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        let src_hash = src.write(&repo).unwrap().to_string();
+
+        // dst tree: jane (modified) + amy (added); bob deleted
+        let mut dst = resolve_tree(&repo, &src_hash).unwrap();
+        write_records(
+            &repo,
+            &mut dst,
+            "people",
+            &[("jane".into(), rec(&[("email", s("new")), ("slug", s("jane"))]))],
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        write_records(&repo, &mut dst, "people", &[("amy".into(), rec(&[("slug", s("amy"))]))], TOML_EXTENSION)
+            .unwrap();
+        delete_records(&repo, &mut dst, "people", &["bob".into()], TOML_EXTENSION).unwrap();
+        let dst_hash = dst.write(&repo).unwrap().to_string();
+
+        let mut src2 = resolve_tree(&repo, &src_hash).unwrap();
+        let mut dst2 = resolve_tree(&repo, &dst_hash).unwrap();
+        let diffs = diff_records(&repo, &mut src2, &mut dst2, "people", TOML_EXTENSION).unwrap();
+
+        let by_path: std::collections::HashMap<&str, &RecordDiff> =
+            diffs.iter().map(|d| (d.change.path.as_str(), d)).collect();
+
+        assert_eq!(by_path["amy"].change.status, RecordStatus::Added);
+        assert_eq!(by_path["bob"].change.status, RecordStatus::Deleted);
+        assert_eq!(by_path["jane"].change.status, RecordStatus::Modified);
+
+        // jane's patch is a single field replace.
+        let jane = by_path["jane"];
+        assert_eq!(jane.patch.len(), 1);
+        assert_eq!(jane.patch[0].path, "/email");
+
+        // amy added -> replace "" <record>; bob deleted -> replace "" null.
+        assert_eq!(by_path["amy"].patch.len(), 1);
+        assert_eq!(by_path["amy"].patch[0].path, "");
+        assert_eq!(by_path["bob"].patch.len(), 1);
+        assert!(matches!(by_path["bob"].patch[0].value, crate::diff::PatchValue::Null));
+    }
+
+    #[test]
+    fn diff_against_empty_tree_is_all_added() {
+        let (_dir, repo) = temp_repo();
+        let mut dst = MutableTree::empty();
+        write_records(&repo, &mut dst, "people", &[("jane".into(), rec(&[("slug", s("jane"))]))], TOML_EXTENSION)
+            .unwrap();
+        let dst_hash = dst.write(&repo).unwrap().to_string();
+
+        let mut empty = resolve_tree(&repo, EMPTY_TREE_HASH).unwrap();
+        let mut dst2 = resolve_tree(&repo, &dst_hash).unwrap();
+        let diffs = diff_records(&repo, &mut empty, &mut dst2, "people", TOML_EXTENSION).unwrap();
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].change.status, RecordStatus::Added);
+    }
+}

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -117,6 +117,16 @@ module.exports = {
   // Stateful compiled definition (compile-once / reuse). Raw class — its
   // structured errors carry `gitsheetsClass`; map with `mapCoreError` if needed.
   CompiledDefinition: addon.CompiledDefinition,
+  // Record CRUD over the holo-tree substrate (batch-first). Substrate / record
+  // parse failures surface as typed core errors.
+  recordRead: wrap(addon.recordRead),
+  recordWrite: wrap(addon.recordWrite),
+  recordDelete: wrap(addon.recordDelete),
+  recordList: wrap(addon.recordList),
+  diffRecords: wrap(addon.diffRecords),
+  // Diff / patch primitives (RFC 6902 createPatch, RFC 7396 mergePatch).
+  createPatch: wrap(addon.createPatch),
+  applyMergePatch: wrap(addon.applyMergePatch),
   // Boundary-test entry: throws the typed class for a given stable code.
   simulateCoreError: wrap(addon.simulateCoreError),
   // Error machinery.

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -61,6 +61,72 @@ export declare function validateBatch(schema: JsValue, records: Array<JsValue>):
  */
 export declare function runComparator(rule: string, a: JsValue, b: JsValue): number
 /**
+ * Read a batch of records by path. Each result is the record (a plain object
+ * with full TOML type fidelity) or `null` when no blob lives at that path.
+ */
+export declare function recordRead(gitDir: string, treeRef: string, base: string, paths: Array<string>, extension?: string | undefined | null): Array<JsValue | undefined | null>
+/**
+ * The result of a `record_write`/`record_delete`: the new root tree hash plus
+ * per-record output (`blobHashes` for writes, `existed` for deletes).
+ */
+export interface JsWriteOutcome {
+  treeHash: string
+  blobHashes: Array<string>
+}
+/** The result of a `record_delete`. */
+export interface JsDeleteOutcome {
+  treeHash: string
+  existed: Array<boolean>
+}
+/**
+ * Write a batch of records (canonical TOML) under `base`, starting from the
+ * tree `baseRef`. `paths[i]` is written from `records[i]`. Returns the new root
+ * tree hash + each written blob hash. The bytes are produced by the core's
+ * bytes-authority, so two bindings writing the same record agree byte-for-byte.
+ */
+export declare function recordWrite(gitDir: string, baseRef: string, base: string, paths: Array<string>, records: Array<JsValue>, extension?: string | undefined | null): JsWriteOutcome
+/**
+ * Delete a batch of records by path under `base`, starting from `baseRef`.
+ * `existed[i]` reports whether `paths[i]` was actually present.
+ */
+export declare function recordDelete(gitDir: string, baseRef: string, base: string, paths: Array<string>, extension?: string | undefined | null): JsDeleteOutcome
+/**
+ * One record from `record_list`: its path (relative to `base`, no extension)
+ * and parsed value.
+ */
+export interface JsRecordEntry {
+  path: string
+  record: JsValue
+}
+/**
+ * List every record under `base` in the tree `treeRef`, in sorted
+ * (git-canonical) path order.
+ */
+export declare function recordList(gitDir: string, treeRef: string, base: string, extension?: string | undefined | null): Array<JsRecordEntry>
+/**
+ * Generate an RFC 6902 JSON Patch transforming `src` into `dst` — the core's
+ * `createPatch`, matching the `rfc6902` package op-for-op. `null`/`undefined`
+ * on either side is the JSON null `Sheet.diffFrom` passes for an added
+ * (`src=null`) or deleted (`dst=null`) record.
+ */
+export declare function createPatch(src?: JsValue | undefined | null, dst?: JsValue | undefined | null): object
+/**
+ * Apply an RFC 7396 JSON Merge Patch to `target` (`null` ⇒ absent), returning
+ * the merged record — the core's `mergePatch` behind `Sheet.patch`. A `null`
+ * in the patch deletes that key; an object merges recursively; anything else
+ * replaces wholesale. Returns `null` only when the patch deletes the record
+ * outright.
+ */
+export declare function applyMergePatch(target: JsValue | undefined | null, patch: JsMergePatch): JsValue | null
+/**
+ * Diff records between two trees (`srcRef` → `dstRef`) under `base`, returning
+ * one entry per change with status, src/dst blob hashes, the parsed src/dst
+ * records, and the RFC 6902 patch — the full `Sheet.diffFrom({records,
+ * patches})` payload, computed in the core. `srcRef` may be the empty-tree hash
+ * for a from-scratch diff.
+ */
+export declare function diffRecords(gitDir: string, srcRef: string, dstRef: string, base: string, extension?: string | undefined | null): object
+/**
  * Throw the core error for a given stable `code`, surfaced as a **structured,
  * matchable** JS error (own `code`, `status`, `gitsheetsClass`, and any
  * `issues`/`conflictingPaths`). Boundary-test entry point: it exercises the

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, simulateCoreError } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, createPatch, applyMergePatch, diffRecords, simulateCoreError } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -319,4 +319,11 @@ module.exports.renderPathsBatch = renderPathsBatch
 module.exports.validateBatch = validateBatch
 module.exports.runComparator = runComparator
 module.exports.CompiledDefinition = CompiledDefinition
+module.exports.recordRead = recordRead
+module.exports.recordWrite = recordWrite
+module.exports.recordDelete = recordDelete
+module.exports.recordList = recordList
+module.exports.createPatch = createPatch
+module.exports.applyMergePatch = applyMergePatch
+module.exports.diffRecords = diffRecords
 module.exports.simulateCoreError = simulateCoreError

--- a/rust/gitsheets-napi/package-lock.json
+++ b/rust/gitsheets-napi/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
         "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1"
+        "ajv-formats": "^3.0.1",
+        "rfc6902": "^5.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -109,6 +110,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc6902": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.2.0.tgz",
+      "integrity": "sha512-ZNQpVnWsdLMTCcLZcUY9ZBhxWuj7/H13EM7NL2gvbAMBXfLeN3iOLi3TWT1+8Or7OTLYXRDCy7sTEStk3j4KBA==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,11 +36,12 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs"
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/record-crud.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "rfc6902": "^5.2.0"
   }
 }

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -24,10 +24,11 @@
 //! paths never bake in per-record FFI crossings.
 
 use chrono::{Datelike, Timelike};
+use gitsheets_core::diff::{MergePatch, PatchOp, PatchValue};
 use gitsheets_core::engine::Engine;
 use gitsheets_core::path_template::Template;
 use gitsheets_core::validation::CompiledSchema;
-use gitsheets_core::{Datetime, Value};
+use gitsheets_core::{record, Datetime, Value};
 use napi::bindgen_prelude::*;
 use napi::{Env, JsDate, JsFunction, JsObject, JsString, JsUnknown, NapiRaw, ValueType};
 use napi_derive::napi;
@@ -438,6 +439,313 @@ impl CompiledDefinition {
     #[napi]
     pub fn snippet_count(&self) -> u32 {
         self.engine.snippet_count() as u32
+    }
+}
+
+// ── record CRUD + diff/patch over the holo-tree substrate ─────────────────────
+//
+// These prove the record engine's parity from JS. Each opens a repo at `gitDir`
+// and resolves a ref/hash to a tree in the core (the binding never touches a
+// `gix::Repository` or a holo-tree node — the seam stays Rust-side). All are
+// batch-first: a `Vec` of paths/records crosses the FFI once.
+
+const DEFAULT_EXTENSION: &str = ".toml";
+
+fn extension_of(extension: Option<String>) -> String {
+    extension.unwrap_or_else(|| DEFAULT_EXTENSION.to_string())
+}
+
+/// Read a batch of records by path. Each result is the record (a plain object
+/// with full TOML type fidelity) or `null` when no blob lives at that path.
+#[napi]
+pub fn record_read(
+    env: Env,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    paths: Vec<String>,
+    extension: Option<String>,
+) -> Result<Vec<Option<JsValue>>> {
+    let ext = extension_of(extension);
+    match record::read_records_at_ref(&git_dir, &tree_ref, &base, &paths, &ext) {
+        Ok(values) => Ok(values.into_iter().map(|v| v.map(JsValue)).collect()),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+/// The result of a `record_write`/`record_delete`: the new root tree hash plus
+/// per-record output (`blobHashes` for writes, `existed` for deletes).
+#[napi(object)]
+pub struct JsWriteOutcome {
+    pub tree_hash: String,
+    pub blob_hashes: Vec<String>,
+}
+
+/// The result of a `record_delete`.
+#[napi(object)]
+pub struct JsDeleteOutcome {
+    pub tree_hash: String,
+    pub existed: Vec<bool>,
+}
+
+/// Write a batch of records (canonical TOML) under `base`, starting from the
+/// tree `baseRef`. `paths[i]` is written from `records[i]`. Returns the new root
+/// tree hash + each written blob hash. The bytes are produced by the core's
+/// bytes-authority, so two bindings writing the same record agree byte-for-byte.
+#[napi]
+pub fn record_write(
+    env: Env,
+    git_dir: String,
+    base_ref: String,
+    base: String,
+    paths: Vec<String>,
+    records: Vec<JsValue>,
+    extension: Option<String>,
+) -> Result<JsWriteOutcome> {
+    if paths.len() != records.len() {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "record_write: paths ({}) and records ({}) length mismatch",
+                paths.len(),
+                records.len()
+            ),
+        ));
+    }
+    let items: Vec<(String, Value)> = paths
+        .into_iter()
+        .zip(records.into_iter().map(|j| j.0))
+        .collect();
+    let ext = extension_of(extension);
+    match record::write_records_at_ref(&git_dir, &base_ref, &base, &items, &ext) {
+        Ok(outcome) => Ok(JsWriteOutcome {
+            tree_hash: outcome.tree_hash,
+            blob_hashes: outcome.blob_hashes,
+        }),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+/// Delete a batch of records by path under `base`, starting from `baseRef`.
+/// `existed[i]` reports whether `paths[i]` was actually present.
+#[napi]
+pub fn record_delete(
+    env: Env,
+    git_dir: String,
+    base_ref: String,
+    base: String,
+    paths: Vec<String>,
+    extension: Option<String>,
+) -> Result<JsDeleteOutcome> {
+    let ext = extension_of(extension);
+    match record::delete_records_at_ref(&git_dir, &base_ref, &base, &paths, &ext) {
+        Ok(outcome) => Ok(JsDeleteOutcome {
+            tree_hash: outcome.tree_hash,
+            existed: outcome.existed,
+        }),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+/// One record from `record_list`: its path (relative to `base`, no extension)
+/// and parsed value.
+#[napi(object)]
+pub struct JsRecordEntry {
+    pub path: String,
+    pub record: JsValue,
+}
+
+/// List every record under `base` in the tree `treeRef`, in sorted
+/// (git-canonical) path order.
+#[napi]
+pub fn record_list(
+    env: Env,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    extension: Option<String>,
+) -> Result<Vec<JsRecordEntry>> {
+    let ext = extension_of(extension);
+    match record::list_records_at_ref(&git_dir, &tree_ref, &base, &ext) {
+        Ok(entries) => Ok(entries
+            .into_iter()
+            .map(|(path, record)| JsRecordEntry {
+                path,
+                record: JsValue(record),
+            })
+            .collect()),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
+/// Build a JS array of RFC 6902 ops, shaping `value` exactly like the `rfc6902`
+/// package: a `remove` carries no `value` key, a null-replace carries
+/// `value: null`, everything else carries the marshalled value.
+fn build_patch_array(env: &Env, ops: &[PatchOp]) -> Result<JsObject> {
+    let mut arr = env.create_array_with_length(ops.len())?;
+    for (i, op) in ops.iter().enumerate() {
+        let mut obj = env.create_object()?;
+        obj.set_named_property("op", env.create_string(op.op.as_str())?)?;
+        obj.set_named_property("path", env.create_string(&op.path)?)?;
+        match &op.value {
+            PatchValue::Absent => {}
+            PatchValue::Null => {
+                obj.set_named_property("value", env.get_null()?)?;
+            }
+            PatchValue::Value(v) => {
+                let raw = unsafe { JsValue::to_napi_value(env.raw(), JsValue(v.clone()))? };
+                let val = unsafe { JsUnknown::from_napi_value(env.raw(), raw)? };
+                obj.set_named_property("value", val)?;
+            }
+        }
+        arr.set_element(i as u32, obj)?;
+    }
+    Ok(arr)
+}
+
+/// Generate an RFC 6902 JSON Patch transforming `src` into `dst` — the core's
+/// `createPatch`, matching the `rfc6902` package op-for-op. `null`/`undefined`
+/// on either side is the JSON null `Sheet.diffFrom` passes for an added
+/// (`src=null`) or deleted (`dst=null`) record.
+#[napi]
+pub fn create_patch(env: Env, src: Option<JsValue>, dst: Option<JsValue>) -> Result<JsObject> {
+    let src_val = src.map(|j| j.0);
+    let dst_val = dst.map(|j| j.0);
+    let ops = gitsheets_core::create_patch(src_val.as_ref(), dst_val.as_ref());
+    build_patch_array(&env, &ops)
+}
+
+/// Apply an RFC 7396 JSON Merge Patch to `target` (`null` ⇒ absent), returning
+/// the merged record — the core's `mergePatch` behind `Sheet.patch`. A `null`
+/// in the patch deletes that key; an object merges recursively; anything else
+/// replaces wholesale. Returns `null` only when the patch deletes the record
+/// outright.
+#[napi]
+pub fn apply_merge_patch(
+    target: Option<JsValue>,
+    patch: JsMergePatch,
+) -> Result<Option<JsValue>> {
+    let target_val = target.map(|j| j.0);
+    Ok(gitsheets_core::apply_merge_patch(target_val.as_ref(), &patch.0).map(JsValue))
+}
+
+/// Diff records between two trees (`srcRef` → `dstRef`) under `base`, returning
+/// one entry per change with status, src/dst blob hashes, the parsed src/dst
+/// records, and the RFC 6902 patch — the full `Sheet.diffFrom({records,
+/// patches})` payload, computed in the core. `srcRef` may be the empty-tree hash
+/// for a from-scratch diff.
+#[napi]
+pub fn diff_records(
+    env: Env,
+    git_dir: String,
+    src_ref: String,
+    dst_ref: String,
+    base: String,
+    extension: Option<String>,
+) -> Result<JsObject> {
+    let ext = extension_of(extension);
+    let diffs = match record::diff_records_at_refs(&git_dir, &src_ref, &dst_ref, &base, &ext) {
+        Ok(d) => d,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+    let mut arr = env.create_array_with_length(diffs.len())?;
+    for (i, d) in diffs.into_iter().enumerate() {
+        let mut obj = env.create_object()?;
+        obj.set_named_property("path", env.create_string(&d.change.path)?)?;
+        obj.set_named_property("status", env.create_string(d.change.status.as_str())?)?;
+        match &d.change.src_hash {
+            Some(h) => obj.set_named_property("srcHash", env.create_string(h)?)?,
+            None => obj.set_named_property("srcHash", env.get_null()?)?,
+        }
+        match &d.change.dst_hash {
+            Some(h) => obj.set_named_property("dstHash", env.create_string(h)?)?,
+            None => obj.set_named_property("dstHash", env.get_null()?)?,
+        }
+        set_optional_record(&env, &mut obj, "src", d.src)?;
+        set_optional_record(&env, &mut obj, "dst", d.dst)?;
+        let patch = build_patch_array(&env, &d.patch)?;
+        obj.set_named_property("patch", patch)?;
+        arr.set_element(i as u32, obj)?;
+    }
+    Ok(arr)
+}
+
+/// Set `key` on `obj` to the marshalled record, or `null` when absent.
+fn set_optional_record(
+    env: &Env,
+    obj: &mut JsObject,
+    key: &str,
+    value: Option<Value>,
+) -> Result<()> {
+    match value {
+        Some(v) => {
+            let raw = unsafe { JsValue::to_napi_value(env.raw(), JsValue(v))? };
+            let val = unsafe { JsUnknown::from_napi_value(env.raw(), raw)? };
+            obj.set_named_property(key, val)?;
+        }
+        None => obj.set_named_property(key, env.get_null()?)?,
+    }
+    Ok(())
+}
+
+/// An RFC 7396 merge patch crossing the FFI — the structured form of a host
+/// partial that *may* carry nulls (which the record `JsValue` rejects). A `null`
+/// marshals to [`MergePatch::Delete`], a plain object to a recursive
+/// [`MergePatch::Merge`], and everything else (scalar, array, `Date`) to a
+/// wholesale [`MergePatch::Replace`].
+pub struct JsMergePatch(pub MergePatch);
+
+impl TypeName for JsMergePatch {
+    fn type_name() -> &'static str {
+        "any"
+    }
+    fn value_type() -> ValueType {
+        ValueType::Unknown
+    }
+}
+
+impl ValidateNapiValue for JsMergePatch {
+    unsafe fn validate(
+        _env: napi::sys::napi_env,
+        _napi_val: napi::sys::napi_value,
+    ) -> Result<napi::sys::napi_value> {
+        Ok(std::ptr::null_mut())
+    }
+}
+
+impl FromNapiValue for JsMergePatch {
+    unsafe fn from_napi_value(
+        env: napi::sys::napi_env,
+        napi_val: napi::sys::napi_value,
+    ) -> Result<Self> {
+        let unknown = JsUnknown::from_napi_value(env, napi_val)?;
+        let patch = match unknown.get_type()? {
+            // The null delete-sentinel (RFC 7396). `undefined` is treated the
+            // same — a missing/cleared key.
+            ValueType::Null | ValueType::Undefined => MergePatch::Delete,
+            ValueType::Object if !unknown.is_array()? && !unknown.is_date()? => {
+                // A plain object merges recursively.
+                let obj = JsObject::from_napi_value(env, napi_val)?;
+                let names = obj.get_property_names()?;
+                let len = names.get_array_length()?;
+                let mut map = indexmap::IndexMap::new();
+                for i in 0..len {
+                    let key_js: JsString = names.get_element(i)?;
+                    let key = key_js.into_utf8()?.as_str()?.to_owned();
+                    let child: JsUnknown = obj.get_named_property(&key)?;
+                    let child = JsMergePatch::from_napi_value(env, child.raw())?;
+                    map.insert(key, child.0);
+                }
+                MergePatch::Merge(map)
+            }
+            // Scalars, arrays, and Dates replace wholesale — marshal through the
+            // record value type (which preserves int/float + the datetime kind).
+            _ => {
+                let value = JsValue::from_napi_value(env, napi_val)?;
+                MergePatch::Replace(value.0)
+            }
+        };
+        Ok(JsMergePatch(patch))
     }
 }
 

--- a/rust/gitsheets-napi/test/record-crud.mjs
+++ b/rust/gitsheets-napi/test/record-crud.mjs
@@ -1,0 +1,212 @@
+// Record CRUD + diff/patch boundary suite for gitsheets-napi.
+//
+// Proves the record engine's parity from JS:
+//   - CRUD round-trips records through the holo-tree substrate (write produces a
+//     real tree/blob hash; read returns the written record byte-faithfully).
+//   - RFC 6902 `createPatch` matches the `rfc6902` npm package op-for-op on a
+//     fixture corpus (the parity target `Sheet.diffFrom` uses).
+//   - RFC 7396 `applyMergePatch` matches `packages/gitsheets/src/patch.ts`'s
+//     inline `mergePatch` on the `patch-semantics.md` worked examples.
+//
+// Requires the addon to be built first: `npm run build:debug` (or `build`).
+// Run with: `npm test` (node --test).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createPatch as rfc6902CreatePatch } from 'rfc6902';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../binding.cjs');
+} catch (err) {
+  throw new Error(
+    `gitsheets-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+const {
+  recordRead,
+  recordWrite,
+  recordDelete,
+  recordList,
+  diffRecords,
+  createPatch,
+  applyMergePatch,
+} = binding;
+
+const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+function freshRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'gitsheets-napi-'));
+  execFileSync('git', ['init', '-q', dir]);
+  return { dir, gitDir: join(dir, '.git') };
+}
+
+// ── CRUD ──────────────────────────────────────────────────────────────────────
+
+test('write → read round-trips a record through holo-tree', () => {
+  const { dir, gitDir } = freshRepo();
+  try {
+    const rec = { email: 'jane@x.org', slug: 'jane', tags: ['a', 'b'], age: 30 };
+    const out = recordWrite(gitDir, EMPTY_TREE, 'people', ['jane'], [rec]);
+    assert.match(out.treeHash, /^[0-9a-f]{40}$/, 'a real tree hash');
+    assert.match(out.blobHashes[0], /^[0-9a-f]{40}$/, 'a real blob hash');
+
+    const read = recordRead(gitDir, out.treeHash, 'people', ['jane']);
+    assert.deepEqual(read[0], rec, 'read back identical');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('read of a missing record is null', () => {
+  const { dir, gitDir } = freshRepo();
+  try {
+    const out = recordWrite(gitDir, EMPTY_TREE, 'people', ['jane'], [{ slug: 'jane' }]);
+    const read = recordRead(gitDir, out.treeHash, 'people', ['nobody']);
+    assert.equal(read[0], null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('list returns every record under base, sorted', () => {
+  const { dir, gitDir } = freshRepo();
+  try {
+    const out = recordWrite(
+      gitDir,
+      EMPTY_TREE,
+      'people',
+      ['zoe', 'amy'],
+      [{ slug: 'zoe' }, { slug: 'amy' }],
+    );
+    const listed = recordList(gitDir, out.treeHash, 'people');
+    assert.deepEqual(
+      listed.map((e) => e.path),
+      ['amy', 'zoe'],
+    );
+    assert.deepEqual(listed[0].record, { slug: 'amy' });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('delete removes a record and reports existence', () => {
+  const { dir, gitDir } = freshRepo();
+  try {
+    const w = recordWrite(gitDir, EMPTY_TREE, 'people', ['jane'], [{ slug: 'jane' }]);
+    const d = recordDelete(gitDir, w.treeHash, 'people', ['jane', 'ghost']);
+    assert.deepEqual(d.existed, [true, false]);
+    const read = recordRead(gitDir, d.treeHash, 'people', ['jane']);
+    assert.equal(read[0], null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('diff classifies added / modified / deleted with RFC 6902 patches', () => {
+  const { dir, gitDir } = freshRepo();
+  try {
+    const src = recordWrite(
+      gitDir,
+      EMPTY_TREE,
+      'people',
+      ['jane', 'bob'],
+      [{ email: 'old', slug: 'jane' }, { slug: 'bob' }],
+    );
+    let dst = recordWrite(gitDir, src.treeHash, 'people', ['jane'], [{ email: 'new', slug: 'jane' }]);
+    dst = recordWrite(gitDir, dst.treeHash, 'people', ['amy'], [{ slug: 'amy' }]);
+    dst = recordDelete(gitDir, dst.treeHash, 'people', ['bob']);
+
+    const diffs = diffRecords(gitDir, src.treeHash, dst.treeHash, 'people');
+    const byPath = Object.fromEntries(diffs.map((d) => [d.path, d]));
+
+    assert.equal(byPath.amy.status, 'added');
+    assert.equal(byPath.bob.status, 'deleted');
+    assert.equal(byPath.jane.status, 'modified');
+
+    assert.deepEqual(byPath.jane.patch, [{ op: 'replace', path: '/email', value: 'new' }]);
+    assert.deepEqual(byPath.amy.patch, [{ op: 'replace', path: '', value: { slug: 'amy' } }]);
+    assert.deepEqual(byPath.bob.patch, [{ op: 'replace', path: '', value: null }]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── RFC 6902 parity vs the `rfc6902` package ───────────────────────────────────
+
+const PATCH_CASES = [
+  ['added', null, { slug: 'jane', email: 'j@x.org' }],
+  ['deleted', { slug: 'jane', email: 'j@x.org' }, null],
+  ['field-change', { slug: 'jane', email: 'old', name: 'Jane' }, { slug: 'jane', email: 'new', name: 'Jane' }],
+  ['field-add', { slug: 'jane' }, { slug: 'jane', email: 'new' }],
+  ['field-remove', { slug: 'jane', email: 'x' }, { slug: 'jane' }],
+  ['nested-change', { a: { city: 'P', zip: '1' } }, { a: { city: 'P', zip: '2' } }],
+  ['nested-add', { a: { city: 'P' } }, { a: { city: 'P', zip: '2' } }],
+  ['array-append', { tags: ['a', 'b'] }, { tags: ['a', 'b', 'c'] }],
+  ['array-replace-elem', { tags: ['a', 'b'] }, { tags: ['a', 'x'] }],
+  ['array-remove', { tags: ['a', 'b', 'c'] }, { tags: ['a'] }],
+  ['array-whole', { tags: ['a', 'b'] }, { tags: ['x'] }],
+  ['array-prepend', { tags: ['b', 'c'] }, { tags: ['a', 'b', 'c'] }],
+  ['array-of-objects', { rows: [{ k: 1 }, { k: 2 }] }, { rows: [{ k: 1 }, { k: 3 }] }],
+  ['type-change', { x: 1 }, { x: '1' }],
+  ['multi-field', { a: 1, b: 2, c: 3 }, { a: 1, b: 20, d: 4 }],
+  ['noop', { a: 1, b: 2 }, { a: 1, b: 2 }],
+  ['pointer-escape', { 'a/b': 1, 'c~d': 2 }, { 'a/b': 9, 'c~d': 2 }],
+];
+
+test('createPatch matches the rfc6902 package op-for-op', () => {
+  for (const [name, src, dst] of PATCH_CASES) {
+    const mine = createPatch(src, dst);
+    const theirs = rfc6902CreatePatch(src, dst);
+    assert.deepEqual(mine, theirs, `createPatch divergence on "${name}"`);
+  }
+});
+
+// ── RFC 7396 parity vs patch.ts's inline mergePatch ────────────────────────────
+
+// Verbatim copy of `packages/gitsheets/src/patch.ts` `mergePatch` — the exact
+// implementation `Sheet.patch` applies. Parity is asserted against it directly.
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return false;
+  if (value instanceof Date) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+function mergePatch(target, patch) {
+  if (!isPlainObject(patch)) return patch;
+  const base = isPlainObject(target) ? { ...target } : {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) delete base[key];
+    else base[key] = mergePatch(base[key], value);
+  }
+  return base;
+}
+
+const MERGE_CASES = [
+  ['update-field', { slug: 'jane', email: 'jane@old.org', fullName: 'Jane' }, { email: 'jane@new.org' }],
+  ['delete-field', { slug: 'jane', email: 'jane@x.org', bio: 'Hello!' }, { bio: null }],
+  ['replace-array', { slug: 'jane', tags: ['foo', 'bar'] }, { tags: ['baz'] }],
+  ['merge-nested', { slug: 'jane', address: { city: 'Philly', zip: '19103' } }, { address: { zip: '19104' } }],
+  ['delete-nested', { slug: 'jane', address: { city: 'Philly', zip: '19103' } }, { address: { zip: null } }],
+  ['partial-nested-merges', { slug: 'jane', address: { city: 'Philly', zip: '19103' } }, { address: { city: 'Pittsburgh' } }],
+  ['add-field', { slug: 'jane' }, { email: 'new@x.org' }],
+  ['add-nested-object', { slug: 'jane' }, { address: { city: 'Philly' } }],
+  ['scalar-types', { n: 1, b: true }, { n: 2, b: false }],
+];
+
+test('applyMergePatch matches patch.ts mergePatch on the spec examples', () => {
+  for (const [name, target, patch] of MERGE_CASES) {
+    const mine = applyMergePatch(target, patch);
+    const theirs = mergePatch(target, patch);
+    assert.deepEqual(mine, theirs, `mergePatch divergence on "${name}"`);
+  }
+});


### PR DESCRIPTION
Lands the **record read/write layer** in `gitsheets-core` and is the **first plan to wire holo-tree into the core**. Implements [`plans/record-engine-core.md`](plans/record-engine-core.md) toward the Rust-core migration (#127).

## What's in

- **holo-tree substrate seam.** `gitsheets-core` gains a git dependency on the hologit repo's `holo-tree` crate (+ `gix` 0.83 to open repos and pass the unified `Repository` handle). Pinned via committed `Cargo.lock` to commit `e3750660`. Branch is `develop` (not `master`): the merged spike fixes this layer depends on — notably `delete_child_deep`'s dirty-propagation (hologit#473) — live on develop and are not yet on master.
- **Record CRUD** (`record.rs`, batch-first): read (blob → `canonical::parse`), write (`canonical::serialize` → `write_child`), delete (`delete_child_deep`), list (`get_blob_map` + parse), plus a record-level tree **diff** (blob-map comparison replacing `git diff-tree`) classifying added/modified/deleted.
- **Diff/patch** (`diff.rs`): RFC 6902 `create_patch` (a faithful port of the `rfc6902` package — object diff, Levenshtein array diff with its cost/tie-break + `/-` padding, wholesale-replace fallback, top-level null) and RFC 7396 `apply_merge_patch` (a port of `patch.ts`'s `mergePatch`).
- **napi exposure**: `recordRead/Write/Delete/List`, `diffRecords`, `createPatch`, `applyMergePatch` — proving parity from JS while keeping the binding thin (ref-string wrappers do the repo-open/tree-resolve in the core; no `gix`/holo-tree types cross the FFI).

## Parity results

- **RFC 6902** — `createPatch` matches the `rfc6902` package **op-for-op** across 17 fixtures (field add/remove/change, nested, all array shapes incl. append/prepend/whole-replace, array-of-objects, pointer escaping). ✅
- **RFC 7396** — `applyMergePatch` matches `patch.ts`'s `mergePatch` across the `patch-semantics.md` worked examples. ✅
- **CRUD** — write produces the expected git blob/tree hashes (verified against an independent sha1) and reads return the record byte-faithfully. ✅

**Enumerated divergences** (both theoretical — parity fixtures stay JSON-representable): datetimes diff by canonical string (emit `replace` on change) where `rfc6902` sees a `Date` object and emits nothing (a latent JS quirk); and no `-M` rename detection — a move is a delete + add.

## Validation

- `cargo build --workspace` + `cargo test --workspace` pass; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- napi addon builds; `node --test` boundary suite green (43 tests, incl. the new record-crud suite).
- Main JS suite stays green (`npm test`: 287 + 66) and independent (`npm run type-check` clean); the main build never imports the `.node` addon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd