### PR TITLE
feat(core): Sheet / Transaction / Store orchestration in the core

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -86,13 +86,14 @@ jobs:
         working-directory: rust/gitsheets-napi
         run: npm run build
 
-      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, record CRUD/diff/patch, query, index)
+      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, record CRUD/diff/patch, query, index, Sheet/Transaction/Store)
         # Explicit file paths (not a glob) so the suite runs identically on
         # node 20 and 22 — `node --test "test/*.mjs"` does NOT expand on node 20.
-        # record-crud/query/index.mjs use `git init` for their temp repos, so git
-        # must be on PATH (it is, on ubuntu-latest). record-query.mjs diffs the
-        # core's query/prune/getFieldNames against a transcribed host reference;
-        # record-index.mjs against a transcribed `Sheet` index build.
+        # The `test` npm script lists every .mjs explicitly (see package.json),
+        # including sheet-store.mjs, which drives the orchestration state machine
+        # (Transaction lifecycle + the two-phase consumer-validator protocol +
+        # Store discovery). record-crud/query/index/sheet-store.mjs use `git init`
+        # for their temp repos, so git must be on PATH (it is, on ubuntu-latest).
         working-directory: rust/gitsheets-napi
         run: npm test
 

--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -31,6 +31,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The transaction tests commit to throwaway gix repos; gix's update_ref
+      # writes a reflog entry, which needs a committer identity from git config.
+      # CI runners have none configured, so without this the reflog write fails
+      # ("The reflog could not be created or updated"). Mirrors hologit's own
+      # holo-tree-napi.yml. (Upstream follow-up: holo-tree's update_ref should
+      # use the commit's identity for the reflog instead of ambient git config.)
+      - name: Configure git identity (commit-bearing tests write reflogs)
+        run: |
+          git config --global user.name "gitsheets CI"
+          git config --global user.email "ci@gitsheets.local"
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -67,6 +78,13 @@ jobs:
         node: ['20', '22']
     steps:
       - uses: actions/checkout@v7
+
+      # Same reflog-identity requirement as the core job (the Sheet/Transaction
+      # boundary tests commit to scratch repos).
+      - name: Configure git identity (commit-bearing tests write reflogs)
+        run: |
+          git config --global user.name "gitsheets CI"
+          git config --global user.email "ci@gitsheets.local"
 
       - uses: actions/setup-node@v6
         with:

--- a/plans/sheet-store-core.md
+++ b/plans/sheet-store-core.md
@@ -177,3 +177,22 @@ embedded-engine parity-gate concern.
 - **Tracked for `python-binding`.** The same `CoreTransaction` surface + the
   two-phase protocol drives the Python binding (Pydantic as the host validator);
   the core orchestration is binding-agnostic.
+- **Upstream holo-tree hardening (Issue).** `holo_repo::update_ref` writes a
+  reflog whose committer it reads from ambient **git config** identity, even when
+  the transaction supplies explicit author/committer for the commit. With no
+  `user.name`/`user.email` configured (a fresh CI runner, or a consumer in an
+  unconfigured/bare context) the ref update fails with *"The reflog could not be
+  created or updated."* Worked around for CI by configuring a git identity in
+  `rust-core.yml` (matching hologit's own CI), but the proper fix is upstream:
+  `update_ref` should derive the reflog identity from the commit's committer (or
+  accept an explicit one / allow suppressing the reflog) so a ref update never
+  depends on ambient git config. Per the holo-tree hardening mandate, file against
+  hologit.
+- **`sort = true` locale collation via boa (decide at `node-binding-thin`).**
+  Array-field locale sorting (`sort = true`'s `localeCompare`) currently runs
+  through the boa engine, which lacks `Intl` — so for non-ASCII / case-sensitive
+  strings it sorts by code unit, diverging from the JS `node:vm` ICU collation
+  (the documented boa parity-gate trade-off). For ASCII data (the common case)
+  there is no divergence. Before the cutover, decide whether locale array-sort
+  fidelity warrants native ICU collation in Rust (e.g. the `icu`/`feruca` crate)
+  instead of boa — a behavior call with an i18n-data blast radius.

--- a/plans/sheet-store-core.md
+++ b/plans/sheet-store-core.md
@@ -1,5 +1,6 @@
 ---
-status: in-progress
+status: done
+pr: https://github.com/JarvusInnovations/gitsheets/pull/210
 depends: [record-query-index]
 specs:
   - specs/rust-core.md
@@ -44,13 +45,28 @@ rules. **Out:** the binding-level idiomatic surface and the consumer validator
 
 ## Validation
 
-- [ ] The full transaction lifecycle (commit, no-op, `parent_moved`, strict mode)
-      matches the JS behavior and the specs.
-- [ ] An upsert through the core produces the same commit/tree as the JS path for
-      the same input (post-rebaseline), incl. correct author/committer identity.
-- [ ] The consumer-validator callback fires at the right point and can reject a
-      write before any bytes are written.
-- [ ] The existing transaction/Sheet/Store test suite passes against the core.
+- [x] The full transaction lifecycle (commit, no-op, `parent_moved`, strict mode)
+      matches the JS behavior and the specs. Commit / no-op (tree-hash equality) /
+      `parent_moved` / `transaction_in_progress` proven in both the Rust lifecycle
+      suite (`transaction.rs` tests) and the napi boundary suite
+      (`test/sheet-store.mjs`). Strict mode + the async mutex *queueing* are
+      host-`Repository` concerns (the core owns the detectable
+      `transaction_in_progress` + `parent_moved` guards) — see Notes.
+- [x] An upsert through the core produces the expected commit/tree for the same
+      input (against the **new canonical form**, per the plan's bytes-vs-semantics
+      note — NOT the v1.0 `@iarna` bytes), incl. correct author/committer identity.
+      `full_upsert_commits_with_identity_trailers_and_record` (Rust) +
+      `full upsert commits with identity, trailers, and the written record` (node).
+- [x] The consumer-validator callback fires at the right point (the two-phase
+      protocol) and can reject a write before any bytes are written. Demonstrated
+      end-to-end in `the consumer validator can REJECT a write before any bytes are
+      written` (asserts nothing was committed), plus the JSON-Schema phase-1
+      rejection cases.
+- [x] Behavioral parity with the existing transaction/Sheet/Store semantics —
+      relevant cases transcribed/ported to the Rust + napi boundary suites (lean on
+      the existing JS suite as the oracle). The main JS suite stays green and
+      independent: `npm test` (287 + 66) + `npm run type-check` pass; the main
+      build never imports the `.node` addon.
 
 ## Risks / unknowns
 
@@ -63,8 +79,101 @@ rules. **Out:** the binding-level idiomatic surface and the consumer validator
 
 ## Notes
 
-(Populated at closeout.)
+**What was built.** Four core modules on top of the merged record/query/index
+engine, plus a napi boundary driver:
+
+- `config.rs` — `SheetConfig` parsing (`loadConfig` port): root, path template,
+  `fields.<f>.sort` rules, `[gitsheet.schema]`, `[gitsheet.format]`, with the
+  markdown body-presence rules. The body↔template *collision* check moved into
+  `Sheet::open` (it needs the compiled template's `get_field_names()`).
+- `sheet.rs` — the compiled-once `Sheet` handle (config + `Template` +
+  `CompiledSchema` + array-sort comparators + index registry + boa `Engine`),
+  composing the lower primitives into `prepare_upsert` / `stage_upsert` /
+  `will_change` / `delete_at_path` / `clear` / `normalize_record` /
+  `path_for_record` / `find_by_*_index`.
+- `transaction.rs` — `Transaction::begin`/`finalize` with parent resolution,
+  optimistic `parent_moved`, no-op detection, `commit_tree` + CAS `update_ref`,
+  trailer validation + commit-message formatting, and a process-wide
+  single-writer registry.
+- `store.rs` — `discover_sheets` + `check_validators`.
+- `gitsheets-napi` — a stateful `CoreTransaction` exposing the state machine, plus
+  `coreDiscoverSheets` / `coreCheckValidators`, with a `node --test` boundary suite.
+
+**The two-phase consumer-validator protocol.** The consumer validator
+(Zod/Pydantic/Standard Schema) runs **host-side** and stays in the binding; the
+core never calls back into the host mid-operation. The write is split:
+**phase 1** `prepare_upsert` (non-mutating) shape-validates (JSON Schema),
+normalizes, renders the path, runs the unique-index conflict check, and
+serializes, returning the candidate (incl. the normalized record marshalled back
+to JS); **the host gate** runs the consumer validator on that candidate and
+throws to reject; **phase 3** `stage_upsert` (mutating) does the rename-delete +
+blob write. Phases 1 and 3 are **separate FFI calls with no core lock held
+between them**, so the host callback can never re-enter the core while it holds
+state — the re-entrancy hazard from the plan's Risks is structurally avoided
+(rather than mitigated by a callback). A transforming validator is supported by
+re-invoking `prepare_upsert` on the transformed record before `stage_upsert`
+(`prepare_upsert` is idempotent and cheap). Demonstrated end-to-end, asserting a
+rejected record is never committed.
+
+**Bytes vs. semantics (per the plan's two design points).** Behavioral parity
+(lifecycle, `parent_moved`, no-op, identity, validation rejection) is verified
+against the existing JS semantics; byte/tree-level correctness is verified against
+the **new Rust canonical form** (key-sorted `toml`-crate bytes), NOT the v1.0
+`@iarna` on-disk bytes — matching the old bytes is the cutover's concern
+(`node-binding-thin`). E.g. the boundary suite asserts the written blob is the
+canonical `email = "..."\nslug = "..."\n`.
+
+**Markdown-format deferral (resolved).** The frontmatter/body codec is **deferred**
+to a follow-up. Rationale: the TOML pipeline is the v1.0 bytes-authority capstone;
+the markdown codec (frontmatter parse/serialize, H1 title extraction, lazy body)
+is a distinct format codec that belongs with the binding re-thin / a dedicated
+format-core plan. The core still *parses + validates* markdown config (so config
+parity holds), but record ops on a markdown sheet fail loudly with
+`config_invalid` ("not yet implemented") rather than writing wrong bytes. TOML
+(the default and the vast majority of sheets) is fully implemented.
+
+**Index build-caching deferral (resolved).** Implemented at the `Sheet` level: a
+cache keyed by the **data-subtree hash**, built once on demand and dropped on any
+mutation (`stage_upsert` / `delete` / `clear` / `define_index`) or when the tree
+hash moves — the `#ensureIndexBuilt` state machine, wrapping the pure
+`UniqueIndex`/`MultiIndex` build primitives. The pre-write unique-conflict check
+in `prepare_upsert` uses it.
+
+**Behavioral-parity coverage.** 110 `gitsheets-core` tests (incl. the lifecycle +
+pipeline integration tests on throwaway gix repos) and 61 napi boundary tests
+(11 new in `sheet-store.mjs`). The main JS suite (287 + 66) stays green and never
+imports the `.node` addon.
+
+**Design decisions.** (1) `time_seconds` / `offset_minutes` are passed *into* the
+core for the commit signature — the host owns the wall-clock + local-timezone
+offset (exactly as JS `commitTreeWithRepo` computes them), keeping the core
+deterministic. (2) The single-writer **registry** in the core detects overlapping
+opens (`transaction_in_progress`); the async *queueing* of contended transactions
+is host-runtime-specific (Node `AsyncLocalStorage`, Python `asyncio`) and stays in
+the binding. (3) Array-field sort comparators (incl. `sort = true`'s
+`localeCompare`) are compiled into boa and run there for `node:vm` parity, rather
+than reimplemented in Rust — the locale/`Intl` divergence is the spec's existing
+embedded-engine parity-gate concern.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Deferred to plan / follow-up — markdown/mdx record codec.** Implement the
+  frontmatter+body format (parse/serialize, H1 title extraction, lazy body,
+  `allowMissingBody`) in the core so markdown sheets round-trip. Config is already
+  parsed/validated; record ops currently fail loudly. Belongs with
+  `node-binding-thin` or a dedicated format-core plan.
+- **Deferred (per plan) — the `--working` working-tree path.** Out of scope here;
+  to be addressed when the working-tree surface is lifted.
+- **Tracked for `node-binding-thin`.** Re-thin the Node `Sheet`/`Transaction`/
+  `Store`/`Repository` onto `CoreTransaction` + the core handles: thread the
+  consumer Standard Schema validator through the two-phase gate; enforce **strict
+  mode** (`requireExplicitTransactions` → `transaction_required`) and the
+  permissive auto-transaction host-side; normalize the core's `Option::None`
+  result fields to `null` for the public API (the raw napi surface returns
+  `undefined`); wire the async single-writer mutex/queueing + `AsyncLocalStorage`
+  nesting detection; map the rename `RECORD_PATH_KEY` annotation to the core's
+  explicit `previous_path`; and cut over the on-disk bytes (the `@iarna` →
+  canonical re-baseline).
+- **Tracked for `python-binding`.** The same `CoreTransaction` surface + the
+  two-phase protocol drives the Python binding (Pydantic as the host validator);
+  the core orchestration is binding-agnostic.

--- a/rust/gitsheets-core/src/config.rs
+++ b/rust/gitsheets-core/src/config.rs
@@ -1,0 +1,377 @@
+//! Sheet configuration — parsing `.gitsheets/<name>.toml` into a [`SheetConfig`].
+//!
+//! This is the first half of the `Sheet` state machine: turning the persisted
+//! `[gitsheet]` definition block into the typed shape the upsert/query pipeline
+//! composes (path template source, field sort rules, JSON Schema, storage
+//! format). A behavior-preserving Rust port of `loadConfig` in
+//! `packages/gitsheets/src/sheet.ts`, per `specs/api/sheet.md` and
+//! `specs/api/store.md`.
+//!
+//! Config parsing is a **definition** concern, so malformed/missing config maps
+//! to the `ConfigError` taxonomy ([`Error::ConfigMissing`] /
+//! [`Error::ConfigInvalid`]) — never a record error.
+
+use crate::error::{Error, Result};
+use crate::value::Value;
+use indexmap::IndexMap;
+
+/// A sort rule for an array-valued field (`[gitsheet.fields.<name>] sort = …`).
+/// Mirrors the JS `SortRule` union: a boolean, a list of field names (ASC each),
+/// a `{field: "ASC"|"DESC"}` directive map, or a raw-JS comparator body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SortRule {
+    /// `true` → natural/locale-ish ascending; `false` → leave order untouched.
+    All(bool),
+    /// `["a", "b"]` → compare by each field, ascending.
+    Fields(Vec<String>),
+    /// `{a = "ASC", b = "DESC"}` → compare by each field in the given direction.
+    Directives(Vec<(String, SortDir)>),
+    /// A raw-JS comparator body `(a, b) => { <rule> }` — the escape hatch.
+    Raw(String),
+}
+
+/// A sort direction in a `{field: dir}` directive map.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortDir {
+    Asc,
+    Desc,
+}
+
+/// Per-field configuration (`[gitsheet.fields.<name>]`). Only `sort` is
+/// meaningful in v1.0.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FieldConfig {
+    pub sort: Option<SortRule>,
+}
+
+/// The storage format a sheet's records are written as.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FormatKind {
+    Toml,
+    Markdown,
+    Mdx,
+}
+
+impl FormatKind {
+    /// The file extension (with leading dot) records of this format are written
+    /// as. Matches the JS `Format.extension`.
+    pub fn extension(self) -> &'static str {
+        match self {
+            FormatKind::Toml => ".toml",
+            FormatKind::Markdown => ".md",
+            FormatKind::Mdx => ".mdx",
+        }
+    }
+
+    fn from_type(s: &str) -> Result<Self> {
+        match s {
+            "toml" => Ok(FormatKind::Toml),
+            "markdown" => Ok(FormatKind::Markdown),
+            "mdx" => Ok(FormatKind::Mdx),
+            other => Err(Error::ConfigInvalid {
+                message: format!("unknown sheet format {other:?} — registered: toml, markdown, mdx"),
+            }),
+        }
+    }
+}
+
+/// Resolved `[gitsheet.format]` config. Defaults to `type = "toml"`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormatConfig {
+    pub kind: FormatKind,
+    /// The field holding the body text (markdown/mdx only).
+    pub body: Option<String>,
+    /// The field denormalized from the body's first H1 (markdown/mdx only).
+    pub title: Option<String>,
+}
+
+impl FormatConfig {
+    pub fn extension(&self) -> &'static str {
+        self.kind.extension()
+    }
+}
+
+/// A parsed sheet definition.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SheetConfig {
+    /// The data subtree this sheet's records live under (default `.`).
+    pub root: String,
+    /// The path-template source (`gitsheet.path`).
+    pub path: String,
+    /// Per-field config, keyed by field name.
+    pub fields: IndexMap<String, FieldConfig>,
+    /// The `[gitsheet.schema]` JSON Schema, if present.
+    pub schema: Option<Value>,
+    /// The storage format.
+    pub format: FormatConfig,
+}
+
+fn as_table(v: &Value) -> Option<&IndexMap<String, Value>> {
+    match v {
+        Value::Table(t) => Some(t),
+        _ => None,
+    }
+}
+
+fn as_str(v: &Value) -> Option<&str> {
+    match v {
+        Value::String(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// Parse a sheet config from the already-parsed config-file [`Value`]. `source`
+/// names the config path for diagnostics (e.g. `.gitsheets/users.toml`).
+///
+/// Mirrors `loadConfig` (`sheet.ts`): requires a `[gitsheet]` table with a
+/// non-empty `path`; reads `root` (default `.`), `fields.<f>.sort`, `schema`,
+/// and `[gitsheet.format]`; enforces the body-field rules (markdown requires a
+/// body; the body field must not collide with the path template).
+pub fn parse_config(raw: &Value, source: &str) -> Result<SheetConfig> {
+    let top = as_table(raw).ok_or_else(|| Error::ConfigInvalid {
+        message: format!("{source}: config is not a table"),
+    })?;
+    let gitsheet = top
+        .get("gitsheet")
+        .and_then(as_table)
+        .ok_or_else(|| Error::ConfigInvalid {
+            message: format!("{source}: missing [gitsheet] table"),
+        })?;
+
+    // path (required, non-empty)
+    let path = gitsheet
+        .get("path")
+        .and_then(as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| Error::ConfigInvalid {
+            message: format!("{source}: gitsheet.path must be a non-empty string"),
+        })?
+        .to_string();
+
+    // root (default ".")
+    let root = match gitsheet.get("root") {
+        None => ".".to_string(),
+        Some(Value::String(s)) => s.clone(),
+        Some(_) => {
+            return Err(Error::ConfigInvalid {
+                message: format!("{source}: gitsheet.root must be a string"),
+            })
+        }
+    };
+
+    // fields
+    let mut fields: IndexMap<String, FieldConfig> = IndexMap::new();
+    if let Some(fields_val) = gitsheet.get("fields") {
+        let fields_table = as_table(fields_val).ok_or_else(|| Error::ConfigInvalid {
+            message: format!("{source}: gitsheet.fields must be a table"),
+        })?;
+        for (fname, fcfg) in fields_table {
+            let Some(fcfg_table) = as_table(fcfg) else {
+                continue;
+            };
+            let mut entry = FieldConfig::default();
+            if let Some(sort) = fcfg_table.get("sort") {
+                entry.sort = Some(parse_sort_rule(sort, source, fname)?);
+            }
+            fields.insert(fname.clone(), entry);
+        }
+    }
+
+    // schema
+    let schema = match gitsheet.get("schema") {
+        None => None,
+        Some(v @ Value::Table(_)) => Some(v.clone()),
+        Some(_) => {
+            return Err(Error::ConfigInvalid {
+                message: format!(
+                    "{source}: gitsheet.schema must be a table representing a JSON Schema"
+                ),
+            })
+        }
+    };
+
+    // format
+    let format = parse_format(gitsheet.get("format"), source)?;
+
+    // Body-field presence rules. (The body↔template *collision* check needs the
+    // compiled template's field names, so it lives in `Sheet::open`.)
+    if format.body.is_some() {
+        if !matches!(format.kind, FormatKind::Markdown | FormatKind::Mdx) {
+            return Err(Error::ConfigInvalid {
+                message: format!(
+                    "{source}: [gitsheet.format].body only applies to markdown/mdx formats"
+                ),
+            });
+        }
+    } else if matches!(format.kind, FormatKind::Markdown | FormatKind::Mdx) {
+        return Err(Error::ConfigInvalid {
+            message: format!(
+                "{source}: [gitsheet.format].body is required when type is \"markdown\" or \"mdx\""
+            ),
+        });
+    }
+
+    Ok(SheetConfig {
+        root,
+        path,
+        fields,
+        schema,
+        format,
+    })
+}
+
+fn parse_format(raw: Option<&Value>, source: &str) -> Result<FormatConfig> {
+    let Some(raw) = raw else {
+        return Ok(FormatConfig {
+            kind: FormatKind::Toml,
+            body: None,
+            title: None,
+        });
+    };
+    let table = as_table(raw).ok_or_else(|| Error::ConfigInvalid {
+        message: format!("{source}: [gitsheet.format] must be a table"),
+    })?;
+    let kind = match table.get("type") {
+        Some(Value::String(s)) => FormatKind::from_type(s).map_err(|e| Error::ConfigInvalid {
+            message: format!("{source}: {}", e.message()),
+        })?,
+        _ => FormatKind::Toml,
+    };
+    let body = table.get("body").and_then(as_str).map(|s| s.to_string());
+    let title = table.get("title").and_then(as_str).map(|s| s.to_string());
+    Ok(FormatConfig { kind, body, title })
+}
+
+fn parse_sort_rule(sort: &Value, source: &str, field: &str) -> Result<SortRule> {
+    match sort {
+        Value::Boolean(b) => Ok(SortRule::All(*b)),
+        Value::String(s) => Ok(SortRule::Raw(s.clone())),
+        Value::Array(items) => {
+            let mut names = Vec::with_capacity(items.len());
+            for it in items {
+                match it {
+                    Value::String(s) => names.push(s.clone()),
+                    _ => {
+                        return Err(Error::ConfigInvalid {
+                            message: format!(
+                                "{source}: gitsheet.fields.{field}.sort[] must be string field names"
+                            ),
+                        })
+                    }
+                }
+            }
+            Ok(SortRule::Fields(names))
+        }
+        Value::Table(map) => {
+            let mut directives = Vec::with_capacity(map.len());
+            for (k, v) in map {
+                let dir = match v {
+                    Value::String(s) if s == "ASC" => SortDir::Asc,
+                    Value::String(s) if s == "DESC" => SortDir::Desc,
+                    _ => {
+                        return Err(Error::ConfigInvalid {
+                            message: format!(
+                                "{source}: gitsheet.fields.{field}.sort.{k} must be 'ASC' or 'DESC'"
+                            ),
+                        })
+                    }
+                };
+                directives.push((k.clone(), dir));
+            }
+            Ok(SortRule::Directives(directives))
+        }
+        _ => Err(Error::ConfigInvalid {
+            message: format!("{source}: gitsheet.fields.{field}.sort has invalid shape"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical;
+
+    fn cfg(toml: &str) -> Result<SheetConfig> {
+        let v = canonical::parse(toml).expect("parse toml");
+        parse_config(&v, ".gitsheets/test.toml")
+    }
+
+    #[test]
+    fn parses_minimal_toml_sheet() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n").unwrap();
+        assert_eq!(c.path, "${{ slug }}");
+        assert_eq!(c.root, "people");
+        assert_eq!(c.format.kind, FormatKind::Toml);
+        assert_eq!(c.format.extension(), ".toml");
+    }
+
+    #[test]
+    fn defaults_root_to_dot() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n").unwrap();
+        assert_eq!(c.root, ".");
+    }
+
+    #[test]
+    fn missing_gitsheet_table_is_config_invalid() {
+        let err = cfg("foo = 1\n").unwrap_err();
+        assert_eq!(err.code(), "config_invalid");
+    }
+
+    #[test]
+    fn empty_path_is_config_invalid() {
+        let err = cfg("[gitsheet]\npath = ''\n").unwrap_err();
+        assert_eq!(err.code(), "config_invalid");
+    }
+
+    #[test]
+    fn parses_field_sort_rules() {
+        let c = cfg(
+            "[gitsheet]\npath = '${{ slug }}'\n[gitsheet.fields.tags]\nsort = true\n[gitsheet.fields.cats]\nsort = ['a', 'b']\n[gitsheet.fields.dirs]\nsort = { a = 'ASC', b = 'DESC' }\n",
+        )
+        .unwrap();
+        assert_eq!(c.fields["tags"].sort, Some(SortRule::All(true)));
+        assert_eq!(
+            c.fields["cats"].sort,
+            Some(SortRule::Fields(vec!["a".into(), "b".into()]))
+        );
+        assert_eq!(
+            c.fields["dirs"].sort,
+            Some(SortRule::Directives(vec![
+                ("a".into(), SortDir::Asc),
+                ("b".into(), SortDir::Desc)
+            ]))
+        );
+    }
+
+    #[test]
+    fn markdown_requires_body() {
+        let err = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\n")
+            .unwrap_err();
+        assert_eq!(err.code(), "config_invalid");
+        assert!(err.message().contains("body is required"));
+    }
+
+    #[test]
+    fn body_only_on_markdown() {
+        let err = cfg(
+            "[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'toml'\nbody = 'content'\n",
+        )
+        .unwrap_err();
+        assert_eq!(err.code(), "config_invalid");
+    }
+    #[test]
+    fn markdown_with_valid_body_parses() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'content'\ntitle = 'name'\n")
+            .unwrap();
+        assert_eq!(c.format.kind, FormatKind::Markdown);
+        assert_eq!(c.format.body.as_deref(), Some("content"));
+        assert_eq!(c.format.title.as_deref(), Some("name"));
+        assert_eq!(c.format.extension(), ".md");
+    }
+
+    #[test]
+    fn parses_schema_block() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.schema]\ntype = 'object'\n").unwrap();
+        assert!(c.schema.is_some());
+    }
+}

--- a/rust/gitsheets-core/src/index.rs
+++ b/rust/gitsheets-core/src/index.rs
@@ -70,6 +70,13 @@ impl UniqueIndex {
     pub fn lookup(&self, key: &str) -> Option<&Value> {
         self.map.get(key).map(|(_, record)| record)
     }
+
+    /// The storage path of the record owning `key`, if any — used by the
+    /// `Sheet` pre-write unique-conflict check to compare the candidate's
+    /// rendered path against the existing owner.
+    pub fn lookup_path(&self, key: &str) -> Option<&str> {
+        self.map.get(key).map(|(path, _)| path.as_str())
+    }
 }
 
 impl MultiIndex {

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -18,6 +18,7 @@
 //! top of this substrate. See [`specs/rust-core.md`](../../../specs/rust-core.md).
 
 pub mod canonical;
+pub mod config;
 pub mod diff;
 pub mod engine;
 pub mod error;
@@ -25,10 +26,14 @@ pub mod index;
 pub mod path_template;
 pub mod query;
 pub mod record;
+pub mod sheet;
+pub mod store;
+pub mod transaction;
 pub mod validation;
 pub mod value;
 
 pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};
+pub use config::{FieldConfig, FormatConfig, FormatKind, SheetConfig, SortDir, SortRule};
 pub use diff::{apply_merge_patch, create_patch, MergePatch, PatchOp, PatchOpKind, PatchValue};
 pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
 pub use index::{MultiIndex, UniqueIndex};
@@ -37,6 +42,8 @@ pub use record::{
     DeleteOutcome, RecordChange, RecordDiff, RecordStatus, WriteOutcome, EMPTY_TREE_HASH,
     TOML_EXTENSION,
 };
+pub use sheet::{Sheet, StageOutcome, UpsertCandidate, WillChange};
+pub use transaction::{Author, Transaction, TransactionOptions, TransactionResult};
 pub use value::{Datetime, DatetimeKind, Value};
 
 /// Identity over a batch of records — the minimal exercise of the value type

--- a/rust/gitsheets-core/src/sheet.rs
+++ b/rust/gitsheets-core/src/sheet.rs
@@ -1,0 +1,938 @@
+//! The `Sheet` half of the orchestration state machine.
+//!
+//! A [`Sheet`] is a compiled sheet definition: the parsed [`SheetConfig`] plus
+//! the path [`Template`], the [`CompiledSchema`], the array-field sort
+//! comparators, and the secondary-index registry — **compiled once on open** and
+//! reused across every operation (the persistent-handle contract from
+//! [`specs/rust-core.md`](../../../specs/rust-core.md)). It composes the lower
+//! primitives ([`crate::canonical`], [`crate::path_template`],
+//! [`crate::validation`], [`crate::record`], [`crate::index`]) into the
+//! upsert / willChange / delete / clear pipeline of
+//! [`specs/api/sheet.md`](../../../specs/api/sheet.md), behavior-preserving
+//! against `packages/gitsheets/src/sheet.ts`.
+//!
+//! ## The two-phase consumer-validator protocol
+//!
+//! The consumer's runtime validator (Standard Schema / Zod / Pydantic) runs
+//! **host-side** and stays in the binding — the core never calls back into the
+//! host mid-operation (re-entrancy hazard). The write is therefore split into:
+//!
+//! 1. **[`Sheet::prepare_upsert`]** *(non-mutating)* — body guard, JSON-Schema
+//!    shape validation, canonical normalization, path render, unique-index
+//!    conflict check, and canonical serialization, returning an
+//!    [`UpsertCandidate`]. No tree mutation.
+//! 2. **host gate** — the binding runs the consumer validator on the candidate's
+//!    normalized record; a rejection throws *before* phase 3, so no bytes are
+//!    written.
+//! 3. **[`Sheet::stage_upsert`]** *(mutating)* — rename-delete + blob write into
+//!    the transaction tree.
+//!
+//! Because phases 1 and 3 are separate calls with **no core lock held between
+//! them**, the host callback never re-enters the core while it holds state. A
+//! transforming validator is supported by re-invoking `prepare_upsert` on the
+//! transformed record before `stage_upsert` (prepare is idempotent and cheap).
+
+use std::collections::HashMap;
+
+use holo_tree::MutableTree;
+use indexmap::IndexMap;
+
+use crate::canonical;
+use crate::config::{self, FormatKind, SheetConfig, SortRule};
+use crate::engine::{Engine, SnippetError, SnippetHandle};
+use crate::error::{Error, Result};
+use crate::index::{MultiIndex, UniqueIndex};
+use crate::path_template::Template;
+use crate::record::{self};
+use crate::validation::CompiledSchema;
+use crate::value::Value;
+
+/// A secondary-index definition (`defineIndex`).
+struct IndexDef {
+    name: String,
+    unique: bool,
+    key_handle: SnippetHandle,
+}
+
+/// Built indexes cached against a single tree hash. Invalidated (dropped) when
+/// the sheet's data tree moves — the `#ensureIndexBuilt` state machine from
+/// `sheet.ts`, now keyed by the data subtree's hash.
+struct IndexCache {
+    tree_hash: String,
+    unique: HashMap<String, UniqueIndex>,
+    multi: HashMap<String, MultiIndex>,
+}
+
+/// The candidate an upsert would write — the output of phase 1 of the two-phase
+/// protocol. Carries everything `stage_upsert` needs plus the willChange info.
+#[derive(Clone, Debug)]
+pub struct UpsertCandidate {
+    /// The sheet-relative path the record renders to (no extension).
+    pub record_path: String,
+    /// The path the record was previously stored at (rename source), if any.
+    pub previous_path: Option<String>,
+    /// The canonical bytes that would be written.
+    pub next_text: String,
+    /// The normalized record (post shape-validation + canonical normalization).
+    pub normalized: Value,
+}
+
+/// The result of [`Sheet::will_change`] — pre-flight idempotency for upsert.
+#[derive(Clone, Debug)]
+pub struct WillChange {
+    pub changed: bool,
+    pub path: String,
+    pub current_blob_hash: Option<String>,
+    pub next_text: String,
+}
+
+/// The result of [`Sheet::stage_upsert`].
+#[derive(Clone, Debug)]
+pub struct StageOutcome {
+    pub blob_hash: String,
+    pub path: String,
+}
+
+/// A compiled sheet handle.
+///
+/// Holds a `!Send` boa [`Engine`] (path/sort/index snippets), so it is
+/// constructed and used on its owning thread — the thread-confinement the spec
+/// requires. The data tree it operates on is passed in per call (owned by the
+/// [`Transaction`](crate::transaction::Transaction)); the Sheet itself never
+/// owns a tree.
+pub struct Sheet {
+    name: String,
+    config: SheetConfig,
+    /// Effective data base: `join(open_root, config.root, prefix)`.
+    base: String,
+    template: Template,
+    schema: Option<CompiledSchema>,
+    /// Per-field array-sort comparators, keyed by field name. `All(false)` rules
+    /// have no entry (they are a no-op).
+    sort_handles: IndexMap<String, SnippetHandle>,
+    indexes: Vec<IndexDef>,
+    index_cache: Option<IndexCache>,
+    engine: Engine,
+}
+
+impl Sheet {
+    /// Open a sheet by reading + parsing its `.gitsheets/<name>.toml` config from
+    /// `tree`, then compiling the template, schema, and sort comparators once.
+    ///
+    /// `config_blob_path` is the full tree path to the config blob
+    /// (`<open_root>/.gitsheets/<name>.toml`). `open_root` is the
+    /// `Repository.openSheet({ root })` scoping (default `"."`); `prefix` is the
+    /// optional sub-prefix under `config.root`. A missing config is
+    /// [`Error::ConfigMissing`].
+    pub fn open(
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        name: &str,
+        config_blob_path: &str,
+        open_root: &str,
+        prefix: &str,
+    ) -> Result<Self> {
+        let bytes = tree
+            .read_blob(repo, config_blob_path)
+            .map_err(record::map_ht)?
+            .ok_or_else(|| Error::ConfigMissing {
+                message: format!("sheet config not found at {config_blob_path}"),
+            })?;
+        let text = String::from_utf8(bytes).map_err(|e| Error::ConfigInvalid {
+            message: format!("{config_blob_path}: config is not valid UTF-8: {e}"),
+        })?;
+        let raw = canonical::parse(&text)?;
+        let config = config::parse_config(&raw, config_blob_path)?;
+
+        let base = join_path(&[open_root, &config.root, prefix]);
+
+        let mut engine = Engine::new()?;
+        let template = Template::compile(&config.path, &mut engine)?;
+
+        // Body↔template collision: the body field must not also identify the
+        // record. Checked here (not in `parse_config`) because it needs the
+        // compiled template's field names — matching the JS guard against
+        // `Template.getFieldNames()`.
+        if let Some(body) = &config.format.body {
+            if template.get_field_names().iter().any(|f| f == body) {
+                return Err(Error::ConfigInvalid {
+                    message: format!(
+                        "{config_blob_path}: [gitsheet.format].body = {body:?} collides with the path template — the body field cannot also identify the record"
+                    ),
+                });
+            }
+        }
+
+        let schema = match &config.schema {
+            Some(s) => Some(CompiledSchema::compile(s)?),
+            None => None,
+        };
+
+        // Compile array-field sort comparators once.
+        let mut sort_handles = IndexMap::new();
+        for (field, fcfg) in &config.fields {
+            if let Some(rule) = &fcfg.sort {
+                if let Some(src) = comparator_source(rule) {
+                    let handle = engine.compile(&src)?;
+                    sort_handles.insert(field.clone(), handle);
+                }
+            }
+        }
+
+        Ok(Sheet {
+            name: name.to_string(),
+            config,
+            base,
+            template,
+            schema,
+            sort_handles,
+            indexes: Vec::new(),
+            index_cache: None,
+            engine,
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn config(&self) -> &SheetConfig {
+        &self.config
+    }
+
+    /// The effective data base where this sheet's records live.
+    pub fn base(&self) -> &str {
+        &self.base
+    }
+
+    fn extension(&self) -> &'static str {
+        self.config.format.extension()
+    }
+
+    /// Guard: the core's TOML pipeline is the v1.0 bytes-authority. Markdown/mdx
+    /// records (frontmatter codec) are deferred to a follow-up — see the plan
+    /// Notes — so a markdown sheet's record operations fail loudly rather than
+    /// writing the wrong bytes.
+    fn require_toml(&self) -> Result<()> {
+        if self.config.format.kind != FormatKind::Toml {
+            return Err(Error::ConfigInvalid {
+                message: format!(
+                    "sheet {:?}: the markdown/mdx record codec is not yet implemented in the Rust core (deferred — see plans/sheet-store-core.md)",
+                    self.name
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Render the path a record maps to (raw record, not normalized) — matches
+    /// `Sheet.pathForRecord`. Used to resolve a record's path for delete.
+    pub fn path_for_record(&mut self, record: &Value) -> Result<String> {
+        self.template.render(record, &mut self.engine)
+    }
+
+    /// Apply canonical normalization — array-field sorts then deep key sort —
+    /// without validating or writing. Matches `Sheet.normalizeRecord`.
+    pub fn normalize_record(&mut self, record: &Value) -> Result<Value> {
+        let mut out = record.clone();
+        if let Value::Table(map) = &mut out {
+            for (field, handle) in &self.sort_handles {
+                if let Some(Value::Array(items)) = map.get_mut(field) {
+                    sort_array(&mut self.engine, *handle, items)?;
+                }
+            }
+        }
+        Ok(canonical::normalize(&out))
+    }
+
+    // ── two-phase upsert ────────────────────────────────────────────────────
+
+    /// Phase 1 of the upsert protocol *(non-mutating)*: body guard, JSON-Schema
+    /// shape validation, canonical normalization, path render, unique-index
+    /// conflict check, and canonical serialization. Returns the candidate the
+    /// binding hands to the consumer validator before phase 3.
+    ///
+    /// `previous_path` is the record's prior storage path (rename source) — the
+    /// host's `RECORD_PATH_KEY` annotation, passed explicitly since symbols are
+    /// a host concern. `allow_missing_body` opts a markdown sheet out of the
+    /// body-presence guard.
+    pub fn prepare_upsert(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record: &Value,
+        previous_path: Option<String>,
+        allow_missing_body: bool,
+    ) -> Result<UpsertCandidate> {
+        self.require_toml()?;
+        let _ = allow_missing_body; // body guard only applies to markdown (deferred)
+
+        // JSON-Schema shape validation (the core's persisted-shape pass). The
+        // consumer Standard Schema validator runs host-side between phases.
+        if let Some(schema) = &self.schema {
+            schema.validate_or_error(record)?;
+        }
+
+        let normalized = self.normalize_record(record)?;
+        let record_path = self.template.render(&normalized, &mut self.engine)?;
+        if record_path.is_empty() {
+            return Err(Error::PathRenderFailed {
+                message: format!(
+                    "could not generate any path for record in sheet \"{}\"",
+                    self.name
+                ),
+            });
+        }
+
+        // Pre-write unique-index conflict check (against the built index for the
+        // current tree) — throws before any mutation.
+        self.check_unique_conflicts(repo, tree, &normalized, &record_path)?;
+
+        let next_text = canonical::serialize(&normalized)?;
+
+        Ok(UpsertCandidate {
+            record_path,
+            previous_path,
+            next_text,
+            normalized,
+        })
+    }
+
+    /// Phase 3 *(mutating)*: rename-delete the old path (if the record moved) and
+    /// write the candidate's bytes into `tree`. Returns the blob hash + path.
+    /// Invalidates the index cache (the tree just changed).
+    pub fn stage_upsert(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        candidate: &UpsertCandidate,
+    ) -> Result<StageOutcome> {
+        if let Some(prev) = &candidate.previous_path {
+            if prev != &candidate.record_path {
+                let old_full = join_record_path(&self.base, prev, self.extension());
+                // Best effort — the old path may not exist.
+                let _ = tree.delete_child_deep(repo, &old_full).map_err(record::map_ht);
+            }
+        }
+        let full = join_record_path(&self.base, &candidate.record_path, self.extension());
+        let blob_id = tree
+            .write_child(repo, &full, &candidate.next_text)
+            .map_err(record::map_ht)?;
+        self.index_cache = None;
+        Ok(StageOutcome {
+            blob_hash: blob_id.to_string(),
+            path: candidate.record_path.clone(),
+        })
+    }
+
+    /// Pre-flight idempotency check for upsert *(non-mutating)*. Runs the same
+    /// phase-1 pipeline, then compares the resulting bytes to the existing blob.
+    /// Matches `Sheet.willChange`.
+    pub fn will_change(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record: &Value,
+        previous_path: Option<String>,
+        allow_missing_body: bool,
+    ) -> Result<WillChange> {
+        let candidate = self.prepare_upsert(repo, tree, record, previous_path, allow_missing_body)?;
+        let full = join_record_path(&self.base, &candidate.record_path, self.extension());
+        match read_blob_text(repo, tree, &full)? {
+            None => Ok(WillChange {
+                changed: true,
+                path: candidate.record_path,
+                current_blob_hash: None,
+                next_text: candidate.next_text,
+            }),
+            Some((hash, current_text)) => Ok(WillChange {
+                changed: current_text != candidate.next_text,
+                path: candidate.record_path,
+                current_blob_hash: Some(hash),
+                next_text: candidate.next_text,
+            }),
+        }
+    }
+
+    /// Delete a record by its already-resolved sheet-relative path *(mutating)*.
+    /// Throws [`Error::RecordNotFound`] when the path doesn't exist. Cascade-
+    /// deletes the record's attachment directory. Matches `Sheet.delete`.
+    pub fn delete_at_path(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record_path: &str,
+    ) -> Result<()> {
+        self.require_toml()?;
+        let full = join_record_path(&self.base, record_path, self.extension());
+        let existed = tree
+            .read_blob(repo, &full)
+            .map_err(record::map_ht)?
+            .is_some();
+        if !existed {
+            return Err(Error::RecordNotFound {
+                message: format!("{}: no record at {record_path}", self.name),
+            });
+        }
+        tree.delete_child_deep(repo, &full).map_err(record::map_ht)?;
+        // Cascade-delete the attachment directory at `<recordPath>/`, if any.
+        let attach_dir = join_path(&[&self.base, record_path]);
+        let _ = tree.delete_child_deep(repo, &attach_dir).map_err(record::map_ht);
+        self.index_cache = None;
+        Ok(())
+    }
+
+    /// `O(1)` clear of the sheet's data subtree *(mutating)*. Matches
+    /// `Sheet.clear`.
+    pub fn clear(&mut self, repo: &gix::Repository, tree: &mut MutableTree) -> Result<()> {
+        let base_arg = if self.base.is_empty() { "." } else { &self.base };
+        tree.clear_children(repo, base_arg).map_err(record::map_ht)?;
+        self.index_cache = None;
+        Ok(())
+    }
+
+    /// List every record under the sheet's base, in sorted path order.
+    pub fn list(
+        &self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+    ) -> Result<Vec<(String, Value)>> {
+        record::list_records(repo, tree, &self.base, self.extension())
+    }
+
+    // ── indexing ─────────────────────────────────────────────────────────────
+
+    /// Declare a secondary index. `key_snippet` is the full keyFn source
+    /// (e.g. `(r) => r.email.toLowerCase()`), compiled once into the engine.
+    pub fn define_index(&mut self, name: &str, unique: bool, key_snippet: &str) -> Result<()> {
+        let key_handle = self.engine.compile(key_snippet)?;
+        self.indexes.push(IndexDef {
+            name: name.to_string(),
+            unique,
+            key_handle,
+        });
+        self.index_cache = None;
+        Ok(())
+    }
+
+    /// Look up a record by a unique index. Builds the index against the current
+    /// tree on demand (cached). [`Error::IndexNotDefined`] if undeclared.
+    pub fn find_by_unique_index(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        name: &str,
+        key: &str,
+    ) -> Result<Option<Value>> {
+        self.ensure_indexes_built(repo, tree)?;
+        let cache = self.index_cache.as_ref().expect("built");
+        let idx = cache.unique.get(name).ok_or_else(|| Error::IndexNotDefined {
+            message: format!("index {name:?} is not defined on sheet {:?}", self.name),
+        })?;
+        Ok(idx.lookup(key).cloned())
+    }
+
+    /// Look up records by a non-unique index. Builds on demand (cached).
+    pub fn find_by_multi_index(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        name: &str,
+        key: &str,
+    ) -> Result<Vec<Value>> {
+        self.ensure_indexes_built(repo, tree)?;
+        let cache = self.index_cache.as_ref().expect("built");
+        let idx = cache.multi.get(name).ok_or_else(|| Error::IndexNotDefined {
+            message: format!("index {name:?} is not defined on sheet {:?}", self.name),
+        })?;
+        Ok(idx.lookup(key).iter().map(|(_, r)| r.clone()).collect())
+    }
+
+    /// The `#ensureIndexBuilt` state machine: build every declared index against
+    /// the current data-tree hash once, and rebuild only when the hash moves.
+    fn ensure_indexes_built(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+    ) -> Result<()> {
+        let tree_hash = self.data_tree_hash(repo, tree)?;
+        if let Some(cache) = &self.index_cache {
+            if cache.tree_hash == tree_hash {
+                return Ok(());
+            }
+        }
+        let records = record::list_records(repo, tree, &self.base, self.extension())?;
+        let mut unique = HashMap::new();
+        let mut multi = HashMap::new();
+        for def in &self.indexes {
+            if def.unique {
+                unique.insert(
+                    def.name.clone(),
+                    UniqueIndex::build(&records, def.key_handle, &mut self.engine)?,
+                );
+            } else {
+                multi.insert(
+                    def.name.clone(),
+                    MultiIndex::build(&records, def.key_handle, &mut self.engine)?,
+                );
+            }
+        }
+        self.index_cache = Some(IndexCache {
+            tree_hash,
+            unique,
+            multi,
+        });
+        Ok(())
+    }
+
+    /// The hash of the sheet's data subtree (the cache key). Falls back to the
+    /// empty-tree hash when the subtree doesn't exist yet.
+    fn data_tree_hash(&self, repo: &gix::Repository, tree: &mut MutableTree) -> Result<String> {
+        let base_arg = if self.base.is_empty() { "." } else { &self.base };
+        match tree.get_subtree(repo, base_arg).map_err(record::map_ht)? {
+            Some(sub) => Ok(sub.write(repo).map_err(record::map_ht)?.to_string()),
+            None => Ok(record::EMPTY_TREE_HASH.to_string()),
+        }
+    }
+
+    /// Pre-write unique-index conflict check against the built indexes for the
+    /// current tree. Only declared **unique** indexes are checked. A key already
+    /// owned by a *different* path is [`Error::IndexUniqueConflict`].
+    fn check_unique_conflicts(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        normalized: &Value,
+        record_path: &str,
+    ) -> Result<()> {
+        if !self.indexes.iter().any(|d| d.unique) {
+            return Ok(());
+        }
+        self.ensure_indexes_built(repo, tree)?;
+        // Collect conflicts first to release the immutable cache borrow before
+        // re-borrowing the engine for key computation.
+        let defs: Vec<(String, SnippetHandle)> = self
+            .indexes
+            .iter()
+            .filter(|d| d.unique)
+            .map(|d| (d.name.clone(), d.key_handle))
+            .collect();
+        for (name, handle) in defs {
+            let key = match self.engine.call_index_key(handle, normalized) {
+                Ok(Some(k)) => k,
+                Ok(None) => continue,
+                Err(SnippetError::UndefinedReference(m) | SnippetError::Other(m)) => {
+                    return Err(Error::ConfigInvalid {
+                        message: format!("index keyFn failed: {m}"),
+                    })
+                }
+            };
+            let owner_path = self
+                .index_cache
+                .as_ref()
+                .and_then(|c| c.unique.get(&name))
+                .and_then(|idx| idx.lookup_path(&key));
+            if let Some(owner) = owner_path {
+                if owner != record_path {
+                    return Err(Error::IndexUniqueConflict {
+                        message: format!(
+                            "unique index \"{name}\" on sheet \"{}\": key {key:?} is already used by {owner}",
+                            self.name
+                        ),
+                        conflicting_paths: vec![owner.to_string(), record_path.to_string()],
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── comparator source generation (matches the JS `buildSorter`) ───────────────
+
+/// Generate the comparator JS source for a sort rule, or `None` for `All(false)`
+/// (a no-op). Mirrors `buildSorter` in `sheet.ts` so the engine runs the same
+/// comparator the host's `node:vm` path would.
+fn comparator_source(rule: &SortRule) -> Option<String> {
+    match rule {
+        SortRule::All(true) => Some(
+            "(a, b) => ( String(a).localeCompare(String(b), undefined, { sensitivity: 'base', ignorePunctuation: true, numeric: true }) )".to_string(),
+        ),
+        SortRule::All(false) => None,
+        SortRule::Raw(rule) => Some(format!("(a, b) => {{ {rule} }}")),
+        SortRule::Fields(fields) => {
+            let directives: Vec<(&str, i32)> = fields.iter().map(|f| (f.as_str(), 1)).collect();
+            Some(directive_comparator(&directives))
+        }
+        SortRule::Directives(dirs) => {
+            let directives: Vec<(&str, i32)> = dirs
+                .iter()
+                .map(|(f, d)| (f.as_str(), if *d == config::SortDir::Asc { 1 } else { -1 }))
+                .collect();
+            Some(directive_comparator(&directives))
+        }
+    }
+}
+
+fn directive_comparator(directives: &[(&str, i32)]) -> String {
+    let mut lines = String::new();
+    for (field, sign) in directives {
+        let key = json_string(field);
+        lines.push_str(&format!(
+            "if ((a[{key}]) < (b[{key}])) return {}; if ((a[{key}]) > (b[{key}])) return {}; ",
+            -sign, sign
+        ));
+    }
+    lines.push_str("return 0;");
+    format!("(a, b) => {{ {lines} }}")
+}
+
+/// JSON-encode a string for embedding as a JS object key literal.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Stable in-place sort of an array via an engine comparator. Insertion sort —
+/// stable and fine for the small arrays sheet fields hold; each comparison runs
+/// the compiled JS comparator (`< 0` ⇒ a before b, matching `Array.sort`).
+fn sort_array(engine: &mut Engine, handle: SnippetHandle, items: &mut [Value]) -> Result<()> {
+    let n = items.len();
+    for i in 1..n {
+        let mut j = i;
+        while j > 0 {
+            let cmp = compare_via(engine, handle, &items[j - 1], &items[j])?;
+            if cmp > 0.0 {
+                items.swap(j - 1, j);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn compare_via(engine: &mut Engine, handle: SnippetHandle, a: &Value, b: &Value) -> Result<f64> {
+    let result = engine
+        .call(handle, &[a.clone(), b.clone()])
+        .map_err(|e| match e {
+            SnippetError::UndefinedReference(m) | SnippetError::Other(m) => Error::ConfigInvalid {
+                message: format!("array-field sort comparator failed: {m}"),
+            },
+        })?;
+    engine.to_number(&result)
+}
+
+// ── path helpers ──────────────────────────────────────────────────────────────
+
+/// Join tree-path segments, dropping empties / `.` / stray slashes. Matches the
+/// JS `joinTreePath`.
+pub fn join_path(parts: &[&str]) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for seg in parts {
+        for p in seg.split('/') {
+            let p = p.trim_matches('/');
+            if !p.is_empty() && p != "." {
+                out.push(p);
+            }
+        }
+    }
+    out.join("/")
+}
+
+/// Join `base` + `record_path` + `extension` into a full tree path.
+fn join_record_path(base: &str, record_path: &str, extension: &str) -> String {
+    format!("{}{}", join_path(&[base, record_path]), extension)
+}
+
+/// Read a blob's hash + UTF-8 text at a full tree path. `None` when absent.
+fn read_blob_text(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    full: &str,
+) -> Result<Option<(String, String)>> {
+    let hash = match tree.get_child(repo, full).map_err(record::map_ht)? {
+        Some(holo_tree::Child::Blob { hash, .. }) => *hash,
+        _ => return Ok(None),
+    };
+    let bytes = tree
+        .read_blob(repo, full)
+        .map_err(record::map_ht)?
+        .ok_or_else(|| Error::RecordNotFound {
+            message: format!("blob vanished at {full}"),
+        })?;
+    let text = String::from_utf8(bytes).map_err(|e| Error::ConfigInvalid {
+        message: format!("record at {full} is not valid UTF-8: {e}"),
+    })?;
+    Ok(Some((hash.to_string(), text)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{write_records, TOML_EXTENSION};
+    use indexmap::IndexMap;
+
+    fn temp_repo() -> (tempfile::TempDir, gix::Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = gix::init(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    fn rec(pairs: &[(&str, Value)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Value::Table(m)
+    }
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+
+    /// A tree pre-loaded with a `.gitsheets/people.toml` config blob.
+    fn tree_with_config(repo: &gix::Repository, config: Value) -> MutableTree {
+        let mut tree = MutableTree::empty();
+        write_records(repo, &mut tree, ".gitsheets", &[("people".into(), config)], TOML_EXTENSION)
+            .unwrap();
+        tree.write(repo).unwrap();
+        tree
+    }
+
+    fn config(path: &str, root: &str) -> Value {
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), s(path));
+        gs.insert("root".to_string(), s(root));
+        let mut top = IndexMap::new();
+        top.insert("gitsheet".to_string(), Value::Table(gs));
+        Value::Table(top)
+    }
+
+    fn open(repo: &gix::Repository, tree: &mut MutableTree) -> Sheet {
+        Sheet::open(repo, tree, "people", ".gitsheets/people.toml", ".", "").unwrap()
+    }
+
+    #[test]
+    fn open_resolves_config_and_base() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let sheet = open(&repo, &mut tree);
+        assert_eq!(sheet.name(), "people");
+        assert_eq!(sheet.base(), "people");
+    }
+
+    #[test]
+    fn missing_config_is_config_missing() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        let err = Sheet::open(&repo, &mut tree, "ghost", ".gitsheets/ghost.toml", ".", "")
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), "config_missing");
+    }
+
+    #[test]
+    fn prepare_renders_normalizes_and_serializes() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[("slug", s("jane")), ("email", s("jane@x.org"))]);
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        assert_eq!(cand.record_path, "jane");
+        // canonical bytes: keys sorted.
+        assert_eq!(cand.next_text, "email = \"jane@x.org\"\nslug = \"jane\"\n");
+    }
+
+    #[test]
+    fn will_change_true_then_false_after_stage() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[("slug", s("jane")), ("email", s("jane@x.org"))]);
+
+        let wc = sheet.will_change(&repo, &mut tree, &r, None, false).unwrap();
+        assert!(wc.changed);
+        assert_eq!(wc.current_blob_hash, None);
+
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &cand).unwrap();
+
+        let wc2 = sheet.will_change(&repo, &mut tree, &r, None, false).unwrap();
+        assert!(!wc2.changed, "byte-identical re-upsert is a no-op");
+        assert!(wc2.current_blob_hash.is_some());
+    }
+
+    #[test]
+    fn stage_rename_deletes_old_path() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        // Write at slug=jane.
+        let r1 = rec(&[("slug", s("jane"))]);
+        let c1 = sheet.prepare_upsert(&repo, &mut tree, &r1, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &c1).unwrap();
+        // Re-upsert with new slug, carrying previous_path=jane → old deleted.
+        let r2 = rec(&[("slug", s("jane-doe"))]);
+        let c2 = sheet
+            .prepare_upsert(&repo, &mut tree, &r2, Some("jane".into()), false)
+            .unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &c2).unwrap();
+        let listed = sheet.list(&repo, &mut tree).unwrap();
+        let paths: Vec<&str> = listed.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["jane-doe"]);
+    }
+
+    #[test]
+    fn delete_missing_is_record_not_found() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        let err = sheet.delete_at_path(&repo, &mut tree, "ghost").err().unwrap();
+        assert_eq!(err.code(), "record_not_found");
+    }
+
+    #[test]
+    fn delete_removes_existing_record() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[("slug", s("jane"))]);
+        let c = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &c).unwrap();
+        sheet.delete_at_path(&repo, &mut tree, "jane").unwrap();
+        assert!(sheet.list(&repo, &mut tree).unwrap().is_empty());
+    }
+
+    #[test]
+    fn clear_empties_the_subtree() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        for slug in ["a", "b", "c"] {
+            let r = rec(&[("slug", s(slug))]);
+            let c = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+            sheet.stage_upsert(&repo, &mut tree, &c).unwrap();
+        }
+        assert_eq!(sheet.list(&repo, &mut tree).unwrap().len(), 3);
+        sheet.clear(&repo, &mut tree).unwrap();
+        assert!(sheet.list(&repo, &mut tree).unwrap().is_empty());
+    }
+
+    #[test]
+    fn normalize_applies_array_field_sort() {
+        // Field `tags` sorts ascending (declarative `true`).
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), s("${{ slug }}"));
+        gs.insert("root".to_string(), s("people"));
+        let mut fields = IndexMap::new();
+        let mut tags = IndexMap::new();
+        tags.insert("sort".to_string(), Value::Boolean(true));
+        fields.insert("tags".to_string(), Value::Table(tags));
+        gs.insert("fields".to_string(), Value::Table(fields));
+        let mut top = IndexMap::new();
+        top.insert("gitsheet".to_string(), Value::Table(gs));
+
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, Value::Table(top));
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[
+            ("slug", s("jane")),
+            ("tags", Value::Array(vec![s("charlie"), s("alpha"), s("bravo")])),
+        ]);
+        let norm = sheet.normalize_record(&r).unwrap();
+        let Value::Table(m) = norm else { panic!() };
+        let Value::Array(items) = &m["tags"] else { panic!() };
+        let got: Vec<&str> = items
+            .iter()
+            .map(|v| match v {
+                Value::String(s) => s.as_str(),
+                _ => "?",
+            })
+            .collect();
+        assert_eq!(got, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn unique_index_conflict_blocks_upsert() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        sheet
+            .define_index("byEmail", true, "(r) => ( r.email )")
+            .unwrap();
+
+        // Stage jane@x.org as slug=jane.
+        let r1 = rec(&[("slug", s("jane")), ("email", s("dup@x.org"))]);
+        let c1 = sheet.prepare_upsert(&repo, &mut tree, &r1, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &c1).unwrap();
+
+        // A different slug claiming the same email → conflict.
+        let r2 = rec(&[("slug", s("bob")), ("email", s("dup@x.org"))]);
+        let err = sheet
+            .prepare_upsert(&repo, &mut tree, &r2, None, false)
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), "index_unique_conflict");
+        assert_eq!(err.conflicting_paths(), &["jane".to_string(), "bob".to_string()]);
+
+        // The same slug re-claiming its own email is fine (no conflict).
+        let r3 = rec(&[("slug", s("jane")), ("email", s("dup@x.org"))]);
+        assert!(sheet.prepare_upsert(&repo, &mut tree, &r3, None, false).is_ok());
+    }
+
+    #[test]
+    fn find_by_index_lookup() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        sheet.define_index("byTeam", false, "(r) => ( r.team )").unwrap();
+        for (slug, team) in [("a", "eng"), ("b", "eng"), ("c", "design")] {
+            let r = rec(&[("slug", s(slug)), ("team", s(team))]);
+            let c = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+            sheet.stage_upsert(&repo, &mut tree, &c).unwrap();
+        }
+        assert_eq!(sheet.find_by_multi_index(&repo, &mut tree, "byTeam", "eng").unwrap().len(), 2);
+        assert_eq!(sheet.find_by_multi_index(&repo, &mut tree, "byTeam", "design").unwrap().len(), 1);
+        let err = sheet
+            .find_by_multi_index(&repo, &mut tree, "nope", "x")
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), "index_not_defined");
+    }
+
+    #[test]
+    fn markdown_record_ops_are_deferred() {
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), s("${{ slug }}"));
+        gs.insert("root".to_string(), s("posts"));
+        let mut fmt = IndexMap::new();
+        fmt.insert("type".to_string(), s("markdown"));
+        fmt.insert("body".to_string(), s("content"));
+        gs.insert("format".to_string(), Value::Table(fmt));
+        let mut top = IndexMap::new();
+        top.insert("gitsheet".to_string(), Value::Table(gs));
+
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_records(&repo, &mut tree, ".gitsheets", &[("people".into(), Value::Table(top))], TOML_EXTENSION).unwrap();
+        tree.write(&repo).unwrap();
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[("slug", s("hi")), ("content", s("# Hi"))]);
+        let err = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).err().unwrap();
+        assert_eq!(err.code(), "config_invalid");
+        assert!(err.message().contains("not yet implemented"));
+    }
+}

--- a/rust/gitsheets-core/src/store.rs
+++ b/rust/gitsheets-core/src/store.rs
@@ -1,0 +1,133 @@
+//! The `Store` multi-sheet surface.
+//!
+//! A behavior-preserving Rust port of the discovery + validator-wiring half of
+//! `packages/gitsheets/src/store.ts` / `Repository.openSheets`, per
+//! [`specs/api/store.md`](../../../specs/api/store.md). The core owns the
+//! *bytes-and-consistency* parts of the Store: **sheet discovery** (enumerating
+//! `.gitsheets/*.toml`) and the **`config_missing` check** (a declared validator
+//! must name a sheet that exists). The typed property surface, the consumer
+//! validators themselves, and the `tx.<sheet>` alias ergonomics are host-idiom
+//! concerns and stay in the binding — the binding opens a [`Transaction`] and a
+//! [`Sheet`] per discovered name and drives the two-phase upsert protocol.
+//!
+//! [`Transaction`]: crate::transaction::Transaction
+//! [`Sheet`]: crate::sheet::Sheet
+
+use holo_tree::MutableTree;
+
+use crate::error::{Error, Result};
+use crate::record;
+use crate::sheet::join_path;
+
+const TOML_EXTENSION: &str = ".toml";
+
+/// Discover every sheet declared in `<open_root>/.gitsheets/*.toml` in `tree`.
+/// Returns the bare sheet names (extension stripped) in sorted (git-canonical)
+/// order. A repo with no `.gitsheets/` directory yields an empty list.
+///
+/// Only *direct* `<name>.toml` children of `.gitsheets/` are sheets — nested
+/// files (e.g. a `.gitsheets/sub/x.toml`) are ignored, matching the JS
+/// `openSheets` which enumerates the directory's immediate `.toml` blobs.
+pub fn discover_sheets(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    open_root: &str,
+) -> Result<Vec<String>> {
+    let dir = join_path(&[open_root, ".gitsheets"]);
+    let dir_arg = if dir.is_empty() { ".".to_string() } else { dir };
+    let subtree = match tree.get_subtree(repo, &dir_arg).map_err(record::map_ht)? {
+        Some(t) => t,
+        None => return Ok(Vec::new()),
+    };
+    let blob_map = subtree.get_blob_map(repo).map_err(record::map_ht)?;
+    let mut names: Vec<String> = Vec::new();
+    for (path, _) in blob_map {
+        // Direct children only: no nested directory component.
+        if path.contains('/') {
+            continue;
+        }
+        if let Some(stripped) = path.strip_suffix(TOML_EXTENSION) {
+            if !stripped.is_empty() {
+                names.push(stripped.to_string());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Verify every name in `validator_names` is present in `declared` (the
+/// discovered sheets). A validator naming a sheet with no
+/// `.gitsheets/<name>.toml` is [`Error::ConfigMissing`], matching `openStore`.
+pub fn check_validators(declared: &[String], validator_names: &[String]) -> Result<()> {
+    for name in validator_names {
+        if !declared.iter().any(|d| d == name) {
+            return Err(Error::ConfigMissing {
+                message: format!(
+                    "Store opens with validators.{name}, but .gitsheets/{name}.toml is not declared"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{write_records, TOML_EXTENSION as EXT};
+    use crate::value::Value;
+    use indexmap::IndexMap;
+
+    fn temp_repo() -> (tempfile::TempDir, gix::Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = gix::init(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    fn table(pairs: &[(&str, &str)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).to_string(), Value::String((*v).to_string()));
+        }
+        Value::Table(m)
+    }
+
+    #[test]
+    fn discovers_declared_sheets_sorted() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        // Two config blobs under `.gitsheets/`.
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), Value::String("${ slug }".to_string()));
+        let cfg = Value::Table({
+            let mut m = IndexMap::new();
+            m.insert("gitsheet".to_string(), Value::Table(gs));
+            m
+        });
+        write_records(&repo, &mut tree, ".gitsheets", &[("users".into(), cfg.clone())], EXT).unwrap();
+        write_records(&repo, &mut tree, ".gitsheets", &[("projects".into(), cfg)], EXT).unwrap();
+
+        let names = discover_sheets(&repo, &mut tree, ".").unwrap();
+        assert_eq!(names, vec!["projects".to_string(), "users".to_string()]);
+    }
+
+    #[test]
+    fn empty_repo_yields_no_sheets() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        assert!(discover_sheets(&repo, &mut tree, ".").unwrap().is_empty());
+        // A non-sheet write doesn't create `.gitsheets`.
+        write_records(&repo, &mut tree, "people", &[("jane".into(), table(&[("slug", "jane")]))], EXT)
+            .unwrap();
+        assert!(discover_sheets(&repo, &mut tree, ".").unwrap().is_empty());
+    }
+
+    #[test]
+    fn check_validators_flags_missing_sheet() {
+        let declared = vec!["users".to_string()];
+        assert!(check_validators(&declared, &["users".to_string()]).is_ok());
+        let err = check_validators(&declared, &["projects".to_string()]).unwrap_err();
+        assert_eq!(err.code(), "config_missing");
+    }
+}

--- a/rust/gitsheets-core/src/transaction.rs
+++ b/rust/gitsheets-core/src/transaction.rs
@@ -1,0 +1,837 @@
+//! The `Transaction` half of the orchestration state machine.
+//!
+//! A [`Transaction`] is the unit of atomicity: mutations stage into a private
+//! in-memory tree built from a parent ref; on success the tree commits and the
+//! configured branch advances; on discard nothing moves. A behavior-preserving
+//! Rust port of `packages/gitsheets/src/transaction.ts` +
+//! `Repository.transact`/`#resolveParent`, per
+//! [`specs/api/transaction.md`](../../../specs/api/transaction.md) and
+//! [`specs/behaviors/transactions.md`](../../../specs/behaviors/transactions.md).
+//!
+//! The lifecycle pieces this owns:
+//!
+//! - **parent resolution** — branch vs. commit-hash vs. default-HEAD, and the
+//!   branch-to-advance.
+//! - **optimistic concurrency** — re-resolve the parent ref at commit; a move is
+//!   [`Error::ParentMoved`]. The CAS `update_ref` is the actual race guard.
+//! - **no-op detection** — skip the commit when the resulting tree hash equals
+//!   the parent commit's tree hash (and on a fresh repo, an initial commit IS
+//!   produced).
+//! - **commit + ref update** — holo-tree's `commit_tree` + CAS `update_ref` with
+//!   explicit author/committer identity.
+//!
+//! ## Single-writer model
+//!
+//! One open transaction per git directory at a time, guarded by a process-wide
+//! registry that detects an overlapping open as [`Error::TransactionInProgress`].
+//! The *async queueing* of contended transactions (Node's `AsyncLocalStorage`
+//! mutex, Python's `asyncio` lock) is inherently host-runtime-specific and stays
+//! in the binding; the core owns the detectable correctness guard (this registry
+//! plus the optimistic `parent_moved` CAS).
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use holo_tree::{repo as holo_repo, MutableTree, ObjectId};
+
+use crate::error::{Error, Result};
+use crate::record;
+
+/// Commit identity (author / committer).
+#[derive(Clone, Debug)]
+pub struct Author {
+    pub name: String,
+    pub email: String,
+}
+
+/// Options for opening a transaction. `time_seconds` / `offset_minutes` carry
+/// the host's wall-clock + local-timezone offset for the commit signature (a
+/// host concern, exactly as the JS `commitTreeWithRepo` computes them).
+#[derive(Clone, Debug)]
+pub struct TransactionOptions {
+    pub parent: Option<String>,
+    pub branch: Option<String>,
+    pub author: Option<Author>,
+    pub committer: Option<Author>,
+    pub message: String,
+    pub trailers: Vec<(String, String)>,
+    pub time_seconds: i64,
+    pub offset_minutes: i32,
+}
+
+/// The outcome of [`Transaction::finalize`]. A no-op (no mutation, or resulting
+/// tree equals the parent's) returns `commit_hash = None` — the consumer's
+/// no-op signal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransactionResult {
+    pub commit_hash: Option<String>,
+    pub tree_hash: Option<String>,
+    pub ref_name: Option<String>,
+    pub parent_commit_hash: Option<String>,
+}
+
+// ── process-wide open-transaction registry ────────────────────────────────────
+
+fn registry() -> &'static Mutex<HashSet<String>> {
+    static REGISTRY: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn registry_key(git_dir: &str) -> String {
+    std::fs::canonicalize(git_dir)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| git_dir.to_string())
+}
+
+/// A live transaction: owns its repo handle + private root tree, the resolved
+/// parent/branch, identity, and message. `!Send` (holds a `gix::Repository` and
+/// holo-tree's thread-local-cached tree) — constructed and used on one thread.
+pub struct Transaction {
+    repo: gix::Repository,
+    root: MutableTree,
+    registry_key: String,
+    parent_commit_hash: Option<ObjectId>,
+    parent_ref: Option<String>,
+    branch_ref: Option<String>,
+    author: Author,
+    committer: Author,
+    message: String,
+    trailers: Vec<(String, String)>,
+    time_seconds: i64,
+    offset_minutes: i32,
+    any_mutation: bool,
+    closed: bool,
+}
+
+impl Transaction {
+    /// Open a transaction against the git directory `git_dir`. Resolves the
+    /// parent ref + branch-to-advance, captures `parentCommitHash`, builds the
+    /// private root tree, and acquires the single-writer slot for this repo.
+    pub fn begin(git_dir: &str, opts: TransactionOptions) -> Result<Self> {
+        validate_trailers(&opts.trailers)?;
+
+        let repo = record::open_repo(git_dir)?;
+        let key = registry_key(git_dir);
+        {
+            let mut set = registry().lock().expect("registry poisoned");
+            if set.contains(&key) {
+                return Err(Error::TransactionInProgress {
+                    message: format!(
+                        "a transaction is already open for {git_dir} — finalize it first"
+                    ),
+                });
+            }
+            set.insert(key.clone());
+        }
+
+        // From here on, any early return must release the slot.
+        let result = (|| {
+            let (parent_ref, parent_commit_hash, branch_ref) =
+                resolve_parent(&repo, opts.parent.as_deref(), opts.branch.as_deref())?;
+
+            let author = resolve_author(&repo, opts.author);
+            let committer = opts.committer.unwrap_or_else(|| author.clone());
+
+            let root = match &parent_commit_hash {
+                Some(hash) => holo_repo::create_tree_from_ref(&repo, &hash.to_string())
+                    .map_err(record::map_ht)?,
+                None => MutableTree::empty(),
+            };
+
+            Ok(Transaction {
+                repo,
+                root,
+                registry_key: key.clone(),
+                parent_commit_hash,
+                parent_ref,
+                branch_ref,
+                author,
+                committer,
+                message: opts.message,
+                trailers: opts.trailers,
+                time_seconds: opts.time_seconds,
+                offset_minutes: opts.offset_minutes,
+                any_mutation: false,
+                closed: false,
+            })
+        })();
+
+        if result.is_err() {
+            registry().lock().expect("registry poisoned").remove(&key);
+        }
+        result
+    }
+
+    /// Borrow the repo handle + root tree together (disjoint) so a `Sheet` can
+    /// run a mutation against this transaction's private tree.
+    pub fn split(&mut self) -> (&gix::Repository, &mut MutableTree) {
+        (&self.repo, &mut self.root)
+    }
+
+    pub fn repo(&self) -> &gix::Repository {
+        &self.repo
+    }
+
+    pub fn parent_commit_hash(&self) -> Option<String> {
+        self.parent_commit_hash.map(|h| h.to_string())
+    }
+
+    /// Mark that a mutating method ran in this transaction. The authoritative
+    /// no-op check is still tree-hash equality at finalize; this flag is the
+    /// cheap short-circuit (matches `tx.markMutated`).
+    pub fn mark_mutated(&mut self) {
+        self.any_mutation = true;
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Finalize: commit-on-success-only with no-op detection + the optimistic
+    /// `parent_moved` re-check + CAS ref movement. Consumes the transaction.
+    pub fn finalize(mut self) -> Result<TransactionResult> {
+        self.closed = true;
+        let parent_str = self.parent_commit_hash.map(|h| h.to_string());
+
+        let no_change = TransactionResult {
+            commit_hash: None,
+            tree_hash: None,
+            ref_name: None,
+            parent_commit_hash: parent_str.clone(),
+        };
+
+        if !self.any_mutation {
+            self.release();
+            return Ok(no_change);
+        }
+
+        // Optimistic concurrency: re-check the parent ref hasn't moved.
+        if let Some(parent_ref) = &self.parent_ref {
+            let current = holo_repo::resolve_ref(&self.repo, parent_ref).map_err(record::map_ht)?;
+            if current != self.parent_commit_hash {
+                self.release();
+                return Err(Error::ParentMoved {
+                    message: format!(
+                        "parent ref {parent_ref} moved during transaction (expected {}, found {})",
+                        opt_hash(&self.parent_commit_hash),
+                        opt_hash(&current),
+                    ),
+                });
+            }
+        }
+
+        let tree_hash = match self.root.write(&self.repo) {
+            Ok(h) => h,
+            Err(e) => {
+                self.release();
+                return Err(record::map_ht(e));
+            }
+        };
+
+        // No-op detection: resulting tree equals the parent commit's tree.
+        if let Some(parent) = self.parent_commit_hash {
+            let mut parent_tree =
+                match holo_repo::create_tree_from_ref(&self.repo, &parent.to_string()) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        self.release();
+                        return Err(record::map_ht(e));
+                    }
+                };
+            let parent_tree_hash = match parent_tree.write(&self.repo) {
+                Ok(h) => h,
+                Err(e) => {
+                    self.release();
+                    return Err(record::map_ht(e));
+                }
+            };
+            if parent_tree_hash == tree_hash {
+                self.release();
+                return Ok(no_change);
+            }
+        }
+
+        let full_message = format_commit_message(&self.message, &self.trailers);
+        let author_sig = match build_signature(&self.author, self.time_seconds, self.offset_minutes) {
+            Ok(s) => s,
+            Err(e) => {
+                self.release();
+                return Err(e);
+            }
+        };
+        let committer_sig =
+            match build_signature(&self.committer, self.time_seconds, self.offset_minutes) {
+                Ok(s) => s,
+                Err(e) => {
+                    self.release();
+                    return Err(e);
+                }
+            };
+
+        let parents: Vec<ObjectId> = self.parent_commit_hash.into_iter().collect();
+        let commit_id = match holo_repo::commit_tree(
+            &self.repo,
+            tree_hash,
+            &parents,
+            &full_message,
+            Some(author_sig),
+            Some(committer_sig),
+        ) {
+            Ok(id) => id,
+            Err(e) => {
+                self.release();
+                return Err(Error::CommitFailed {
+                    message: format!("holo-tree commit_tree failed: {e}"),
+                });
+            }
+        };
+
+        if let Some(branch) = &self.branch_ref {
+            if let Err(e) =
+                holo_repo::update_ref(&self.repo, branch, commit_id, self.parent_commit_hash)
+            {
+                self.release();
+                return Err(Error::CommitFailed {
+                    message: format!("holo-tree update_ref {branch} failed: {e}"),
+                });
+            }
+        }
+
+        let ref_name = self.branch_ref.clone();
+        self.release();
+        Ok(TransactionResult {
+            commit_hash: Some(commit_id.to_string()),
+            tree_hash: Some(tree_hash.to_string()),
+            ref_name,
+            parent_commit_hash: parent_str,
+        })
+    }
+
+    /// Discard the transaction without committing (handler threw). Releases the
+    /// single-writer slot.
+    pub fn discard(mut self) {
+        self.closed = true;
+        self.release();
+    }
+
+    fn release(&self) {
+        registry()
+            .lock()
+            .expect("registry poisoned")
+            .remove(&self.registry_key);
+    }
+}
+
+impl Drop for Transaction {
+    fn drop(&mut self) {
+        // Safety net: a leaked/panicked transaction frees its slot.
+        if !self.registry_key.is_empty() {
+            if let Ok(mut set) = registry().lock() {
+                set.remove(&self.registry_key);
+            }
+        }
+    }
+}
+
+fn opt_hash(h: &Option<ObjectId>) -> String {
+    h.map(|h| h.to_string()).unwrap_or_else(|| "null".into())
+}
+
+// ── parent resolution (port of Repository.#resolveParent) ─────────────────────
+
+fn resolve_parent(
+    repo: &gix::Repository,
+    parent: Option<&str>,
+    branch: Option<&str>,
+) -> Result<(Option<String>, Option<ObjectId>, Option<String>)> {
+    match parent {
+        None => {
+            if let Some(head_ref) = head_branch_ref(repo) {
+                let commit = holo_repo::resolve_ref(repo, &head_ref).map_err(record::map_ht)?;
+                let branch_ref = branch.map(qualify_ref).unwrap_or_else(|| head_ref.clone());
+                Ok((Some(head_ref), commit, Some(branch_ref)))
+            } else {
+                // Detached HEAD or fresh repo.
+                let head_hash = holo_repo::resolve_ref(repo, "HEAD").map_err(record::map_ht)?;
+                Ok((None, head_hash, branch.map(qualify_ref)))
+            }
+        }
+        Some(p) => {
+            if is_likely_branch(p) {
+                let ref_name = qualify_ref(p);
+                let commit = holo_repo::resolve_ref(repo, &ref_name).map_err(record::map_ht)?;
+                let Some(commit) = commit else {
+                    return Err(Error::RefNotFound {
+                        message: format!("ref not found: {p}"),
+                    });
+                };
+                let branch_ref = branch.map(qualify_ref).unwrap_or_else(|| ref_name.clone());
+                Ok((Some(ref_name), Some(commit), Some(branch_ref)))
+            } else {
+                let resolved = holo_repo::resolve_ref(repo, p).map_err(record::map_ht)?;
+                let Some(resolved) = resolved else {
+                    return Err(Error::RefNotFound {
+                        message: format!("cannot resolve commit: {p}"),
+                    });
+                };
+                Ok((None, Some(resolved), branch.map(qualify_ref)))
+            }
+        }
+    }
+}
+
+/// The symbolic-ref name HEAD points at (e.g. `refs/heads/main`), even when the
+/// branch is unborn. `None` when HEAD is detached.
+fn head_branch_ref(repo: &gix::Repository) -> Option<String> {
+    let head = repo.head().ok()?;
+    head.referent_name().map(|n| n.as_bstr().to_string())
+}
+
+fn is_likely_branch(p: &str) -> bool {
+    let ref_like = !p.is_empty()
+        && p.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '/' | '-'));
+    let hash_like = (4..=40).contains(&p.len()) && p.chars().all(|c| c.is_ascii_hexdigit());
+    ref_like && !hash_like
+}
+
+fn qualify_ref(name: &str) -> String {
+    if name.starts_with("refs/") {
+        name.to_string()
+    } else {
+        format!("refs/heads/{name}")
+    }
+}
+
+fn resolve_author(repo: &gix::Repository, explicit: Option<Author>) -> Author {
+    if let Some(a) = explicit {
+        return a;
+    }
+    if let Some(Ok(sig)) = repo.author() {
+        let name = sig.name.to_string();
+        let email = sig.email.to_string();
+        if !name.is_empty() && !email.is_empty() {
+            return Author { name, email };
+        }
+    }
+    Author {
+        name: "Anonymous".into(),
+        email: "anonymous@gitsheets.local".into(),
+    }
+}
+
+// ── commit message + trailers (port of transaction.ts) ────────────────────────
+
+const TRAILER_KEY_ERR: &str =
+    "does not match HTTP-header style (e.g., \"Subject-Id\", \"Action\")";
+
+fn validate_trailers(trailers: &[(String, String)]) -> Result<()> {
+    for (key, value) in trailers {
+        if !is_http_header_key(key) {
+            return Err(Error::CommitFailed {
+                message: format!("trailer key {key:?} {TRAILER_KEY_ERR}"),
+            });
+        }
+        if value.contains('\r') || value.contains('\n') {
+            return Err(Error::CommitFailed {
+                message: format!(
+                    "trailer {key:?} has invalid value (must be string with no newlines): {value:?}"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// HTTP-header style: hyphen-separated segments, each `[A-Z][a-z0-9]*`. Matches
+/// the `HTTP_HEADER_KEY_RE` in `transaction.ts`.
+fn is_http_header_key(key: &str) -> bool {
+    if key.is_empty() {
+        return false;
+    }
+    key.split('-').all(|seg| {
+        let mut chars = seg.chars();
+        match chars.next() {
+            Some(c) if c.is_ascii_uppercase() => {}
+            _ => return false,
+        }
+        chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    })
+}
+
+/// Format the commit message: subject/body (trimmed trailing whitespace) plus
+/// trailers appended after a blank line. Matches `formatCommitMessage`.
+pub fn format_commit_message(message: &str, trailers: &[(String, String)]) -> String {
+    let body = message.trim_end();
+    if trailers.is_empty() {
+        return format!("{body}\n");
+    }
+    let lines: Vec<String> = trailers
+        .iter()
+        .map(|(k, v)| format!("{k}: {v}"))
+        .collect();
+    format!("{body}\n\n{}\n", lines.join("\n"))
+}
+
+fn build_signature(
+    author: &Author,
+    seconds: i64,
+    offset_minutes: i32,
+) -> Result<gix::actor::Signature> {
+    let (sign, abs) = if offset_minutes < 0 {
+        ('-', -offset_minutes)
+    } else {
+        ('+', offset_minutes)
+    };
+    let hh = abs / 60;
+    let mm = abs % 60;
+    let time = format!("{seconds} {sign}{hh:02}{mm:02}");
+    gix::actor::SignatureRef {
+        name: author.name.as_str().into(),
+        email: author.email.as_str().into(),
+        time: time.as_str(),
+    }
+    .to_owned()
+    .map_err(|e| Error::CommitFailed {
+        message: format!("invalid commit signature: {e}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{self, write_records, TOML_EXTENSION};
+    use crate::sheet::Sheet;
+    use crate::value::Value;
+    use indexmap::IndexMap;
+
+    fn config_value(path: &str, root: &str) -> Value {
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), Value::String(path.to_string()));
+        gs.insert("root".to_string(), Value::String(root.to_string()));
+        let mut top = IndexMap::new();
+        top.insert("gitsheet".to_string(), Value::Table(gs));
+        Value::Table(top)
+    }
+
+    fn record_value(pairs: &[(&str, &str)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).to_string(), Value::String((*v).to_string()));
+        }
+        Value::Table(m)
+    }
+
+    /// A throwaway repo with a committed `.gitsheets/people.toml` (`path =
+    /// ${ slug }`, root = `people`) on `refs/heads/main`, HEAD symbolic to it.
+    /// Returns the tempdir, the git-dir path, and the initial commit hash.
+    fn setup(config: Value) -> (tempfile::TempDir, String, ObjectId) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = gix::init(dir.path()).unwrap();
+        let git_dir = dir.path().join(".git").to_string_lossy().into_owned();
+
+        let mut tree = MutableTree::empty();
+        write_records(
+            &repo,
+            &mut tree,
+            ".gitsheets",
+            &[("people".into(), config)],
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        let tree_hash = tree.write(&repo).unwrap();
+        let sig = build_signature(
+            &Author {
+                name: "Seed".into(),
+                email: "seed@x.org".into(),
+            },
+            1_600_000_000,
+            0,
+        )
+        .unwrap();
+        let commit =
+            holo_repo::commit_tree(&repo, tree_hash, &[], "init\n", Some(sig.clone()), Some(sig))
+                .unwrap();
+        holo_repo::update_ref(&repo, "refs/heads/main", commit, None).unwrap();
+        std::fs::write(dir.path().join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        (dir, git_dir, commit)
+    }
+
+    fn default_opts(message: &str) -> TransactionOptions {
+        TransactionOptions {
+            parent: None,
+            branch: None,
+            author: Some(Author {
+                name: "Jane Doe".into(),
+                email: "jane@x.org".into(),
+            }),
+            committer: None,
+            message: message.to_string(),
+            trailers: vec![],
+            time_seconds: 1_700_000_000,
+            offset_minutes: -300,
+        }
+    }
+
+    /// `Transaction::begin` expecting an error (the Ok type isn't `Debug`).
+    fn begin_err(git_dir: &str, opts: TransactionOptions) -> Error {
+        match Transaction::begin(git_dir, opts) {
+            Err(e) => e,
+            Ok(tx) => {
+                tx.discard();
+                panic!("expected Transaction::begin to fail")
+            }
+        }
+    }
+
+    /// Drive a single staged upsert through a transaction → finalize.
+    fn upsert_one(git_dir: &str, opts: TransactionOptions, rec: Value) -> TransactionResult {
+        let mut tx = Transaction::begin(git_dir, opts).unwrap();
+        {
+            let (repo, tree) = tx.split();
+            let mut sheet =
+                Sheet::open(repo, tree, "people", ".gitsheets/people.toml", ".", "").unwrap();
+            let candidate = sheet.prepare_upsert(repo, tree, &rec, None, false).unwrap();
+            sheet.stage_upsert(repo, tree, &candidate).unwrap();
+        }
+        tx.mark_mutated();
+        tx.finalize().unwrap()
+    }
+
+    #[test]
+    fn full_upsert_commits_with_identity_trailers_and_record() {
+        let (dir, git_dir, parent) = setup(config_value("${{ slug }}", "people"));
+        let mut opts = default_opts("people: add jane");
+        opts.trailers = vec![("Action".into(), "person.create".into())];
+        let result = upsert_one(
+            &git_dir,
+            opts,
+            record_value(&[("slug", "jane"), ("email", "jane@x.org")]),
+        );
+
+        let commit_hash = result.commit_hash.expect("a commit was produced");
+        assert_eq!(result.ref_name.as_deref(), Some("refs/heads/main"));
+        assert_eq!(result.parent_commit_hash.as_deref(), Some(parent.to_string().as_str()));
+
+        // The branch advanced to the new commit.
+        let repo = record::open_repo(&git_dir).unwrap();
+        let head = holo_repo::resolve_ref(&repo, "refs/heads/main").unwrap().unwrap();
+        assert_eq!(head.to_string(), commit_hash);
+
+        // Author/committer identity + message + trailer survived.
+        let obj = repo.rev_parse_single("HEAD").unwrap().object().unwrap();
+        let commit = obj.try_into_commit().unwrap();
+        let author = commit.author().unwrap();
+        assert_eq!(author.name.to_string(), "Jane Doe");
+        assert_eq!(author.email.to_string(), "jane@x.org");
+        let committer = commit.committer().unwrap();
+        assert_eq!(committer.name.to_string(), "Jane Doe"); // committer falls back to author
+        let message = commit.message_raw().unwrap().to_string();
+        assert!(message.contains("people: add jane"));
+        assert!(message.contains("Action: person.create"));
+
+        // The record landed at people/jane.toml with canonical bytes.
+        let read = record::read_records_at_ref(
+            &git_dir,
+            &commit_hash,
+            "people",
+            &["jane".into()],
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        assert_eq!(
+            read[0].as_ref().unwrap(),
+            &record_value(&[("email", "jane@x.org"), ("slug", "jane")])
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn reupsert_of_byte_identical_record_is_a_noop() {
+        let (_dir, git_dir, _parent) = setup(config_value("${{ slug }}", "people"));
+        let rec = record_value(&[("slug", "jane"), ("email", "jane@x.org")]);
+        let first = upsert_one(&git_dir, default_opts("add jane"), rec.clone());
+        assert!(first.commit_hash.is_some());
+
+        // Re-upsert the exact same record: the resulting tree equals the parent's
+        // → no commit (tree-hash equality no-op).
+        let second = upsert_one(&git_dir, default_opts("re-add jane"), rec);
+        assert_eq!(second.commit_hash, None);
+        assert_eq!(second.tree_hash, None);
+        assert_eq!(second.ref_name, None);
+    }
+
+    #[test]
+    fn no_mutation_short_circuits_to_noop() {
+        let (_dir, git_dir, _parent) = setup(config_value("${{ slug }}", "people"));
+        let tx = Transaction::begin(&git_dir, default_opts("nothing")).unwrap();
+        // Never mark mutated → no commit.
+        let result = tx.finalize().unwrap();
+        assert_eq!(result.commit_hash, None);
+    }
+
+    #[test]
+    fn parent_moved_when_branch_advances_mid_transaction() {
+        let (_dir, git_dir, parent) = setup(config_value("${{ slug }}", "people"));
+        let mut tx = Transaction::begin(&git_dir, default_opts("add jane")).unwrap();
+        {
+            let (repo, tree) = tx.split();
+            let mut sheet =
+                Sheet::open(repo, tree, "people", ".gitsheets/people.toml", ".", "").unwrap();
+            let rec = record_value(&[("slug", "jane")]);
+            let candidate = sheet.prepare_upsert(repo, tree, &rec, None, false).unwrap();
+            sheet.stage_upsert(repo, tree, &candidate).unwrap();
+        }
+        tx.mark_mutated();
+
+        // Externally advance refs/heads/main (a separate process committed).
+        let repo2 = record::open_repo(&git_dir).unwrap();
+        let mut t = holo_repo::create_tree_from_ref(&repo2, &parent.to_string()).unwrap();
+        write_records(
+            &repo2,
+            &mut t,
+            "people",
+            &[("intruder".into(), record_value(&[("slug", "intruder")]))],
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        let th = t.write(&repo2).unwrap();
+        let sig = build_signature(
+            &Author {
+                name: "Other".into(),
+                email: "o@x.org".into(),
+            },
+            1_700_000_001,
+            0,
+        )
+        .unwrap();
+        let c1 = holo_repo::commit_tree(&repo2, th, &[parent], "external\n", Some(sig.clone()), Some(sig))
+            .unwrap();
+        holo_repo::update_ref(&repo2, "refs/heads/main", c1, Some(parent)).unwrap();
+
+        let err = tx.finalize().unwrap_err();
+        assert_eq!(err.code(), "parent_moved");
+    }
+
+    #[test]
+    fn concurrent_open_on_same_repo_is_transaction_in_progress() {
+        let (_dir, git_dir, _parent) = setup(config_value("${{ slug }}", "people"));
+        let tx1 = Transaction::begin(&git_dir, default_opts("first")).unwrap();
+        let err = begin_err(&git_dir, default_opts("second"));
+        assert_eq!(err.code(), "transaction_in_progress");
+        // Releasing the first frees the slot.
+        tx1.discard();
+        let tx2 = Transaction::begin(&git_dir, default_opts("third")).unwrap();
+        tx2.discard();
+    }
+
+    #[test]
+    fn validation_rejection_prevents_any_write() {
+        // Schema requires email to match a pattern.
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), Value::String("${ slug }".to_string()));
+        gs.insert("root".to_string(), Value::String("people".to_string()));
+        let mut schema = IndexMap::new();
+        schema.insert("type".to_string(), Value::String("object".to_string()));
+        let mut props = IndexMap::new();
+        let mut email_schema = IndexMap::new();
+        email_schema.insert("type".to_string(), Value::String("string".to_string()));
+        email_schema.insert("format".to_string(), Value::String("email".to_string()));
+        props.insert("email".to_string(), Value::Table(email_schema));
+        schema.insert("properties".to_string(), Value::Table(props));
+        schema.insert(
+            "required".to_string(),
+            Value::Array(vec![Value::String("email".to_string())]),
+        );
+        gs.insert("schema".to_string(), Value::Table(schema));
+        let mut top = IndexMap::new();
+        top.insert("gitsheet".to_string(), Value::Table(gs));
+
+        let (_dir, git_dir, _parent) = setup(Value::Table(top));
+        let mut tx = Transaction::begin(&git_dir, default_opts("bad")).unwrap();
+        let err = {
+            let (repo, tree) = tx.split();
+            let mut sheet =
+                Sheet::open(repo, tree, "people", ".gitsheets/people.toml", ".", "").unwrap();
+            let bad = record_value(&[("slug", "jane"), ("email", "not-an-email")]);
+            sheet.prepare_upsert(repo, tree, &bad, None, false).unwrap_err()
+        };
+        assert_eq!(err.code(), "validation_failed");
+        // No stage happened → no mutation → finalize is a no-op.
+        let result = tx.finalize().unwrap();
+        assert_eq!(result.commit_hash, None);
+    }
+
+    #[test]
+    fn commit_onto_a_branch_name_advances_that_branch() {
+        let (_dir, git_dir, parent) = setup(config_value("${{ slug }}", "people"));
+        // Create a feature branch at the same parent.
+        let repo = record::open_repo(&git_dir).unwrap();
+        holo_repo::update_ref(&repo, "refs/heads/feature", parent, None).unwrap();
+
+        let mut opts = default_opts("on feature");
+        opts.parent = Some("feature".into());
+        let result = upsert_one(&git_dir, opts, record_value(&[("slug", "fx")]));
+        assert_eq!(result.ref_name.as_deref(), Some("refs/heads/feature"));
+        // main is untouched.
+        let repo = record::open_repo(&git_dir).unwrap();
+        let main = holo_repo::resolve_ref(&repo, "refs/heads/main").unwrap().unwrap();
+        assert_eq!(main, parent);
+    }
+
+    #[test]
+    fn commit_onto_a_hash_advances_no_branch() {
+        let (_dir, git_dir, parent) = setup(config_value("${{ slug }}", "people"));
+        let mut opts = default_opts("detached");
+        opts.parent = Some(parent.to_string());
+        let result = upsert_one(&git_dir, opts, record_value(&[("slug", "d")]));
+        assert!(result.commit_hash.is_some());
+        assert_eq!(result.ref_name, None);
+    }
+
+    #[test]
+    fn unknown_parent_branch_is_ref_not_found() {
+        let (_dir, git_dir, _parent) = setup(config_value("${{ slug }}", "people"));
+        let mut opts = default_opts("x");
+        opts.parent = Some("nope".into());
+        let err = begin_err(&git_dir, opts);
+        assert_eq!(err.code(), "ref_not_found");
+    }
+
+    #[test]
+    fn invalid_trailer_key_is_rejected() {
+        let (_dir, git_dir, _parent) = setup(config_value("${{ slug }}", "people"));
+        let mut opts = default_opts("x");
+        opts.trailers = vec![("not a header".into(), "v".into())];
+        let err = begin_err(&git_dir, opts);
+        assert_eq!(err.code(), "commit_failed");
+    }
+
+    #[test]
+    fn commit_message_formatting_matches_js() {
+        assert_eq!(format_commit_message("subject", &[]), "subject\n");
+        assert_eq!(
+            format_commit_message("subject\n\nbody", &[("A".into(), "1".into())]),
+            "subject\n\nbody\n\nA: 1\n"
+        );
+        assert_eq!(
+            format_commit_message(
+                "s",
+                &[("Action".into(), "x".into()), ("Reason".into(), "y".into())]
+            ),
+            "s\n\nAction: x\nReason: y\n"
+        );
+    }
+
+    #[test]
+    fn http_header_key_validation() {
+        assert!(is_http_header_key("Action"));
+        assert!(is_http_header_key("Subject-Id"));
+        assert!(is_http_header_key("User-Ip"));
+        assert!(is_http_header_key("Response-Code"));
+        assert!(!is_http_header_key("action"));
+        assert!(!is_http_header_key("subject_id"));
+        assert!(!is_http_header_key(""));
+        assert!(!is_http_header_key("Has Space"));
+    }
+}

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -139,6 +139,13 @@ module.exports = {
   // Diff / patch primitives (RFC 6902 createPatch, RFC 7396 mergePatch).
   createPatch: wrap(addon.createPatch),
   applyMergePatch: wrap(addon.applyMergePatch),
+  // Orchestration: Sheet / Transaction / Store state machine (sheet-store-core).
+  // CoreTransaction is the stateful two-phase-protocol driver. Raw class — its
+  // methods throw structured errors carrying `gitsheetsClass`/`code`; map with
+  // `mapCoreError` where a typed instance is wanted.
+  CoreTransaction: addon.CoreTransaction,
+  coreDiscoverSheets: wrap(addon.coreDiscoverSheets),
+  coreCheckValidators: wrap(addon.coreCheckValidators),
   // Boundary-test entry: throws the typed class for a given stable code.
   simulateCoreError: wrap(addon.simulateCoreError),
   // Error machinery.

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -183,6 +183,56 @@ export declare function diffRecords(gitDir: string, srcRef: string, dstRef: stri
  * error-variant → typed-class mapping without standing up real engine paths.
  */
 export declare function simulateCoreError(code: string): void
+/** Commit identity for the JS surface. */
+export interface JsAuthor {
+  name: string
+  email: string
+}
+/** One ordered commit trailer (`Key: value`). */
+export interface JsTrailer {
+  key: string
+  value: string
+}
+/**
+ * Options for opening a [`CoreTransaction`]. `timeSeconds` / `offsetMinutes`
+ * carry the host clock + local-timezone offset (a host concern), exactly as the
+ * JS `commitTreeWithRepo` computes them today.
+ */
+export interface JsTransactionOptions {
+  parent?: string
+  branch?: string
+  author?: JsAuthor
+  committer?: JsAuthor
+  message: string
+  trailers?: Array<JsTrailer>
+  timeSeconds: number
+  offsetMinutes: number
+}
+/**
+ * The outcome of [`CoreTransaction::finalize`]. A no-op (no mutation, or the
+ * resulting tree equals the parent's) returns `commitHash = null`.
+ */
+export interface JsTransactionResult {
+  commitHash?: string
+  treeHash?: string
+  refName?: string
+  parentCommitHash?: string
+}
+/** The outcome of [`CoreTransaction::stage_upsert`]. */
+export interface JsStageOutcome {
+  blobHash: string
+  path: string
+}
+/**
+ * Discover every sheet declared in `<openRoot>/.gitsheets/*.toml` in the tree
+ * `treeRef`. Sorted bare names. The `Store` discovery half (`openStore`).
+ */
+export declare function coreDiscoverSheets(gitDir: string, treeRef: string, openRoot: string): Array<string>
+/**
+ * The `openStore` `config_missing` check: every validator must name a declared
+ * sheet. Throws `ConfigError(config_missing)` otherwise.
+ */
+export declare function coreCheckValidators(declared: Array<string>, validatorNames: Array<string>): void
 /**
  * A compiled sheet definition: the embedded engine plus the definition's
  * path template (and optional raw-JS sort comparator), **compiled once** at
@@ -211,4 +261,56 @@ export declare class CompiledDefinition {
    * not per `render_path` / `compare` call.
    */
   snippetCount(): number
+}
+/**
+ * A live transaction the JS boundary suite drives. Holds a `!Send`
+ * `Transaction` (repo + private tree) and the opened `Sheet`s, so it is
+ * constructed and used on its owning JS thread — the thread-confinement the
+ * spec requires.
+ */
+export declare class CoreTransaction {
+  /**
+   * Open a transaction against `gitDir`. Resolves the parent/branch, builds
+   * the private tree, and acquires the single-writer slot. A concurrent open
+   * on the same repo throws `TransactionError(transaction_in_progress)`.
+   */
+  static begin(gitDir: string, opts: JsTransactionOptions): CoreTransaction
+  /**
+   * Open a sheet against this transaction's tree (config read + template /
+   * schema / sort comparators compiled once).
+   */
+  openSheet(name: string, configPath: string, openRoot: string, prefix: string): void
+  /**
+   * Phase 1 of the two-phase protocol *(non-mutating)*. Returns the candidate
+   * (`path`, `nextText`, and the normalized `record`) for the host validator;
+   * the candidate is stashed for a subsequent `stageUpsert`. A JSON-Schema
+   * rejection throws `ValidationError` here, before any bytes are written.
+   */
+  prepareUpsert(name: string, record: JsValue, previousPath?: string | undefined | null): object
+  /**
+   * Phase 3 *(mutating)*: write the stashed candidate from the last
+   * `prepareUpsert` for `name`. Marks the transaction mutated.
+   */
+  stageUpsert(name: string): JsStageOutcome
+  /**
+   * Pre-flight idempotency check (`Sheet.willChange`) — same phase-1 pipeline,
+   * then a byte comparison to the existing blob. Non-mutating.
+   */
+  willChange(name: string, record: JsValue, previousPath?: string | undefined | null): object
+  /**
+   * Delete a record by its sheet-relative path *(mutating)*. Throws
+   * `NotFoundError(record_not_found)` when absent.
+   */
+  delete(name: string, recordPath: string): void
+  /** `Sheet.clear` *(mutating)* — empties the sheet's data subtree. */
+  clear(name: string): void
+  /** The parent commit hash captured at open (null on a fresh repo). */
+  parentCommitHash(): string | null
+  /**
+   * Finalize: commit-on-success-only with no-op detection + `parent_moved`
+   * re-check + CAS ref movement. Consumes the transaction.
+   */
+  finalize(): JsTransactionResult
+  /** Discard without committing (handler threw). Releases the writer slot. */
+  discard(): void
 }

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -334,3 +334,6 @@ module.exports.createPatch = createPatch
 module.exports.applyMergePatch = applyMergePatch
 module.exports.diffRecords = diffRecords
 module.exports.simulateCoreError = simulateCoreError
+module.exports.CoreTransaction = CoreTransaction
+module.exports.coreDiscoverSheets = coreDiscoverSheets
+module.exports.coreCheckValidators = coreCheckValidators

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs",
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs",
     "bench": "node bench/query-bench.mjs"
   },
   "devDependencies": {

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -1052,3 +1052,349 @@ fn throw_structured_error(env: &Env, err: &gitsheets_core::Error) -> Result<()> 
     env.throw(obj)?;
     Ok(())
 }
+
+// ── orchestration: Sheet / Transaction / Store (sheet-store-core) ──────────────
+//
+// A stateful `CoreTransaction` exposes the core's state machine to a `node
+// --test` boundary suite. It demonstrates the lifecycle (commit / no-op /
+// parent_moved / transaction_in_progress) and the **two-phase consumer-validator
+// protocol**: `prepareUpsert` runs phase 1 (shape-validate → normalize → render →
+// unique-check → serialize) and hands the candidate back to JS; the host runs its
+// validator; `stageUpsert` runs phase 3 (write). No core lock is held across the
+// host callback — `prepareUpsert` and `stageUpsert` are separate FFI calls.
+
+use std::collections::HashMap;
+
+use gitsheets_core::sheet::Sheet as CoreSheet;
+use gitsheets_core::sheet::UpsertCandidate;
+use gitsheets_core::store;
+use gitsheets_core::transaction::{Author as CoreAuthor, Transaction, TransactionOptions};
+
+/// Commit identity for the JS surface.
+#[napi(object)]
+pub struct JsAuthor {
+    pub name: String,
+    pub email: String,
+}
+
+/// One ordered commit trailer (`Key: value`).
+#[napi(object)]
+pub struct JsTrailer {
+    pub key: String,
+    pub value: String,
+}
+
+/// Options for opening a [`CoreTransaction`]. `timeSeconds` / `offsetMinutes`
+/// carry the host clock + local-timezone offset (a host concern), exactly as the
+/// JS `commitTreeWithRepo` computes them today.
+#[napi(object)]
+pub struct JsTransactionOptions {
+    pub parent: Option<String>,
+    pub branch: Option<String>,
+    pub author: Option<JsAuthor>,
+    pub committer: Option<JsAuthor>,
+    pub message: String,
+    pub trailers: Option<Vec<JsTrailer>>,
+    pub time_seconds: i64,
+    pub offset_minutes: i32,
+}
+
+/// The outcome of [`CoreTransaction::finalize`]. A no-op (no mutation, or the
+/// resulting tree equals the parent's) returns `commitHash = null`.
+#[napi(object)]
+pub struct JsTransactionResult {
+    pub commit_hash: Option<String>,
+    pub tree_hash: Option<String>,
+    pub ref_name: Option<String>,
+    pub parent_commit_hash: Option<String>,
+}
+
+/// The outcome of [`CoreTransaction::stage_upsert`].
+#[napi(object)]
+pub struct JsStageOutcome {
+    pub blob_hash: String,
+    pub path: String,
+}
+
+/// A live transaction the JS boundary suite drives. Holds a `!Send`
+/// `Transaction` (repo + private tree) and the opened `Sheet`s, so it is
+/// constructed and used on its owning JS thread — the thread-confinement the
+/// spec requires.
+#[napi]
+pub struct CoreTransaction {
+    inner: Option<Transaction>,
+    sheets: HashMap<String, CoreSheet>,
+    pending: HashMap<String, UpsertCandidate>,
+}
+
+#[napi]
+impl CoreTransaction {
+    /// Open a transaction against `gitDir`. Resolves the parent/branch, builds
+    /// the private tree, and acquires the single-writer slot. A concurrent open
+    /// on the same repo throws `TransactionError(transaction_in_progress)`.
+    #[napi(factory)]
+    pub fn begin(env: Env, git_dir: String, opts: JsTransactionOptions) -> Result<Self> {
+        let core_opts = TransactionOptions {
+            parent: opts.parent,
+            branch: opts.branch,
+            author: opts.author.map(|a| CoreAuthor {
+                name: a.name,
+                email: a.email,
+            }),
+            committer: opts.committer.map(|a| CoreAuthor {
+                name: a.name,
+                email: a.email,
+            }),
+            message: opts.message,
+            trailers: opts
+                .trailers
+                .unwrap_or_default()
+                .into_iter()
+                .map(|t| (t.key, t.value))
+                .collect(),
+            time_seconds: opts.time_seconds,
+            offset_minutes: opts.offset_minutes,
+        };
+        match Transaction::begin(&git_dir, core_opts) {
+            Ok(tx) => Ok(CoreTransaction {
+                inner: Some(tx),
+                sheets: HashMap::new(),
+                pending: HashMap::new(),
+            }),
+            Err(err) => Err(raise_core_error(&env, &err)),
+        }
+    }
+
+    /// Open a sheet against this transaction's tree (config read + template /
+    /// schema / sort comparators compiled once).
+    #[napi]
+    pub fn open_sheet(
+        &mut self,
+        env: Env,
+        name: String,
+        config_path: String,
+        open_root: String,
+        prefix: String,
+    ) -> Result<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let (repo, tree) = tx.split();
+        match CoreSheet::open(repo, tree, &name, &config_path, &open_root, &prefix) {
+            Ok(sheet) => {
+                sheets.insert(name, sheet);
+                Ok(())
+            }
+            Err(err) => Err(raise_core_error(&env, &err)),
+        }
+    }
+
+    /// Phase 1 of the two-phase protocol *(non-mutating)*. Returns the candidate
+    /// (`path`, `nextText`, and the normalized `record`) for the host validator;
+    /// the candidate is stashed for a subsequent `stageUpsert`. A JSON-Schema
+    /// rejection throws `ValidationError` here, before any bytes are written.
+    #[napi]
+    pub fn prepare_upsert(
+        &mut self,
+        env: Env,
+        name: String,
+        record: JsValue,
+        previous_path: Option<String>,
+    ) -> Result<JsObject> {
+        let Self {
+            inner,
+            sheets,
+            pending,
+        } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get_mut(&name)
+            .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
+        let candidate = match sheet.prepare_upsert(repo, tree, &record.0, previous_path, false) {
+            Ok(c) => c,
+            Err(err) => return Err(raise_core_error(&env, &err)),
+        };
+
+        let mut obj = env.create_object()?;
+        obj.set_named_property("path", env.create_string(&candidate.record_path)?)?;
+        obj.set_named_property("nextText", env.create_string(&candidate.next_text)?)?;
+        let rec_raw =
+            unsafe { JsValue::to_napi_value(env.raw(), JsValue(candidate.normalized.clone()))? };
+        let rec = unsafe { JsUnknown::from_napi_value(env.raw(), rec_raw)? };
+        obj.set_named_property("record", rec)?;
+
+        pending.insert(name, candidate);
+        Ok(obj)
+    }
+
+    /// Phase 3 *(mutating)*: write the stashed candidate from the last
+    /// `prepareUpsert` for `name`. Marks the transaction mutated.
+    #[napi]
+    pub fn stage_upsert(&mut self, env: Env, name: String) -> Result<JsStageOutcome> {
+        let Self {
+            inner,
+            sheets,
+            pending,
+        } = self;
+        let candidate = pending.remove(&name).ok_or_else(|| {
+            Error::new(
+                Status::InvalidArg,
+                format!("no prepared candidate for sheet {name:?}"),
+            )
+        })?;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let outcome = {
+            let (repo, tree) = tx.split();
+            let sheet = sheets.get_mut(&name).ok_or_else(|| {
+                Error::new(Status::InvalidArg, format!("sheet {name:?} not opened"))
+            })?;
+            match sheet.stage_upsert(repo, tree, &candidate) {
+                Ok(o) => o,
+                Err(err) => return Err(raise_core_error(&env, &err)),
+            }
+        };
+        tx.mark_mutated();
+        Ok(JsStageOutcome {
+            blob_hash: outcome.blob_hash,
+            path: outcome.path,
+        })
+    }
+
+    /// Pre-flight idempotency check (`Sheet.willChange`) — same phase-1 pipeline,
+    /// then a byte comparison to the existing blob. Non-mutating.
+    #[napi]
+    pub fn will_change(
+        &mut self,
+        env: Env,
+        name: String,
+        record: JsValue,
+        previous_path: Option<String>,
+    ) -> Result<JsObject> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get_mut(&name)
+            .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
+        let wc = match sheet.will_change(repo, tree, &record.0, previous_path, false) {
+            Ok(w) => w,
+            Err(err) => return Err(raise_core_error(&env, &err)),
+        };
+        let mut obj = env.create_object()?;
+        obj.set_named_property("changed", env.get_boolean(wc.changed)?)?;
+        obj.set_named_property("path", env.create_string(&wc.path)?)?;
+        match &wc.current_blob_hash {
+            Some(h) => obj.set_named_property("currentBlobHash", env.create_string(h)?)?,
+            None => obj.set_named_property("currentBlobHash", env.get_null()?)?,
+        }
+        obj.set_named_property("nextText", env.create_string(&wc.next_text)?)?;
+        Ok(obj)
+    }
+
+    /// Delete a record by its sheet-relative path *(mutating)*. Throws
+    /// `NotFoundError(record_not_found)` when absent.
+    #[napi]
+    pub fn delete(&mut self, env: Env, name: String, record_path: String) -> Result<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets.get_mut(&name).ok_or_else(|| {
+                Error::new(Status::InvalidArg, format!("sheet {name:?} not opened"))
+            })?;
+            if let Err(err) = sheet.delete_at_path(repo, tree, &record_path) {
+                return Err(raise_core_error(&env, &err));
+            }
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// `Sheet.clear` *(mutating)* — empties the sheet's data subtree.
+    #[napi]
+    pub fn clear(&mut self, env: Env, name: String) -> Result<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets.get_mut(&name).ok_or_else(|| {
+                Error::new(Status::InvalidArg, format!("sheet {name:?} not opened"))
+            })?;
+            if let Err(err) = sheet.clear(repo, tree) {
+                return Err(raise_core_error(&env, &err));
+            }
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// The parent commit hash captured at open (null on a fresh repo).
+    #[napi]
+    pub fn parent_commit_hash(&self) -> Option<String> {
+        self.inner.as_ref().and_then(|t| t.parent_commit_hash())
+    }
+
+    /// Finalize: commit-on-success-only with no-op detection + `parent_moved`
+    /// re-check + CAS ref movement. Consumes the transaction.
+    #[napi]
+    pub fn finalize(&mut self, env: Env) -> Result<JsTransactionResult> {
+        let tx = self.inner.take().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        match tx.finalize() {
+            Ok(r) => Ok(JsTransactionResult {
+                commit_hash: r.commit_hash,
+                tree_hash: r.tree_hash,
+                ref_name: r.ref_name,
+                parent_commit_hash: r.parent_commit_hash,
+            }),
+            Err(err) => Err(raise_core_error(&env, &err)),
+        }
+    }
+
+    /// Discard without committing (handler threw). Releases the writer slot.
+    #[napi]
+    pub fn discard(&mut self) {
+        if let Some(tx) = self.inner.take() {
+            tx.discard();
+        }
+    }
+}
+
+/// Discover every sheet declared in `<openRoot>/.gitsheets/*.toml` in the tree
+/// `treeRef`. Sorted bare names. The `Store` discovery half (`openStore`).
+#[napi]
+pub fn core_discover_sheets(
+    env: Env,
+    git_dir: String,
+    tree_ref: String,
+    open_root: String,
+) -> Result<Vec<String>> {
+    let repo = record::open_repo(&git_dir).map_err(|err| raise_core_error(&env, &err))?;
+    let mut tree =
+        record::resolve_tree(&repo, &tree_ref).map_err(|err| raise_core_error(&env, &err))?;
+    store::discover_sheets(&repo, &mut tree, &open_root).map_err(|err| raise_core_error(&env, &err))
+}
+
+/// The `openStore` `config_missing` check: every validator must name a declared
+/// sheet. Throws `ConfigError(config_missing)` otherwise.
+#[napi]
+pub fn core_check_validators(
+    env: Env,
+    declared: Vec<String>,
+    validator_names: Vec<String>,
+) -> Result<()> {
+    store::check_validators(&declared, &validator_names).map_err(|err| raise_core_error(&env, &err))
+}

--- a/rust/gitsheets-napi/test/sheet-store.mjs
+++ b/rust/gitsheets-napi/test/sheet-store.mjs
@@ -1,0 +1,332 @@
+// Sheet / Transaction / Store orchestration boundary suite for gitsheets-napi.
+//
+// Drives the core's state machine through the napi `CoreTransaction` and proves
+// behavioral parity with specs/api/{transaction,sheet,store}.md +
+// behaviors/transactions.md:
+//   - the full transaction lifecycle: commit (with identity + trailers + the
+//     written record), no-op detection (re-upsert of byte-identical bytes), the
+//     optimistic parent_moved conflict, and the transaction_in_progress guard;
+//   - the TWO-PHASE consumer-validator protocol: prepareUpsert (phase 1) hands a
+//     candidate to the host validator, which can REJECT before stageUpsert
+//     (phase 3) writes any bytes;
+//   - Store discovery + the config_missing validator check.
+//
+// Requires the addon to be built first: `npm run build:debug` (or `build`).
+// Run with: `npm test` (node --test).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../binding.cjs');
+} catch (err) {
+  throw new Error(
+    `gitsheets-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+const { CoreTransaction, coreDiscoverSheets, coreCheckValidators } = binding;
+
+const CONFIG = "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n";
+
+// A repo with `.gitsheets/people.toml` committed on `main`, HEAD symbolic to it.
+function setupRepo(config = CONFIG) {
+  const dir = mkdtempSync(join(tmpdir(), 'gitsheets-sscore-'));
+  execFileSync('git', ['init', '-q', '-b', 'main', dir]);
+  execFileSync('git', ['-C', dir, 'config', 'user.name', 'Seed']);
+  execFileSync('git', ['-C', dir, 'config', 'user.email', 'seed@x.org']);
+  mkdirSync(join(dir, '.gitsheets'), { recursive: true });
+  writeFileSync(join(dir, '.gitsheets/people.toml'), config);
+  execFileSync('git', ['-C', dir, 'add', '.gitsheets/people.toml']);
+  execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'init']);
+  return { dir, gitDir: join(dir, '.git') };
+}
+
+function defaultOpts(message, extra = {}) {
+  return {
+    parent: undefined,
+    branch: undefined,
+    author: { name: 'Jane Doe', email: 'jane@x.org' },
+    committer: undefined,
+    message,
+    trailers: undefined,
+    timeSeconds: 1_700_000_000,
+    offsetMinutes: -300,
+    ...extra,
+  };
+}
+
+// Drive one full prepare → (host validator) → stage → finalize cycle.
+function upsertOne(gitDir, opts, record, validate) {
+  const tx = CoreTransaction.begin(gitDir, opts);
+  try {
+    tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+    const candidate = tx.prepareUpsert('people', record);
+    if (validate) validate(candidate.record); // host-side consumer validator
+    tx.stageUpsert('people');
+    return tx.finalize();
+  } catch (err) {
+    tx.discard();
+    throw err;
+  }
+}
+
+function gitLog(gitDir, format) {
+  return execFileSync('git', ['--git-dir', gitDir, 'log', '-1', `--format=${format}`])
+    .toString()
+    .trim();
+}
+
+test('full upsert commits with identity, trailers, and the written record', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const opts = defaultOpts('people: add jane', {
+      trailers: [{ key: 'Action', value: 'person.create' }],
+    });
+    const result = upsertOne(gitDir, opts, { slug: 'jane', email: 'jane@x.org' });
+
+    assert.match(result.commitHash, /^[0-9a-f]{40}$/, 'a commit was produced');
+    assert.equal(result.refName, 'refs/heads/main');
+
+    // Branch advanced; identity + trailer survived.
+    assert.equal(gitLog(gitDir, '%H'), result.commitHash);
+    assert.equal(gitLog(gitDir, '%an'), 'Jane Doe');
+    assert.equal(gitLog(gitDir, '%ae'), 'jane@x.org');
+    assert.equal(gitLog(gitDir, '%cn'), 'Jane Doe'); // committer falls back to author
+    const body = gitLog(gitDir, '%B');
+    assert.match(body, /people: add jane/);
+    assert.match(body, /Action: person\.create/);
+
+    // The record landed at people/jane.toml with canonical (key-sorted) bytes.
+    const blob = execFileSync('git', [
+      '--git-dir',
+      gitDir,
+      'show',
+      `${result.commitHash}:people/jane.toml`,
+    ]).toString();
+    assert.equal(blob, 'email = "jane@x.org"\nslug = "jane"\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('re-upsert of byte-identical record is a no-op (no commit)', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const first = upsertOne(gitDir, defaultOpts('add jane'), { slug: 'jane', email: 'j@x.org' });
+    assert.ok(first.commitHash);
+
+    const second = upsertOne(gitDir, defaultOpts('re-add jane'), { slug: 'jane', email: 'j@x.org' });
+    assert.equal(second.commitHash ?? null, null, 'tree-hash equality → no commit');
+    assert.equal(second.refName ?? null, null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('no mutating call short-circuits finalize to a no-op', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('nothing'));
+    const result = tx.finalize();
+    assert.equal(result.commitHash ?? null, null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('parent_moved when the branch advances mid-transaction', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('add jane'));
+    tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+    const cand = tx.prepareUpsert('people', { slug: 'jane' });
+    tx.stageUpsert('people');
+
+    // A separate process commits to refs/heads/main.
+    execFileSync('git', ['-C', dir, 'commit', '-q', '--allow-empty', '-m', 'external']);
+
+    void cand;
+    assert.throws(
+      () => tx.finalize(),
+      (err) => err.code === 'parent_moved',
+      'finalize detects the parent move',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a concurrent open on the same repo is transaction_in_progress', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const tx1 = CoreTransaction.begin(gitDir, defaultOpts('first'));
+    try {
+      assert.throws(
+        () => CoreTransaction.begin(gitDir, defaultOpts('second')),
+        (err) => err.code === 'transaction_in_progress',
+      );
+    } finally {
+      tx1.discard();
+    }
+    // Slot freed — a fresh open succeeds.
+    const tx2 = CoreTransaction.begin(gitDir, defaultOpts('third'));
+    tx2.discard();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── the two-phase consumer-validator protocol ──────────────────────────────────
+
+test('the consumer validator can REJECT a write before any bytes are written', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    // A host-side validator that requires a non-empty email (Zod/Pydantic stand-in).
+    const validate = (record) => {
+      if (typeof record.email !== 'string' || record.email.length === 0) {
+        throw new Error('email is required');
+      }
+    };
+
+    // Phase 1 returns the candidate; the host validator throws; phase 3 (stage)
+    // never runs → no bytes, the finalize is a no-op.
+    assert.throws(
+      () => upsertOne(gitDir, defaultOpts('bad'), { slug: 'bad' }, validate),
+      /email is required/,
+    );
+
+    // Prove nothing was written: a fresh transaction sees no people/bad.toml.
+    assert.throws(
+      () => execFileSync('git', ['--git-dir', gitDir, 'show', 'HEAD:people/bad.toml'], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+      }),
+      'the rejected record was never committed',
+    );
+
+    // And the same record, once it passes the validator, DOES commit.
+    const ok = upsertOne(gitDir, defaultOpts('good'), { slug: 'good', email: 'g@x.org' }, validate);
+    assert.ok(ok.commitHash);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('willChange reports idempotency without mutating', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    upsertOne(gitDir, defaultOpts('add jane'), { slug: 'jane', email: 'j@x.org' });
+
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('check'));
+    try {
+      tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+      const same = tx.willChange('people', { slug: 'jane', email: 'j@x.org' });
+      assert.equal(same.changed, false, 'byte-identical → no change');
+      assert.match(same.currentBlobHash, /^[0-9a-f]{40}$/);
+
+      const diff = tx.willChange('people', { slug: 'jane', email: 'new@x.org' });
+      assert.equal(diff.changed, true);
+    } finally {
+      // willChange never mutated → finalize is a no-op; discard to free the slot.
+      tx.discard();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('JSON-Schema shape validation rejects in phase 1', () => {
+  const config =
+    "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n" +
+    "[gitsheet.schema]\ntype = 'object'\nrequired = ['email']\n" +
+    "[gitsheet.schema.properties.email]\ntype = 'string'\nformat = 'email'\n";
+  const { dir, gitDir } = setupRepo(config);
+  try {
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('bad'));
+    try {
+      tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+      assert.throws(
+        () => tx.prepareUpsert('people', { slug: 'jane', email: 'not-an-email' }),
+        (err) => err.code === 'validation_failed' && err.gitsheetsClass === 'ValidationError',
+      );
+    } finally {
+      tx.discard();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('delete and clear', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    upsertOne(gitDir, defaultOpts('add jane'), { slug: 'jane' });
+    upsertOne(gitDir, defaultOpts('add bob'), { slug: 'bob' });
+
+    // delete jane
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('delete jane'));
+    let result;
+    try {
+      tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+      tx.delete('people', 'jane');
+      result = tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+    assert.ok(result.commitHash);
+    assert.throws(() =>
+      execFileSync('git', ['--git-dir', gitDir, 'show', 'HEAD:people/jane.toml'], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+      }),
+    );
+    // bob survives
+    execFileSync('git', ['--git-dir', gitDir, 'show', 'HEAD:people/bob.toml']);
+
+    // delete of a missing record throws record_not_found
+    const tx2 = CoreTransaction.begin(gitDir, defaultOpts('delete ghost'));
+    try {
+      tx2.openSheet('people', '.gitsheets/people.toml', '.', '');
+      assert.throws(
+        () => tx2.delete('people', 'ghost'),
+        (err) => err.code === 'record_not_found',
+      );
+    } finally {
+      tx2.discard();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Store discovery + validator check ──────────────────────────────────────────
+
+test('discover_sheets enumerates .gitsheets/*.toml', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    // Add a second sheet config and commit.
+    writeFileSync(join(dir, '.gitsheets/projects.toml'), "[gitsheet]\npath = '${{ slug }}'\n");
+    execFileSync('git', ['-C', dir, 'add', '.gitsheets/projects.toml']);
+    execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'add projects']);
+
+    const names = coreDiscoverSheets(gitDir, 'HEAD', '.');
+    assert.deepEqual(names, ['people', 'projects']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('check_validators flags a validator naming a missing sheet', () => {
+  assert.doesNotThrow(() => coreCheckValidators(['people', 'projects'], ['people']));
+  assert.throws(
+    () => coreCheckValidators(['people'], ['projects']),
+    (err) => err.code === 'config_missing' && err.name === 'ConfigError',
+  );
+});


### PR DESCRIPTION
Lifts the orchestration layer — `Sheet`, `Transaction`, `Store` — into `gitsheets-core` on top of the record + query/index engine, the behavior-parity capstone of the core. Implements `plans/sheet-store-core.md` (refs #127).

## What landed

**`config.rs`** — parses `.gitsheets/<name>.toml` into `SheetConfig` (root, path template, field sort rules, JSON Schema, format), a port of `loadConfig`.

**`sheet.rs`** — the compiled-once sheet handle composing the lower primitives into the upsert pipeline, split into the **two-phase consumer-validator protocol**:
- `prepare_upsert` (phase 1, non-mutating): JSON-Schema shape validation → canonical normalization (array-field sorts + deep key sort) → path render → unique-index conflict check → canonical serialize, returning the candidate.
- host gate: the binding runs the consumer validator (Zod/Pydantic) on the candidate; a rejection throws before phase 3.
- `stage_upsert` (phase 3, mutating): rename-delete + blob write.

Because phases 1 and 3 are separate FFI calls with **no core lock held between them**, the host callback never re-enters the core while it holds state — the re-entrancy hazard is structurally avoided. Plus `will_change`, `delete`, `clear`, `normalize_record`, `path_for_record`, and Sheet-level **index build-caching** keyed by the data-tree hash (invalidated on mutation).

**`transaction.rs`** — parent resolution (branch / hash / default-HEAD), the optimistic `parent_moved` re-check, no-op detection (tree-hash equality), `commit_tree` + CAS `update_ref` with explicit author/committer identity + trailers, and a process-wide single-writer guard (`transaction_in_progress`).

**`store.rs`** — sheet discovery (`.gitsheets/*.toml`) + the `config_missing` validator check.

**napi** — a stateful `CoreTransaction` drives the two-phase protocol from JS; a `node --test` boundary suite proves the lifecycle parity end-to-end.

## Bytes vs. semantics

Per the plan, byte/tree-level correctness is verified against the **new Rust canonical form** (not the v1.0 `@iarna` bytes — the cutover's concern), while behavioral parity (lifecycle, parent_moved, no-op, strict/permissive, identity, validation rejection) is verified against the existing JS semantics.

## Deferrals

- **Markdown/mdx record codec** — config is still parsed + validated, but record ops on a markdown sheet fail loudly (`config_invalid`); the frontmatter codec is a follow-up. TOML (the v1.0 default) is fully implemented.
- **`--working` tree path** — out of scope (deferred per the plan).
- **Strict mode + async mutex queueing** — host-Repository concerns (the core owns the detectable `transaction_in_progress` + `parent_moved` guards); they re-thin into the bindings (`node-binding-thin` / `python-binding`).

## Validation

- `cargo build --workspace` ✅ · `cargo test --workspace` ✅ (110 core tests incl. full lifecycle + pipeline) · `cargo clippy --workspace --all-targets -- -D warnings` ✅ clean
- napi addon builds; `node --test` boundary suite ✅ 61/61 (incl. 11 new sheet/transaction/store cases)
- main JS suite stays green + independent of the addon: `npm test` ✅ (287 + 66) · `npm run type-check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd