### PR TITLE
feat(python): pyo3 binding over gitsheets-core

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
 
       # Node is needed only for the cross-binding byte-identical proof: the
       # Python parity suite drives the napi binding through _node_writer.mjs and

--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -124,3 +124,54 @@ jobs:
         # plans/record-query-index.md Notes.
         working-directory: rust/gitsheets-napi
         run: npm run bench
+
+  python:
+    name: gitsheets-py (pyo3 wheel + parity)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # The Sheet/Transaction commit tests + the cross-binding commit-parity test
+      # commit to scratch repos, whose update_ref writes a reflog needing a
+      # committer identity from git config (same requirement as the other jobs).
+      - name: Configure git identity (commit-bearing tests write reflogs)
+        run: |
+          git config --global user.name "gitsheets CI"
+          git config --global user.email "ci@gitsheets.local"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - uses: astral-sh/setup-uv@v8
+
+      # Node is needed only for the cross-binding byte-identical proof: the
+      # Python parity suite drives the napi binding through _node_writer.mjs and
+      # asserts the resulting tree/blob/commit bytes match.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Build the napi addon (release) — the cross-binding parity peer
+        working-directory: rust/gitsheets-napi
+        run: |
+          npm install
+          npm run build
+
+      - name: Build + install the gitsheets-py wheel (maturin/abi3)
+        working-directory: rust/gitsheets-py
+        run: |
+          uv venv
+          uv pip install maturin pytest pydantic
+          .venv/bin/maturin build --release --out dist
+          uv pip install --no-index --find-links dist gitsheets
+
+      - name: Smoke + cross-binding byte-identical parity tests
+        working-directory: rust/gitsheets-py
+        run: .venv/bin/pytest tests/ -v

--- a/plans/python-binding.md
+++ b/plans/python-binding.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: [sheet-store-core]
 specs:
   - specs/rust-core.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/211
 ---
 
 # Plan: Python binding (pyo3)
@@ -39,15 +40,19 @@ core plan).
 
 ## Validation
 
-- [ ] A record written via **Python** and a record written via **Node** for the
+- [x] A record written via **Python** and a record written via **Node** for the
       same input produce **byte-identical** commits (the cross-binding consistency
-      proof — the architecture's whole point).
-- [ ] A definition-embedded JS snippet yields identical results under Python and
-      Node.
-- [ ] Type fidelity: a `datetime` round-trips Python → core → on-disk → Node as the
-      same instant.
-- [ ] Wheels build + install on the target platforms; a smoke test round-trips
-      upsert→commit.
+      proof — the architecture's whole point). `tests/test_cross_binding.py` —
+      identical tree, blob, AND commit hashes for both bindings over the same core
+      (4 passing tests; concrete `typed`-fixture run in PR #211).
+- [x] A definition-embedded JS snippet yields identical results under Python and
+      Node (`test_embedded_engine_comparator_identical_across_bindings`).
+- [x] Type fidelity: a `datetime` round-trips Python → core → on-disk → Node as the
+      same instant; int/float stay distinct (smoke + cross-binding `typed` fixture).
+- [x] Wheels build + install on this platform; a smoke test round-trips
+      upsert→commit (abi3 `cp39-abi3-manylinux` wheel built with maturin, installed
+      into a uv venv, `pytest tests/` = 21/21). The full per-platform release
+      matrix + trusted publishing is a documented follow-up.
 
 ## Risks / unknowns
 
@@ -60,8 +65,68 @@ core plan).
 
 ## Notes
 
-(Populated at closeout.)
+Built `rust/gitsheets-py` — a net-new pyo3 (0.29, abi3-py39) workspace member
+over the *unmodified* `gitsheets-core`. No change to the core or the Node binding;
+only the shared `rust/Cargo.toml` `members` line + `Cargo.lock`.
+
+**Surface.** Mirrors the full napi entry-point set, batch-first: marshalling
+round-trip, canonical TOML parse/serialize, path-template render, JSON-Schema
+validate, the embedded **boa** engine (`run_comparator` + `CompiledDefinition`),
+record CRUD/list/diff over holo-tree, query + candidates + field-names,
+unique/multi indices, RFC 6902/7396 patch, substrate stats, and the
+Sheet/Transaction/Store state machine (`CoreTransaction`) with the two-phase
+consumer-validator protocol. A pure-Python `gitsheets/__init__.py` adds the
+idiomatic surface (`transact` context manager, `Transaction` facade); the
+consumer validator is any callable (Pydantic `model_validate`, etc.) run on the
+normalized record between `prepare_upsert` and `stage_upsert`.
+
+**Type fidelity.** `int` ↔ Integer (Python arbitrary-precision in, `i64` core; an
+out-of-`i64` int raises `OverflowError` — no 2^53 dance), `float` ↔ Float (kept
+distinct), `str`/`bool`, `datetime.datetime` ↔ Datetime, `dict` ↔ Table,
+`list`/`tuple` ↔ Array. Datetimes funnel through the *same* epoch-millis bridge as
+the napi `Date` mapping (aware-UTC instant; naive treated as UTC; sub-ms dropped),
+which is what makes a Python `datetime` and a JS `Date` at the same instant
+serialize to identical bytes. Datetime detection is `isinstance` against the
+runtime `datetime` class (abi3-safe — no datetime C-API).
+
+**Cross-binding byte-identical proof (the headline).** `test_cross_binding.py`
+writes the same logical record from Python and from Node (the napi binding,
+driven through `_node_writer.mjs`) and asserts identical tree + blob hashes
+(`record_write`, content-addressed) AND identical commit hashes (full
+upsert→commit from a shared seed). PASSED for real on linux — e.g. the `typed`
+fixture (`count = 7` int, `ratio = 1.5` float, `when = …Z` datetime) yields tree
+`bf0a0b1e…` / blob `83a5df2b…` from both bindings. Commit parity also passes. No
+bytes-authority leak found.
+
+**GIL / thread model.** pyo3 holds the GIL per call. The two `!Send` stateful
+classes (boa engine; `gix::Repository` + holo-tree thread-local cache) are
+declared `#[pyclass(unsendable)]`, so pyo3 pins each instance to its creating
+thread — the runtime enforcement of the core's thread-confinement requirement.
+The two-phase protocol holds no core borrow across the Python validator callback
+(`prepare_upsert` and `stage_upsert` are separate FFI calls); the single-writer
+registry lock is only held briefly in begin/finalize/discard.
+
+**Packaging.** maturin mixed layout (`python-source = "python"`,
+`module-name = "gitsheets._gitsheets"`), abi3-py39 → one wheel per platform for
+CPython ≥ 3.9. Locally: `gitsheets-0.0.0-cp39-abi3-manylinux_2_39_x86_64.whl`
+built + installed into a uv venv; `pytest tests/` = 21/21. A `python` CI job
+(`.github/workflows/rust-core.yml`) builds the wheel + the napi peer and runs the
+suite. The per-platform release matrix + trusted publishing is deferred (below).
+
+**Validations run:** `cargo clippy --workspace --all-targets -- -D warnings`
+clean; `cargo test -p gitsheets-core` 110+ pass (core untouched); napi `npm test`
+61/61 (independent); `pytest tests/` 21/21.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Per-platform wheel release matrix + trusted publishing** (taxonomy: packaging
+  / release-track). Mirror the holo-tree prebuild playbook: a
+  `PyO3/maturin-action` build matrix across the six targets (incl. musl + macOS +
+  windows) + sdist, and PyPI trusted publishing on tag. This plan scaffolded the
+  maturin config + a single-platform CI build; the release matrix is its own track.
+- **Async surface** (taxonomy: ergonomics). Sync-only today (matches Node's sync
+  core surface); add `asyncio` wrappers only if a real consumer needs them.
+- **`Store`/`Repository` high-level Python API** (taxonomy: ergonomics). The
+  binding exposes the `CoreTransaction` primitive + a thin `transact` helper; a
+  fuller idiomatic `Store.open(...)` / sheet-handle API can layer on later without
+  touching the core.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -804,6 +804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitsheets-py"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+ "gitsheets-core",
+ "indexmap",
+ "pyo3",
+ "toml",
+]
+
+[[package]]
 name = "gix"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1767,6 +1778,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -1777,6 +1791,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holo-tree"
@@ -2545,6 +2565,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+dependencies = [
+ "indexmap",
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +3004,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["gitsheets-core", "gitsheets-napi"]
+members = ["gitsheets-core", "gitsheets-napi", "gitsheets-py"]
 resolver = "2"
 
 [workspace.package]

--- a/rust/gitsheets-py/.gitignore
+++ b/rust/gitsheets-py/.gitignore
@@ -1,0 +1,8 @@
+# Python virtualenvs + build/test artifacts (built per-platform in CI).
+.venv/
+dist/
+build/
+*.egg-info/
+__pycache__/
+.pytest_cache/
+*.so

--- a/rust/gitsheets-py/Cargo.toml
+++ b/rust/gitsheets-py/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gitsheets-py"
+description = "Python (pyo3) binding for gitsheets-core: marshals records between Python and the Rust core with full TOML type fidelity."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+name = "gitsheets_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+gitsheets-core = { version = "0.0.0", path = "../gitsheets-core" }
+indexmap = "2"
+pyo3 = { version = "0.29.0", features = ["extension-module", "abi3-py39", "indexmap"] }
+toml = "0.8"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/rust/gitsheets-py/README.md
+++ b/rust/gitsheets-py/README.md
@@ -1,0 +1,58 @@
+# gitsheets (Python)
+
+The Python binding for [gitsheets](https://github.com/JarvusInnovations/gitsheets) —
+a git-backed document store for low-volume, high-touch, human-scale data.
+
+It is a thin [pyo3](https://pyo3.rs) binding over the shared Rust
+`gitsheets-core` engine. Everything that determines on-disk bytes (canonical
+TOML, path-template rendering, JSON-Schema validation, the embedded JS engine,
+the Sheet/Transaction/Store state machine) lives in the core, so **a record
+written from Python and the same record written from the Node binding produce
+byte-identical trees, blobs, and commits.**
+
+## Type fidelity
+
+The binding marshals Python natives ↔ the core's TOML-faithful value type:
+
+| Python                | core `Value`      | TOML                       |
+| --------------------- | ----------------- | -------------------------- |
+| `int`                 | `Integer` (`i64`) | integer (distinct from float) |
+| `float`               | `Float` (`f64`)   | float (`1` ≠ `1.0`)        |
+| `str`                 | `String`          | string                     |
+| `bool`                | `Boolean`         | boolean                    |
+| `datetime.datetime`   | `Datetime`        | datetime (aware UTC instant) |
+| `dict`                | `Table`           | table                      |
+| `list` / `tuple`      | `Array`           | array                      |
+
+Python's `int` is arbitrary-precision, so small ids stay ergonomic and large
+values never lose precision (an `int` outside the `i64` range TOML permits
+raises `OverflowError`).
+
+## Consumer validators
+
+The runtime consumer-validator hook runs Python-side on the normalized record
+before the core writes any bytes — pass any callable (a Pydantic
+`Model.model_validate`, a Zod-style check, a plain assertion):
+
+```python
+import gitsheets
+from pydantic import BaseModel
+
+class Person(BaseModel):
+    slug: str
+    email: str
+
+with gitsheets.transact(git_dir, "add jane", time_seconds, author=("Jane", "jane@x.org"), branch="refs/heads/main") as tx:
+    tx.open_sheet("people", ".gitsheets/people.toml")
+    tx.upsert("people", {"slug": "jane", "email": "jane@x.org"}, validate=Person.model_validate)
+```
+
+## Development
+
+Build a local wheel and run the smoke + cross-binding parity suite:
+
+```bash
+uv venv && uv pip install maturin pytest pydantic
+uv run maturin develop
+uv run pytest tests/
+```

--- a/rust/gitsheets-py/pyproject.toml
+++ b/rust/gitsheets-py/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "gitsheets"
+description = "Python binding for gitsheets-core — a git-backed document store, over the shared Rust engine."
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+readme = "README.md"
+authors = [{ name = "Jarvus Innovations" }]
+classifiers = [
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "License :: OSI Approved :: Apache Software License",
+]
+dynamic = ["version"]
+
+[project.urls]
+Repository = "https://github.com/JarvusInnovations/gitsheets"
+
+[project.optional-dependencies]
+# The consumer-validator hook is validator-agnostic (any callable / Pydantic
+# model). Pydantic is pulled in only for the dev/test parity suite.
+test = ["pytest>=8", "pydantic>=2"]
+
+[tool.maturin]
+# Mixed Rust/Python layout: the compiled extension is `gitsheets._gitsheets`,
+# wrapped by the pure-Python idiomatic surface under `python/gitsheets/`.
+module-name = "gitsheets._gitsheets"
+python-source = "python"
+manifest-path = "Cargo.toml"
+# abi3 wheels: one wheel per platform works on CPython >= 3.9.
+features = ["pyo3/abi3-py39"]

--- a/rust/gitsheets-py/python/gitsheets/__init__.py
+++ b/rust/gitsheets-py/python/gitsheets/__init__.py
@@ -1,0 +1,212 @@
+"""gitsheets — a git-backed document store, Python binding.
+
+This is the thin Python surface over the compiled ``gitsheets._gitsheets``
+extension, which is itself a thin pyo3 binding over the shared Rust
+``gitsheets-core`` engine. Everything that determines on-disk bytes (canonical
+TOML, path rendering, validation, the embedded JS engine, the
+Sheet/Transaction/Store state machine) lives in the core — so a record written
+from Python and the same record written from the Node binding produce
+byte-identical trees, blobs, and commits.
+
+The binding marshals Python natives ↔ the core value type with full TOML type
+fidelity: ``int`` ↔ TOML integer (arbitrary precision in, ``i64`` in the core),
+``float`` ↔ TOML float (kept distinct from int), ``datetime.datetime`` ↔ TOML
+datetime (an aware UTC instant, mirroring the Node ``Date`` projection),
+``dict`` ↔ table, ``list`` ↔ array.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional
+
+from . import _gitsheets as _core
+
+# ── re-exported native surface ────────────────────────────────────────────────
+
+# Typed exception hierarchy (mirrors the Node binding's GitsheetsError classes).
+GitsheetsError = _core.GitsheetsError
+ConfigError = _core.ConfigError
+ValidationError = _core.ValidationError
+TransactionError = _core.TransactionError
+IndexError = _core.IndexError  # noqa: A001 — intentional: gitsheets.IndexError
+RefError = _core.RefError
+PathTemplateError = _core.PathTemplateError
+NotFoundError = _core.NotFoundError
+
+# Stateful classes.
+CompiledDefinition = _core.CompiledDefinition
+CoreTransaction = _core.CoreTransaction
+
+# Batch-first functions (the FFI marshalling boundary).
+roundtrip = _core.roundtrip
+parse_records = _core.parse_records
+serialize_records = _core.serialize_records
+render_paths_batch = _core.render_paths_batch
+validate_batch = _core.validate_batch
+run_comparator = _core.run_comparator
+record_read = _core.record_read
+record_write = _core.record_write
+record_delete = _core.record_delete
+record_list = _core.record_list
+substrate_stats = _core.substrate_stats
+substrate_reset = _core.substrate_reset
+create_patch = _core.create_patch
+apply_merge_patch = _core.apply_merge_patch
+diff_records = _core.diff_records
+record_query = _core.record_query
+record_query_candidates = _core.record_query_candidates
+template_field_names = _core.template_field_names
+record_index_unique = _core.record_index_unique
+record_index_multi = _core.record_index_multi
+core_discover_sheets = _core.core_discover_sheets
+core_check_validators = _core.core_check_validators
+simulate_core_error = _core.simulate_core_error
+
+#: The git empty-tree hash — a valid ``base_ref`` for a from-scratch write.
+EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+__all__ = [
+    "GitsheetsError",
+    "ConfigError",
+    "ValidationError",
+    "TransactionError",
+    "IndexError",
+    "RefError",
+    "PathTemplateError",
+    "NotFoundError",
+    "CompiledDefinition",
+    "CoreTransaction",
+    "Transaction",
+    "transact",
+    "EMPTY_TREE_HASH",
+    "roundtrip",
+    "parse_records",
+    "serialize_records",
+    "render_paths_batch",
+    "validate_batch",
+    "run_comparator",
+    "record_read",
+    "record_write",
+    "record_delete",
+    "record_list",
+    "substrate_stats",
+    "substrate_reset",
+    "create_patch",
+    "apply_merge_patch",
+    "diff_records",
+    "record_query",
+    "record_query_candidates",
+    "template_field_names",
+    "record_index_unique",
+    "record_index_multi",
+    "core_discover_sheets",
+    "core_check_validators",
+    "simulate_core_error",
+]
+
+# Type for a consumer-supplied runtime validator: it receives the normalized
+# record (a dict) and either returns / mutates nothing on success or raises to
+# reject the write before any bytes are staged.
+Validator = Callable[[dict], Any]
+
+
+class Transaction:
+    """An idiomatic facade over :class:`CoreTransaction`.
+
+    Drives the two-phase consumer-validator protocol: :meth:`upsert` runs the
+    core's phase-1 pipeline (shape-validate → normalize → render → unique-check
+    → serialize), hands the normalized record to the optional Python
+    ``validate`` callback, and only then stages the write. The callback runs
+    with **no core lock held** — phase 1 and phase 3 are separate FFI calls.
+
+    Use via :func:`transact`, which commits on success and discards on error.
+    """
+
+    def __init__(self, inner: CoreTransaction) -> None:
+        self._inner = inner
+
+    def open_sheet(
+        self,
+        name: str,
+        config_path: str,
+        open_root: str = ".",
+        prefix: str = "",
+    ) -> "Transaction":
+        self._inner.open_sheet(name, config_path, open_root, prefix)
+        return self
+
+    def upsert(
+        self,
+        sheet: str,
+        record: dict,
+        *,
+        validate: Optional[Validator] = None,
+        previous_path: Optional[str] = None,
+    ) -> dict:
+        """Upsert ``record`` into ``sheet`` (prepare → validate → stage)."""
+        candidate = self._inner.prepare_upsert(sheet, record, previous_path)
+        if validate is not None:
+            validate(candidate["record"])
+        return self._inner.stage_upsert(sheet)
+
+    def will_change(
+        self,
+        sheet: str,
+        record: dict,
+        previous_path: Optional[str] = None,
+    ) -> dict:
+        return self._inner.will_change(sheet, record, previous_path)
+
+    def delete(self, sheet: str, record_path: str) -> None:
+        self._inner.delete(sheet, record_path)
+
+    def clear(self, sheet: str) -> None:
+        self._inner.clear(sheet)
+
+    @property
+    def parent_commit_hash(self) -> Optional[str]:
+        return self._inner.parent_commit_hash()
+
+
+@contextmanager
+def transact(
+    git_dir: str,
+    message: str,
+    time_seconds: int,
+    *,
+    offset_minutes: int = 0,
+    parent: Optional[str] = None,
+    branch: Optional[str] = None,
+    author: Optional[tuple[str, str]] = None,
+    committer: Optional[tuple[str, str]] = None,
+    trailers: Optional[list[tuple[str, str]]] = None,
+) -> Iterator[Transaction]:
+    """Open a transaction, commit on success, discard on error.
+
+    Yields a :class:`Transaction`. On clean exit the transaction is finalized
+    (commit-on-success-only, with no-op detection); on exception it is
+    discarded, releasing the single-writer slot. The finalized result dict is
+    available on the manager's ``.result`` after the block via the returned
+    facade's ``_result`` — most callers just need the commit to land, so the
+    common path is fire-and-forget.
+    """
+    inner = CoreTransaction.begin(
+        git_dir,
+        message,
+        time_seconds,
+        offset_minutes,
+        parent,
+        branch,
+        author,
+        committer,
+        trailers,
+    )
+    facade = Transaction(inner)
+    try:
+        yield facade
+    except BaseException:
+        inner.discard()
+        raise
+    else:
+        facade.result = inner.finalize()  # type: ignore[attr-defined]

--- a/rust/gitsheets-py/src/lib.rs
+++ b/rust/gitsheets-py/src/lib.rs
@@ -1,0 +1,11 @@
+//! `gitsheets-py` — the Python (pyo3) binding for `gitsheets-core`.
+//!
+//! Scaffold only; the marshalling boundary + entry points land in the next
+//! commit.
+
+use pyo3::prelude::*;
+
+#[pymodule]
+fn _gitsheets(_m: &Bound<'_, PyModule>) -> PyResult<()> {
+    Ok(())
+}

--- a/rust/gitsheets-py/src/lib.rs
+++ b/rust/gitsheets-py/src/lib.rs
@@ -1,11 +1,1225 @@
-//! `gitsheets-py` — the Python (pyo3) binding for `gitsheets-core`.
+//! `gitsheets-py` — the Python (pyo3) binding for [`gitsheets_core`].
 //!
-//! Scaffold only; the marshalling boundary + entry points land in the next
-//! commit.
+//! This crate is the **second** binding over the same Rust core, and its whole
+//! reason to exist is to prove the thin-binding model: everything that
+//! determines on-disk bytes lives in `gitsheets-core`, so a record written from
+//! Python and the same record written from Node produce **byte-identical**
+//! trees, blobs, and commits. The binding owns exactly one thing — **marshalling**
+//! between Python host objects and the core's TOML-faithful
+//! [`Value`](gitsheets_core::Value), with the type-fidelity rules from
+//! [`specs/rust-core.md`](../../../specs/rust-core.md):
+//!
+//! - **Integers** — the core stores `i64`; Python's `int` is arbitrary-precision,
+//!   so it maps directly (no 2^53 dance like JS). An inbound `int` outside the
+//!   `i64` range TOML permits raises `OverflowError`.
+//! - **Floats** — `f64`, kept distinct from integers (`1` and `1.0` differ).
+//! - **Datetimes** — all four TOML kinds live in the core; the binding surfaces
+//!   them as an aware UTC `datetime.datetime`, mirroring the Node `Date` mapping
+//!   (an absolute instant at UTC), with the precise kind retained core-side.
+//! - **Tables ↔ `dict`, arrays ↔ `list`, strings/bools** — obvious.
+//!
+//! Errors cross as typed Python exceptions (a `GitsheetsError` hierarchy mirroring
+//! the Node `binding.cjs` classes), each carrying `code`/`status`/
+//! `gitsheets_class` plus `issues`/`conflicting_paths` payloads.
+//!
+//! GIL / thread model: pyo3 holds the GIL across each call. The stateful classes
+//! ([`CompiledDefinition`], [`CoreTransaction`]) hold a `!Send` boa engine and a
+//! `gix::Repository`, so they are declared `unsendable` — pyo3 pins them to their
+//! creating thread, which is exactly the thread-confinement the embedded engine
+//! and holo-tree's thread-local cache require. The two-phase consumer-validator
+//! protocol (`prepare_upsert` → host validates → `stage_upsert`) holds no core
+//! borrow across the Python callback: they are separate FFI calls.
 
+use std::collections::HashMap;
+
+use chrono::{Datelike, Timelike};
+use gitsheets_core::diff::{MergePatch, PatchOp, PatchValue};
+use gitsheets_core::engine::Engine;
+use gitsheets_core::index::{MultiIndex, UniqueIndex};
+use gitsheets_core::path_template::Template;
+use gitsheets_core::query::{self, Filter, FilterPred};
+use gitsheets_core::record;
+use gitsheets_core::sheet::{Sheet as CoreSheet, UpsertCandidate};
+use gitsheets_core::store;
+use gitsheets_core::transaction::{Author as CoreAuthor, Transaction, TransactionOptions};
+use gitsheets_core::validation::CompiledSchema;
+use gitsheets_core::{Datetime, Value};
+use indexmap::IndexMap;
+use pyo3::create_exception;
+use pyo3::exceptions::{PyException, PyOverflowError, PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
+use toml::value::{Date as TomlDate, Datetime as TomlDatetime, Offset, Time as TomlTime};
+
+const DEFAULT_EXTENSION: &str = ".toml";
+
+fn extension_of(extension: Option<String>) -> String {
+    extension.unwrap_or_else(|| DEFAULT_EXTENSION.to_string())
+}
+
+// ── typed exception hierarchy (mirrors binding.cjs) ───────────────────────────
+
+create_exception!(_gitsheets, GitsheetsError, PyException);
+create_exception!(_gitsheets, ConfigError, GitsheetsError);
+create_exception!(_gitsheets, ValidationError, GitsheetsError);
+create_exception!(_gitsheets, TransactionError, GitsheetsError);
+create_exception!(_gitsheets, IndexError, GitsheetsError);
+create_exception!(_gitsheets, RefError, GitsheetsError);
+create_exception!(_gitsheets, PathTemplateError, GitsheetsError);
+create_exception!(_gitsheets, NotFoundError, GitsheetsError);
+
+/// Map a structured core error onto its typed Python exception, attaching the
+/// `code`/`status`/`gitsheets_class` discriminants and any `issues` /
+/// `conflicting_paths` payloads — the Python analogue of `binding.cjs`'s
+/// `mapCoreError` + the napi `throw_structured_error`.
+fn raise_core_error(py: Python<'_>, err: &gitsheets_core::Error) -> PyErr {
+    let class = err.class().as_str();
+    let message = err.message().to_string();
+    let pyerr = match class {
+        "ConfigError" => ConfigError::new_err(message),
+        "ValidationError" => ValidationError::new_err(message),
+        "TransactionError" => TransactionError::new_err(message),
+        "IndexError" => IndexError::new_err(message),
+        "RefError" => RefError::new_err(message),
+        "PathTemplateError" => PathTemplateError::new_err(message),
+        "NotFoundError" => NotFoundError::new_err(message),
+        _ => GitsheetsError::new_err(message),
+    };
+    let value = pyerr.value(py);
+    let _ = value.setattr("code", err.code());
+    let _ = value.setattr("status", err.status());
+    let _ = value.setattr("gitsheets_class", class);
+
+    let issues = err.issues();
+    if !issues.is_empty() {
+        let list = PyList::empty(py);
+        for issue in issues {
+            let d = PyDict::new(py);
+            let _ = d.set_item("path", issue.path.clone());
+            let _ = d.set_item("message", issue.message.clone());
+            let _ = d.set_item("source", issue.source.as_str());
+            let _ = d.set_item("schema_path", issue.schema_path.clone());
+            let _ = d.set_item("code", issue.code.clone());
+            let _ = list.append(d);
+        }
+        let _ = value.setattr("issues", list);
+    }
+    let paths = err.conflicting_paths();
+    if !paths.is_empty() {
+        let _ = value.setattr("conflicting_paths", paths.to_vec());
+    }
+    pyerr
+}
+
+// ── core Value <-> Python marshalling ─────────────────────────────────────────
+
+/// Is this object a `datetime.datetime`? Detected by `isinstance` against the
+/// runtime `datetime` class (abi3-safe — no datetime C-API needed).
+fn is_py_datetime(obj: &Bound<'_, PyAny>) -> PyResult<bool> {
+    let cls = obj.py().import("datetime")?.getattr("datetime")?;
+    obj.is_instance(&cls)
+}
+
+/// Marshal a Python object into a core [`Value`] with full type fidelity. The
+/// type order matters: `bool` is a subclass of `int` in Python, so it is checked
+/// first.
+fn py_to_value(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
+    if let Ok(b) = obj.cast::<PyBool>() {
+        return Ok(Value::Boolean(b.is_true()));
+    }
+    if obj.cast::<PyInt>().is_ok() {
+        let v: i64 = obj.extract().map_err(|_| {
+            PyOverflowError::new_err("integer is outside the i64 range TOML permits")
+        })?;
+        return Ok(Value::Integer(v));
+    }
+    if let Ok(f) = obj.cast::<PyFloat>() {
+        return Ok(Value::Float(f.value()));
+    }
+    if let Ok(s) = obj.cast::<PyString>() {
+        return Ok(Value::String(s.extract::<String>()?));
+    }
+    if is_py_datetime(obj)? {
+        return Ok(Value::Datetime(py_datetime_to_core(obj)?));
+    }
+    if let Ok(d) = obj.cast::<PyDict>() {
+        let mut map = IndexMap::new();
+        for (k, v) in d.iter() {
+            let key: String = k
+                .extract()
+                .map_err(|_| PyTypeError::new_err("table (dict) keys must be strings"))?;
+            map.insert(key, py_to_value(&v)?);
+        }
+        return Ok(Value::Table(map));
+    }
+    if let Ok(l) = obj.cast::<PyList>() {
+        let mut items = Vec::with_capacity(l.len());
+        for item in l.iter() {
+            items.push(py_to_value(&item)?);
+        }
+        return Ok(Value::Array(items));
+    }
+    if let Ok(t) = obj.cast::<PyTuple>() {
+        let mut items = Vec::with_capacity(t.len());
+        for item in t.iter() {
+            items.push(py_to_value(&item)?);
+        }
+        return Ok(Value::Array(items));
+    }
+    let type_name = obj.get_type().name()?.to_string();
+    Err(PyTypeError::new_err(format!(
+        "cannot marshal Python value of type {type_name} to a TOML value (None has no TOML representation)"
+    )))
+}
+
+/// Marshal a core [`Value`] back to a Python object.
+fn value_to_py<'py>(py: Python<'py>, value: Value) -> PyResult<Bound<'py, PyAny>> {
+    Ok(match value {
+        Value::String(s) => s.into_pyobject(py)?.into_any(),
+        Value::Boolean(b) => b.into_pyobject(py)?.to_owned().into_any(),
+        Value::Integer(i) => i.into_pyobject(py)?.into_any(),
+        Value::Float(f) => f.into_pyobject(py)?.into_any(),
+        Value::Datetime(dt) => core_datetime_to_py(py, &dt)?,
+        Value::Array(items) => {
+            let list = PyList::empty(py);
+            for item in items {
+                list.append(value_to_py(py, item)?)?;
+            }
+            list.into_any()
+        }
+        Value::Table(map) => {
+            let dict = PyDict::new(py);
+            for (k, v) in map {
+                dict.set_item(k, value_to_py(py, v)?)?;
+            }
+            dict.into_any()
+        }
+    })
+}
+
+fn opt_value_to_py<'py>(py: Python<'py>, value: Option<Value>) -> PyResult<Bound<'py, PyAny>> {
+    match value {
+        Some(v) => value_to_py(py, v),
+        None => Ok(py.None().into_bound(py)),
+    }
+}
+
+/// Marshal an iterable of Python records into a `Vec<Value>` (one FFI crossing
+/// for the whole batch).
+fn py_records_to_values(obj: &Bound<'_, PyAny>) -> PyResult<Vec<Value>> {
+    let mut out = Vec::new();
+    for item in obj.try_iter()? {
+        out.push(py_to_value(&item?)?);
+    }
+    Ok(out)
+}
+
+// ── datetime <-> Python datetime bridge (host-surface concern) ────────────────
+
+/// Build an offset-datetime (UTC `Z`) core datetime from epoch milliseconds —
+/// byte-identical to the napi `unix_millis_to_datetime`, so a Python `datetime`
+/// and a JS `Date` at the same instant produce the same core value.
+fn unix_millis_to_datetime(ms: i64) -> PyResult<Datetime> {
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+        .ok_or_else(|| PyValueError::new_err(format!("datetime {ms} ms is out of range")))?;
+    let toml_dt = TomlDatetime {
+        date: Some(TomlDate {
+            year: dt.year() as u16,
+            month: dt.month() as u8,
+            day: dt.day() as u8,
+        }),
+        time: Some(TomlTime {
+            hour: dt.hour() as u8,
+            minute: dt.minute() as u8,
+            second: dt.second() as u8,
+            nanosecond: dt.nanosecond(),
+        }),
+        offset: Some(Offset::Z),
+    };
+    Ok(Datetime(toml_dt))
+}
+
+/// Epoch milliseconds for any of the four datetime kinds — byte-identical to the
+/// napi `datetime_to_unix_millis` (local kinds projected to UTC for the surface;
+/// the core retains the precise kind for re-serialization).
+fn datetime_to_unix_millis(dt: &Datetime) -> PyResult<i64> {
+    let TomlDatetime { date, time, offset } = dt.0;
+    let date = date.unwrap_or(TomlDate {
+        year: 1970,
+        month: 1,
+        day: 1,
+    });
+    let time = time.unwrap_or(TomlTime {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        nanosecond: 0,
+    });
+    let naive_date =
+        chrono::NaiveDate::from_ymd_opt(date.year as i32, date.month as u32, date.day as u32)
+            .ok_or_else(|| PyValueError::new_err("datetime has an invalid date"))?;
+    let naive_time = chrono::NaiveTime::from_hms_nano_opt(
+        time.hour as u32,
+        time.minute as u32,
+        time.second as u32,
+        time.nanosecond,
+    )
+    .ok_or_else(|| PyValueError::new_err("datetime has an invalid time"))?;
+    let naive = chrono::NaiveDateTime::new(naive_date, naive_time);
+    let offset_minutes: i64 = match offset {
+        Some(Offset::Z) => 0,
+        Some(Offset::Custom { minutes }) => minutes as i64,
+        None => 0,
+    };
+    Ok(naive.and_utc().timestamp_millis() - offset_minutes * 60_000)
+}
+
+/// Convert a Python `datetime.datetime` to a core datetime. Aware datetimes are
+/// converted to UTC; naive ones are interpreted as UTC (matching the Node
+/// `Date`-as-instant projection). The instant funnels through the same
+/// epoch-millis bridge as napi, so the resulting core value is byte-identical.
+fn py_datetime_to_core(obj: &Bound<'_, PyAny>) -> PyResult<Datetime> {
+    let py = obj.py();
+    let utc = py.import("datetime")?.getattr("timezone")?.getattr("utc")?;
+    let tzinfo = obj.getattr("tzinfo")?;
+    let norm = if tzinfo.is_none() {
+        obj.clone()
+    } else {
+        obj.call_method1("astimezone", (utc,))?
+    };
+    let year: i32 = norm.getattr("year")?.extract()?;
+    let month: u32 = norm.getattr("month")?.extract()?;
+    let day: u32 = norm.getattr("day")?.extract()?;
+    let hour: u32 = norm.getattr("hour")?.extract()?;
+    let minute: u32 = norm.getattr("minute")?.extract()?;
+    let second: u32 = norm.getattr("second")?.extract()?;
+    let micro: u32 = norm.getattr("microsecond")?.extract()?;
+    let date = chrono::NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| PyValueError::new_err("datetime has an invalid date"))?;
+    let time = chrono::NaiveTime::from_hms_micro_opt(hour, minute, second, micro)
+        .ok_or_else(|| PyValueError::new_err("datetime has an invalid time"))?;
+    let ms = chrono::NaiveDateTime::new(date, time).and_utc().timestamp_millis();
+    unix_millis_to_datetime(ms)
+}
+
+/// Build an aware UTC Python `datetime.datetime` from a core datetime, mirroring
+/// the napi `Date` projection (the absolute instant at UTC).
+fn core_datetime_to_py<'py>(py: Python<'py>, dt: &Datetime) -> PyResult<Bound<'py, PyAny>> {
+    let ms = datetime_to_unix_millis(dt)?;
+    let cdt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+        .ok_or_else(|| PyValueError::new_err("datetime is out of range"))?;
+    let dt_mod = py.import("datetime")?;
+    let utc = dt_mod.getattr("timezone")?.getattr("utc")?;
+    let cls = dt_mod.getattr("datetime")?;
+    let micro = cdt.nanosecond() / 1000;
+    let args = (
+        cdt.year(),
+        cdt.month(),
+        cdt.day(),
+        cdt.hour(),
+        cdt.minute(),
+        cdt.second(),
+        micro,
+        utc,
+    );
+    cls.call1(args)
+}
+
+// ── marshalling round-trip + canonical bytes-authority (batch-first) ──────────
+
+/// Round-trip a batch of records through the core, preserving full type
+/// fidelity. The whole list crosses the FFI once.
+#[pyfunction]
+fn roundtrip<'py>(py: Python<'py>, records: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyList>> {
+    let core = py_records_to_values(records)?;
+    let out = PyList::empty(py);
+    for v in gitsheets_core::echo_batch(core) {
+        out.append(value_to_py(py, v)?)?;
+    }
+    Ok(out)
+}
+
+/// Parse a batch of TOML documents into records with full type fidelity.
+#[pyfunction]
+fn parse_records<'py>(py: Python<'py>, documents: Vec<String>) -> PyResult<Bound<'py, PyList>> {
+    match gitsheets_core::parse_batch(documents) {
+        Ok(values) => {
+            let out = PyList::empty(py);
+            for v in values {
+                out.append(value_to_py(py, v)?)?;
+            }
+            Ok(out)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
+}
+
+/// Serialize a batch of records to their canonical TOML bytes in one call.
+#[pyfunction]
+fn serialize_records(py: Python<'_>, records: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
+    let values = py_records_to_values(records)?;
+    gitsheets_core::serialize_batch(&values).map_err(|err| raise_core_error(py, &err))
+}
+
+// ── definition logic: path templates, validation, embedded engine ────────────
+
+/// Render a path template against a batch of records (the template + its embedded
+/// snippets compiled once, reused across the batch).
+#[pyfunction]
+fn render_paths_batch(
+    py: Python<'_>,
+    template: String,
+    records: &Bound<'_, PyAny>,
+) -> PyResult<Vec<String>> {
+    let values = py_records_to_values(records)?;
+    let mut engine = Engine::new().map_err(|err| raise_core_error(py, &err))?;
+    let compiled = Template::compile(&template, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+    let mut out = Vec::with_capacity(values.len());
+    for record in &values {
+        out.push(
+            compiled
+                .render(record, &mut engine)
+                .map_err(|e| raise_core_error(py, &e))?,
+        );
+    }
+    Ok(out)
+}
+
+/// Validate a batch of records against a JSON Schema (compiled once). Returns the
+/// issues per record (an empty inner list ⇒ valid).
+#[pyfunction]
+fn validate_batch<'py>(
+    py: Python<'py>,
+    schema: &Bound<'py, PyAny>,
+    records: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyList>> {
+    let schema_val = py_to_value(schema)?;
+    let values = py_records_to_values(records)?;
+    let compiled = CompiledSchema::compile(&schema_val).map_err(|e| raise_core_error(py, &e))?;
+    let out = PyList::empty(py);
+    for record in &values {
+        let issues = PyList::empty(py);
+        for issue in compiled.validate(record) {
+            let d = PyDict::new(py);
+            d.set_item("path", issue.path)?;
+            d.set_item("message", issue.message)?;
+            d.set_item("source", issue.source.as_str())?;
+            d.set_item("schema_path", issue.schema_path)?;
+            d.set_item("code", issue.code)?;
+            issues.append(d)?;
+        }
+        out.append(issues)?;
+    }
+    Ok(out)
+}
+
+/// Compile a raw-JS sort comparator (`rule`, the body of `(a, b) => { … }`) and
+/// run it once against `a`/`b` in the **core's** boa engine — so Python's result
+/// matches Node's for the identical snippet.
+#[pyfunction]
+fn run_comparator(
+    py: Python<'_>,
+    rule: String,
+    a: &Bound<'_, PyAny>,
+    b: &Bound<'_, PyAny>,
+) -> PyResult<f64> {
+    let a_val = py_to_value(a)?;
+    let b_val = py_to_value(b)?;
+    let mut engine = Engine::new().map_err(|err| raise_core_error(py, &err))?;
+    let wrapped = format!("(a, b) => {{ {rule} }}");
+    let handle = engine.compile(&wrapped).map_err(|e| raise_core_error(py, &e))?;
+    let result = engine
+        .call(handle, &[a_val, b_val])
+        .map_err(|e| PyRuntimeError::new_err(format!("{e:?}")))?;
+    engine.to_number(&result).map_err(|e| raise_core_error(py, &e))
+}
+
+/// A compiled sheet definition: the embedded engine plus the path template (and
+/// optional raw-JS sort comparator), compiled once and reused. Holds a `!Send`
+/// boa context → `unsendable` (pinned to its creating thread).
+#[pyclass(unsendable)]
+struct CompiledDefinition {
+    engine: Engine,
+    template: Template,
+    sort_handle: Option<usize>,
+}
+
+#[pymethods]
+impl CompiledDefinition {
+    #[new]
+    #[pyo3(signature = (path_template, sort_rule=None))]
+    fn new(py: Python<'_>, path_template: String, sort_rule: Option<String>) -> PyResult<Self> {
+        let mut engine = Engine::new().map_err(|err| raise_core_error(py, &err))?;
+        let template =
+            Template::compile(&path_template, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+        let sort_handle = match sort_rule {
+            Some(rule) => {
+                let wrapped = format!("(a, b) => {{ {rule} }}");
+                Some(engine.compile(&wrapped).map_err(|e| raise_core_error(py, &e))?)
+            }
+            None => None,
+        };
+        Ok(CompiledDefinition {
+            engine,
+            template,
+            sort_handle,
+        })
+    }
+
+    fn render_path(&mut self, py: Python<'_>, record: &Bound<'_, PyAny>) -> PyResult<String> {
+        let value = py_to_value(record)?;
+        self.template
+            .render(&value, &mut self.engine)
+            .map_err(|e| raise_core_error(py, &e))
+    }
+
+    fn compare(&mut self, a: &Bound<'_, PyAny>, b: &Bound<'_, PyAny>) -> PyResult<f64> {
+        let handle = self
+            .sort_handle
+            .ok_or_else(|| PyValueError::new_err("definition has no sort rule"))?;
+        let a_val = py_to_value(a)?;
+        let b_val = py_to_value(b)?;
+        let result = self
+            .engine
+            .call(handle, &[a_val, b_val])
+            .map_err(|e| PyRuntimeError::new_err(format!("{e:?}")))?;
+        self.engine
+            .to_number(&result)
+            .map_err(|e| PyRuntimeError::new_err(e.message().to_string()))
+    }
+
+    fn snippet_count(&self) -> u32 {
+        self.engine.snippet_count() as u32
+    }
+}
+
+// ── record CRUD + diff/patch over the holo-tree substrate (batch-first) ───────
+
+/// Read a batch of records by path. Each result is the record (a `dict` with full
+/// TOML type fidelity) or `None` when no blob lives at that path.
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, base, paths, extension=None))]
+fn record_read<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    paths: Vec<String>,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyList>> {
+    let ext = extension_of(extension);
+    match record::read_records_at_ref(&git_dir, &tree_ref, &base, &paths, &ext) {
+        Ok(values) => {
+            let out = PyList::empty(py);
+            for v in values {
+                out.append(opt_value_to_py(py, v)?)?;
+            }
+            Ok(out)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
+}
+
+/// Write a batch of records (canonical TOML) under `base` starting from the tree
+/// `base_ref`. Returns `{ "tree_hash", "blob_hashes" }`. The bytes come from the
+/// core's bytes-authority, so two bindings writing the same record agree
+/// byte-for-byte.
+#[pyfunction]
+#[pyo3(signature = (git_dir, base_ref, base, paths, records, extension=None))]
+fn record_write<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    base_ref: String,
+    base: String,
+    paths: Vec<String>,
+    records: &Bound<'py, PyAny>,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let values = py_records_to_values(records)?;
+    if paths.len() != values.len() {
+        return Err(PyValueError::new_err(format!(
+            "record_write: paths ({}) and records ({}) length mismatch",
+            paths.len(),
+            values.len()
+        )));
+    }
+    let items: Vec<(String, Value)> = paths.into_iter().zip(values).collect();
+    let ext = extension_of(extension);
+    match record::write_records_at_ref(&git_dir, &base_ref, &base, &items, &ext) {
+        Ok(outcome) => {
+            let d = PyDict::new(py);
+            d.set_item("tree_hash", outcome.tree_hash)?;
+            d.set_item("blob_hashes", outcome.blob_hashes)?;
+            Ok(d)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
+}
+
+/// Delete a batch of records by path under `base`. Returns
+/// `{ "tree_hash", "existed" }`.
+#[pyfunction]
+#[pyo3(signature = (git_dir, base_ref, base, paths, extension=None))]
+fn record_delete<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    base_ref: String,
+    base: String,
+    paths: Vec<String>,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let ext = extension_of(extension);
+    match record::delete_records_at_ref(&git_dir, &base_ref, &base, &paths, &ext) {
+        Ok(outcome) => {
+            let d = PyDict::new(py);
+            d.set_item("tree_hash", outcome.tree_hash)?;
+            d.set_item("existed", outcome.existed)?;
+            Ok(d)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
+}
+
+/// List every record under `base` in sorted (git-canonical) path order. Each
+/// entry is `{ "path", "record" }`.
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, base, extension=None))]
+fn record_list<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyList>> {
+    let ext = extension_of(extension);
+    match record::list_records_at_ref(&git_dir, &tree_ref, &base, &ext) {
+        Ok(entries) => {
+            let out = PyList::empty(py);
+            for (path, rec) in entries {
+                let d = PyDict::new(py);
+                d.set_item("path", path)?;
+                d.set_item("record", value_to_py(py, rec)?)?;
+                out.append(d)?;
+            }
+            Ok(out)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
+}
+
+/// A snapshot of holo-tree's process-wide tree/blob counters.
+#[pyfunction]
+fn substrate_stats(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
+    let s = record::substrate_stats();
+    let d = PyDict::new(py);
+    d.set_item("trees_read", s.trees_read as i64)?;
+    d.set_item("trees_written", s.trees_written as i64)?;
+    d.set_item("trees_skipped_clean", s.trees_skipped_clean as i64)?;
+    d.set_item("cache_hits", s.cache_hits as i64)?;
+    d.set_item("cache_misses", s.cache_misses as i64)?;
+    d.set_item("blobs_read", s.blobs_read as i64)?;
+    Ok(d)
+}
+
+/// Reset the substrate counters + the thread-local tree cache.
+#[pyfunction]
+fn substrate_reset() {
+    record::substrate_reset();
+}
+
+// ── diff / patch primitives (RFC 6902 / RFC 7396) ─────────────────────────────
+
+/// Build a Python list of RFC 6902 ops shaped like the `rfc6902` package: a
+/// `remove` carries no `value` key, a null-replace carries `value: None`,
+/// everything else carries the marshalled value.
+fn build_patch_list<'py>(py: Python<'py>, ops: &[PatchOp]) -> PyResult<Bound<'py, PyList>> {
+    let list = PyList::empty(py);
+    for op in ops {
+        let d = PyDict::new(py);
+        d.set_item("op", op.op.as_str())?;
+        d.set_item("path", op.path.clone())?;
+        match &op.value {
+            PatchValue::Absent => {}
+            PatchValue::Null => d.set_item("value", py.None())?,
+            PatchValue::Value(v) => d.set_item("value", value_to_py(py, v.clone())?)?,
+        }
+        list.append(d)?;
+    }
+    Ok(list)
+}
+
+/// Generate an RFC 6902 JSON Patch transforming `src` into `dst`. `None` on
+/// either side is the JSON null `Sheet.diffFrom` passes for an added/deleted
+/// record.
+#[pyfunction]
+#[pyo3(signature = (src=None, dst=None))]
+fn create_patch<'py>(
+    py: Python<'py>,
+    src: Option<&Bound<'py, PyAny>>,
+    dst: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyList>> {
+    let src_val = match src {
+        Some(o) if !o.is_none() => Some(py_to_value(o)?),
+        _ => None,
+    };
+    let dst_val = match dst {
+        Some(o) if !o.is_none() => Some(py_to_value(o)?),
+        _ => None,
+    };
+    let ops = gitsheets_core::create_patch(src_val.as_ref(), dst_val.as_ref());
+    build_patch_list(py, &ops)
+}
+
+/// Parse a Python object into an RFC 7396 merge patch: `None` ⇒ delete, a `dict`
+/// ⇒ recursive merge, anything else ⇒ wholesale replace.
+fn py_to_merge_patch(obj: &Bound<'_, PyAny>) -> PyResult<MergePatch> {
+    if obj.is_none() {
+        return Ok(MergePatch::Delete);
+    }
+    if let Ok(d) = obj.cast::<PyDict>() {
+        // A datetime is a dict? No — only plain dicts merge; datetimes are caught
+        // by py_to_value below. (PyDict downcast only matches real dicts.)
+        let mut map = IndexMap::new();
+        for (k, v) in d.iter() {
+            let key: String = k
+                .extract()
+                .map_err(|_| PyTypeError::new_err("merge-patch keys must be strings"))?;
+            map.insert(key, py_to_merge_patch(&v)?);
+        }
+        return Ok(MergePatch::Merge(map));
+    }
+    Ok(MergePatch::Replace(py_to_value(obj)?))
+}
+
+/// Apply an RFC 7396 JSON Merge Patch to `target` (`None` ⇒ absent). Returns the
+/// merged record, or `None` only when the patch deletes the record outright.
+#[pyfunction]
+#[pyo3(signature = (target, patch))]
+fn apply_merge_patch<'py>(
+    py: Python<'py>,
+    target: Option<&Bound<'py, PyAny>>,
+    patch: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let target_val = match target {
+        Some(o) if !o.is_none() => Some(py_to_value(o)?),
+        _ => None,
+    };
+    let merge = py_to_merge_patch(patch)?;
+    let merged = gitsheets_core::apply_merge_patch(target_val.as_ref(), &merge);
+    opt_value_to_py(py, merged)
+}
+
+/// Diff records between two trees (`src_ref` → `dst_ref`) under `base`, returning
+/// one entry per change with `status`, `src_hash`/`dst_hash`, the parsed
+/// `src`/`dst` records, and the RFC 6902 `patch`.
+#[pyfunction]
+#[pyo3(signature = (git_dir, src_ref, dst_ref, base, extension=None))]
+fn diff_records<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    src_ref: String,
+    dst_ref: String,
+    base: String,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyList>> {
+    let ext = extension_of(extension);
+    let diffs = record::diff_records_at_refs(&git_dir, &src_ref, &dst_ref, &base, &ext)
+        .map_err(|e| raise_core_error(py, &e))?;
+    let out = PyList::empty(py);
+    for d in diffs {
+        let obj = PyDict::new(py);
+        obj.set_item("path", d.change.path)?;
+        obj.set_item("status", d.change.status.as_str())?;
+        obj.set_item("src_hash", d.change.src_hash)?;
+        obj.set_item("dst_hash", d.change.dst_hash)?;
+        obj.set_item("src", opt_value_to_py(py, d.src)?)?;
+        obj.set_item("dst", opt_value_to_py(py, d.dst)?)?;
+        obj.set_item("patch", build_patch_list(py, &d.patch)?)?;
+        out.append(obj)?;
+    }
+    Ok(out)
+}
+
+// ── query traversal + filtering ───────────────────────────────────────────────
+
+fn parse_filter(obj: &Bound<'_, PyDict>, engine: &mut Engine) -> PyResult<Filter> {
+    let mut filter = Filter::new();
+    for (k, v) in obj.iter() {
+        let key: String = k
+            .extract()
+            .map_err(|_| PyTypeError::new_err("filter keys must be strings"))?;
+        filter.push(key, parse_filter_pred(&v, engine)?);
+    }
+    Ok(filter)
+}
+
+fn parse_filter_pred(val: &Bound<'_, PyAny>, engine: &mut Engine) -> PyResult<FilterPred> {
+    if let Ok(d) = val.cast::<PyDict>() {
+        if let Some(pred) = d.get_item("$pred")? {
+            if let Ok(s) = pred.cast::<PyString>() {
+                let src = s.extract::<String>()?;
+                let wrapped = format!("(value, record) => ( {src} )");
+                let handle = engine
+                    .compile(&wrapped)
+                    .map_err(|e| raise_core_error(val.py(), &e))?;
+                return Ok(FilterPred::Predicate(handle));
+            }
+        }
+        let nested = parse_filter(d, engine)?;
+        return Ok(FilterPred::Nested(nested));
+    }
+    Ok(FilterPred::Equals(py_to_value(val)?))
+}
+
+/// Query records under `base` in the tree `tree_ref`, returning each matched
+/// `{ "path", "record" }` in sorted path order. The template prunes the walk; the
+/// filter (equality / nested / `{"$pred": "<js>"}` snippets) runs in the core.
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, base, template, filter, extension=None))]
+fn record_query<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    template: String,
+    filter: &Bound<'py, PyDict>,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyList>> {
+    let ext = extension_of(extension);
+    let repo = record::open_repo(&git_dir).map_err(|e| raise_core_error(py, &e))?;
+    let mut tree = record::resolve_tree(&repo, &tree_ref).map_err(|e| raise_core_error(py, &e))?;
+    let mut engine = Engine::new().map_err(|e| raise_core_error(py, &e))?;
+    let compiled = Template::compile(&template, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+    let parsed = parse_filter(filter, &mut engine)?;
+    match query::query_records(&repo, &mut tree, &base, &compiled, &parsed, &mut engine, &ext) {
+        Ok(rows) => {
+            let out = PyList::empty(py);
+            for (path, rec) in rows {
+                let d = PyDict::new(py);
+                d.set_item("path", path)?;
+                d.set_item("record", value_to_py(py, rec)?)?;
+                out.append(d)?;
+            }
+            Ok(out)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
+}
+
+/// The pruning candidate set alone (no content filter) — the `Template.queryTree`
+/// parity target. `query` is a partial record of the path-template input fields.
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, base, template, query, extension=None))]
+fn record_query_candidates(
+    py: Python<'_>,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    template: String,
+    query: &Bound<'_, PyAny>,
+    extension: Option<String>,
+) -> PyResult<Vec<String>> {
+    let ext = extension_of(extension);
+    let query_val = py_to_value(query)?;
+    let repo = record::open_repo(&git_dir).map_err(|e| raise_core_error(py, &e))?;
+    let mut tree = record::resolve_tree(&repo, &tree_ref).map_err(|e| raise_core_error(py, &e))?;
+    let mut engine = Engine::new().map_err(|e| raise_core_error(py, &e))?;
+    let compiled = Template::compile(&template, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+    query::query_candidate_paths(&repo, &mut tree, &base, &compiled, &query_val, &mut engine, &ext)
+        .map_err(|e| raise_core_error(py, &e))
+}
+
+/// The record fields that contribute to rendering `template` (the query
+/// auto-derivation set).
+#[pyfunction]
+fn template_field_names(py: Python<'_>, template: String) -> PyResult<Vec<String>> {
+    let mut engine = Engine::new().map_err(|e| raise_core_error(py, &e))?;
+    let compiled = Template::compile(&template, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+    Ok(compiled.get_field_names())
+}
+
+// ── secondary indexing ─────────────────────────────────────────────────────────
+
+/// Build a unique index over the records under `base` and look up each key.
+/// `results[i]` is the record for `keys[i]`, or `None`.
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, base, key_snippet, keys, extension=None))]
+fn record_index_unique<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    key_snippet: String,
+    keys: Vec<String>,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyList>> {
+    let ext = extension_of(extension);
+    let records = record::list_records_at_ref(&git_dir, &tree_ref, &base, &ext)
+        .map_err(|e| raise_core_error(py, &e))?;
+    let mut engine = Engine::new().map_err(|e| raise_core_error(py, &e))?;
+    let handle = engine.compile(&key_snippet).map_err(|e| raise_core_error(py, &e))?;
+    let index =
+        UniqueIndex::build(&records, handle, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+    let out = PyList::empty(py);
+    for k in &keys {
+        out.append(opt_value_to_py(py, index.lookup(k).cloned())?)?;
+    }
+    Ok(out)
+}
+
+/// Build a non-unique index over the records under `base` and look up each key.
+/// `results[i]` is every record carrying `keys[i]` (an empty list when none).
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, base, key_snippet, keys, extension=None))]
+fn record_index_multi<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    tree_ref: String,
+    base: String,
+    key_snippet: String,
+    keys: Vec<String>,
+    extension: Option<String>,
+) -> PyResult<Bound<'py, PyList>> {
+    let ext = extension_of(extension);
+    let records = record::list_records_at_ref(&git_dir, &tree_ref, &base, &ext)
+        .map_err(|e| raise_core_error(py, &e))?;
+    let mut engine = Engine::new().map_err(|e| raise_core_error(py, &e))?;
+    let handle = engine.compile(&key_snippet).map_err(|e| raise_core_error(py, &e))?;
+    let index =
+        MultiIndex::build(&records, handle, &mut engine).map_err(|e| raise_core_error(py, &e))?;
+    let out = PyList::empty(py);
+    for k in &keys {
+        let inner = PyList::empty(py);
+        for (_, rec) in index.lookup(k) {
+            inner.append(value_to_py(py, rec.clone())?)?;
+        }
+        out.append(inner)?;
+    }
+    Ok(out)
+}
+
+// ── orchestration: Sheet / Transaction / Store ────────────────────────────────
+
+/// A live transaction driving the core's state machine, exposing the two-phase
+/// consumer-validator protocol. Holds a `!Send` `Transaction` (repo + private
+/// tree) → `unsendable` (pinned to its creating thread).
+#[pyclass(unsendable)]
+struct CoreTransaction {
+    inner: Option<Transaction>,
+    sheets: HashMap<String, CoreSheet>,
+    pending: HashMap<String, UpsertCandidate>,
+}
+
+#[pymethods]
+impl CoreTransaction {
+    /// Open a transaction against `git_dir`. `author`/`committer` are
+    /// `(name, email)` tuples; `trailers` a list of `(key, value)` tuples. A
+    /// concurrent open on the same repo raises `TransactionError`.
+    #[staticmethod]
+    #[pyo3(signature = (git_dir, message, time_seconds, offset_minutes=0, parent=None, branch=None, author=None, committer=None, trailers=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn begin(
+        py: Python<'_>,
+        git_dir: String,
+        message: String,
+        time_seconds: i64,
+        offset_minutes: i32,
+        parent: Option<String>,
+        branch: Option<String>,
+        author: Option<(String, String)>,
+        committer: Option<(String, String)>,
+        trailers: Option<Vec<(String, String)>>,
+    ) -> PyResult<Self> {
+        let core_opts = TransactionOptions {
+            parent,
+            branch,
+            author: author.map(|(name, email)| CoreAuthor { name, email }),
+            committer: committer.map(|(name, email)| CoreAuthor { name, email }),
+            message,
+            trailers: trailers.unwrap_or_default(),
+            time_seconds,
+            offset_minutes,
+        };
+        match Transaction::begin(&git_dir, core_opts) {
+            Ok(tx) => Ok(CoreTransaction {
+                inner: Some(tx),
+                sheets: HashMap::new(),
+                pending: HashMap::new(),
+            }),
+            Err(err) => Err(raise_core_error(py, &err)),
+        }
+    }
+
+    /// Open a sheet against this transaction's tree (config read + template /
+    /// schema / sort comparators compiled once).
+    fn open_sheet(
+        &mut self,
+        py: Python<'_>,
+        name: String,
+        config_path: String,
+        open_root: String,
+        prefix: String,
+    ) -> PyResult<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let (repo, tree) = tx.split();
+        match CoreSheet::open(repo, tree, &name, &config_path, &open_root, &prefix) {
+            Ok(sheet) => {
+                sheets.insert(name, sheet);
+                Ok(())
+            }
+            Err(err) => Err(raise_core_error(py, &err)),
+        }
+    }
+
+    /// Phase 1 (non-mutating): returns `{ "path", "next_text", "record" }` for the
+    /// host validator and stashes the candidate for `stage_upsert`. A JSON-Schema
+    /// rejection raises `ValidationError` here, before any bytes are written.
+    #[pyo3(signature = (name, record, previous_path=None))]
+    fn prepare_upsert<'py>(
+        &mut self,
+        py: Python<'py>,
+        name: String,
+        record: &Bound<'py, PyAny>,
+        previous_path: Option<String>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let record_val = py_to_value(record)?;
+        let Self {
+            inner,
+            sheets,
+            pending,
+        } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get_mut(&name)
+            .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+        let candidate = sheet
+            .prepare_upsert(repo, tree, &record_val, previous_path, false)
+            .map_err(|e| raise_core_error(py, &e))?;
+
+        let d = PyDict::new(py);
+        d.set_item("path", candidate.record_path.clone())?;
+        d.set_item("next_text", candidate.next_text.clone())?;
+        d.set_item("record", value_to_py(py, candidate.normalized.clone())?)?;
+        pending.insert(name, candidate);
+        Ok(d)
+    }
+
+    /// Phase 3 (mutating): write the stashed candidate from the last
+    /// `prepare_upsert` for `name`. Returns `{ "blob_hash", "path" }`.
+    fn stage_upsert<'py>(&mut self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyDict>> {
+        let Self {
+            inner,
+            sheets,
+            pending,
+        } = self;
+        let candidate = pending
+            .remove(&name)
+            .ok_or_else(|| PyValueError::new_err(format!("no prepared candidate for sheet {name:?}")))?;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let outcome = {
+            let (repo, tree) = tx.split();
+            let sheet = sheets
+                .get_mut(&name)
+                .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+            sheet
+                .stage_upsert(repo, tree, &candidate)
+                .map_err(|e| raise_core_error(py, &e))?
+        };
+        tx.mark_mutated();
+        let d = PyDict::new(py);
+        d.set_item("blob_hash", outcome.blob_hash)?;
+        d.set_item("path", outcome.path)?;
+        Ok(d)
+    }
+
+    /// Pre-flight idempotency check (`Sheet.willChange`). Non-mutating. Returns
+    /// `{ "changed", "path", "current_blob_hash", "next_text" }`.
+    #[pyo3(signature = (name, record, previous_path=None))]
+    fn will_change<'py>(
+        &mut self,
+        py: Python<'py>,
+        name: String,
+        record: &Bound<'py, PyAny>,
+        previous_path: Option<String>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let record_val = py_to_value(record)?;
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get_mut(&name)
+            .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+        let wc = sheet
+            .will_change(repo, tree, &record_val, previous_path, false)
+            .map_err(|e| raise_core_error(py, &e))?;
+        let d = PyDict::new(py);
+        d.set_item("changed", wc.changed)?;
+        d.set_item("path", wc.path)?;
+        d.set_item("current_blob_hash", wc.current_blob_hash)?;
+        d.set_item("next_text", wc.next_text)?;
+        Ok(d)
+    }
+
+    /// Delete a record by its sheet-relative path (mutating). Raises
+    /// `NotFoundError` when absent.
+    fn delete(&mut self, py: Python<'_>, name: String, record_path: String) -> PyResult<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets
+                .get_mut(&name)
+                .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+            sheet
+                .delete_at_path(repo, tree, &record_path)
+                .map_err(|e| raise_core_error(py, &e))?;
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// `Sheet.clear` (mutating) — empties the sheet's data subtree.
+    fn clear(&mut self, py: Python<'_>, name: String) -> PyResult<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets
+                .get_mut(&name)
+                .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+            sheet.clear(repo, tree).map_err(|e| raise_core_error(py, &e))?;
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// The parent commit hash captured at open (`None` on a fresh repo).
+    fn parent_commit_hash(&self) -> Option<String> {
+        self.inner.as_ref().and_then(|t| t.parent_commit_hash())
+    }
+
+    /// Finalize: commit-on-success-only with no-op detection + `parent_moved`
+    /// re-check + CAS ref movement. Returns `{ "commit_hash", "tree_hash",
+    /// "ref_name", "parent_commit_hash" }` (a no-op leaves `commit_hash = None`).
+    fn finalize<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let tx = self
+            .inner
+            .take()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        match tx.finalize() {
+            Ok(r) => {
+                let d = PyDict::new(py);
+                d.set_item("commit_hash", r.commit_hash)?;
+                d.set_item("tree_hash", r.tree_hash)?;
+                d.set_item("ref_name", r.ref_name)?;
+                d.set_item("parent_commit_hash", r.parent_commit_hash)?;
+                Ok(d)
+            }
+            Err(err) => Err(raise_core_error(py, &err)),
+        }
+    }
+
+    /// Discard without committing (handler raised). Releases the writer slot.
+    fn discard(&mut self) {
+        if let Some(tx) = self.inner.take() {
+            tx.discard();
+        }
+    }
+}
+
+/// Discover every sheet declared in `<open_root>/.gitsheets/*.toml` in the tree
+/// `tree_ref`. Sorted bare names.
+#[pyfunction]
+fn core_discover_sheets(
+    py: Python<'_>,
+    git_dir: String,
+    tree_ref: String,
+    open_root: String,
+) -> PyResult<Vec<String>> {
+    let repo = record::open_repo(&git_dir).map_err(|e| raise_core_error(py, &e))?;
+    let mut tree = record::resolve_tree(&repo, &tree_ref).map_err(|e| raise_core_error(py, &e))?;
+    store::discover_sheets(&repo, &mut tree, &open_root).map_err(|e| raise_core_error(py, &e))
+}
+
+/// The `open_store` `config_missing` check: every validator must name a declared
+/// sheet. Raises `ConfigError` otherwise.
+#[pyfunction]
+fn core_check_validators(
+    py: Python<'_>,
+    declared: Vec<String>,
+    validator_names: Vec<String>,
+) -> PyResult<()> {
+    store::check_validators(&declared, &validator_names).map_err(|e| raise_core_error(py, &e))
+}
+
+/// Raise the typed exception for a given stable error `code` — the boundary-test
+/// entry point exercising the error-variant → typed-class mapping.
+#[pyfunction]
+fn simulate_core_error(py: Python<'_>, code: String) -> PyResult<()> {
+    match gitsheets_core::example_error(&code) {
+        Some(err) => Err(raise_core_error(py, &err)),
+        None => Err(PyValueError::new_err(format!("unknown error code '{code}'"))),
+    }
+}
+
+// ── module ────────────────────────────────────────────────────────────────────
 
 #[pymodule]
-fn _gitsheets(_m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _gitsheets(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
+
+    // Typed exceptions.
+    m.add("GitsheetsError", py.get_type::<GitsheetsError>())?;
+    m.add("ConfigError", py.get_type::<ConfigError>())?;
+    m.add("ValidationError", py.get_type::<ValidationError>())?;
+    m.add("TransactionError", py.get_type::<TransactionError>())?;
+    m.add("IndexError", py.get_type::<IndexError>())?;
+    m.add("RefError", py.get_type::<RefError>())?;
+    m.add("PathTemplateError", py.get_type::<PathTemplateError>())?;
+    m.add("NotFoundError", py.get_type::<NotFoundError>())?;
+
+    // Stateful classes.
+    m.add_class::<CompiledDefinition>()?;
+    m.add_class::<CoreTransaction>()?;
+
+    // Functions.
+    m.add_function(wrap_pyfunction!(roundtrip, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_records, m)?)?;
+    m.add_function(wrap_pyfunction!(serialize_records, m)?)?;
+    m.add_function(wrap_pyfunction!(render_paths_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(validate_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(run_comparator, m)?)?;
+    m.add_function(wrap_pyfunction!(record_read, m)?)?;
+    m.add_function(wrap_pyfunction!(record_write, m)?)?;
+    m.add_function(wrap_pyfunction!(record_delete, m)?)?;
+    m.add_function(wrap_pyfunction!(record_list, m)?)?;
+    m.add_function(wrap_pyfunction!(substrate_stats, m)?)?;
+    m.add_function(wrap_pyfunction!(substrate_reset, m)?)?;
+    m.add_function(wrap_pyfunction!(create_patch, m)?)?;
+    m.add_function(wrap_pyfunction!(apply_merge_patch, m)?)?;
+    m.add_function(wrap_pyfunction!(diff_records, m)?)?;
+    m.add_function(wrap_pyfunction!(record_query, m)?)?;
+    m.add_function(wrap_pyfunction!(record_query_candidates, m)?)?;
+    m.add_function(wrap_pyfunction!(template_field_names, m)?)?;
+    m.add_function(wrap_pyfunction!(record_index_unique, m)?)?;
+    m.add_function(wrap_pyfunction!(record_index_multi, m)?)?;
+    m.add_function(wrap_pyfunction!(core_discover_sheets, m)?)?;
+    m.add_function(wrap_pyfunction!(core_check_validators, m)?)?;
+    m.add_function(wrap_pyfunction!(simulate_core_error, m)?)?;
+
     Ok(())
 }

--- a/rust/gitsheets-py/tests/_node_writer.mjs
+++ b/rust/gitsheets-py/tests/_node_writer.mjs
@@ -1,0 +1,75 @@
+// Cross-binding parity helper: drives the *Node* (napi) binding over the same
+// gitsheets-core, so the Python parity suite can prove byte-identical output.
+//
+// Usage: node _node_writer.mjs <op> [arg...]
+//   record-write <fixture>            → { treeHash, blobHashes }
+//   commit <gitDir>                   → { commitHash, treeHash, refName }
+//   comparator <rule> <aJson> <bJson> → { result }
+//
+// The binding.cjs path comes from $GITSHEETS_NAPI_BINDING. Fixtures are authored
+// here as native JS values (the whole point: the same logical data, expressed in
+// each host's native types, must serialize to identical bytes via the core).
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const binding = require(process.env.GITSHEETS_NAPI_BINDING);
+
+const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+// Fixtures shared with the Python side (test_cross_binding.py builds the same
+// logical records in Python natives). Keep the two in lockstep.
+const FIXTURES = {
+  basic: { email: 'jane@x.org', slug: 'jane', tags: ['a', 'b'], age: 30 },
+  // int vs float fidelity + a datetime instant (the same UTC instant the Python
+  // side constructs as datetime(2026, 6, 26, 12, 0, 0, tzinfo=utc)).
+  typed: {
+    slug: 'jane',
+    count: 7, // integral number → core Integer
+    ratio: 1.5, // → core Float
+    when: new Date(Date.UTC(2026, 5, 26, 12, 0, 0)),
+  },
+};
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj));
+}
+
+const [op, ...args] = process.argv.slice(2);
+
+if (op === 'record-write') {
+  const record = FIXTURES[args[0]];
+  const res = binding.recordWrite(args[1], EMPTY_TREE, 'people', ['jane'], [record]);
+  out({ treeHash: res.treeHash, blobHashes: res.blobHashes });
+} else if (op === 'commit') {
+  const gitDir = args[0];
+  const opts = {
+    parent: undefined,
+    branch: 'refs/heads/main',
+    author: { name: 'Jane Doe', email: 'jane@x.org' },
+    committer: undefined,
+    message: 'people: add jane',
+    trailers: [{ key: 'Action', value: 'person.create' }],
+    timeSeconds: 1_700_000_000,
+    offsetMinutes: -300,
+  };
+  const tx = binding.CoreTransaction.begin(gitDir, opts);
+  try {
+    tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+    tx.prepareUpsert('people', { slug: 'jane', email: 'jane@x.org' });
+    tx.stageUpsert('people');
+    const r = tx.finalize();
+    out({ commitHash: r.commitHash, treeHash: r.treeHash, refName: r.refName });
+  } catch (err) {
+    tx.discard();
+    throw err;
+  }
+} else if (op === 'comparator') {
+  const rule = args[0];
+  const a = JSON.parse(args[1]);
+  const b = JSON.parse(args[2]);
+  out({ result: binding.runComparator(rule, a, b) });
+} else {
+  process.stderr.write(`unknown op: ${op}\n`);
+  process.exit(2);
+}

--- a/rust/gitsheets-py/tests/test_cross_binding.py
+++ b/rust/gitsheets-py/tests/test_cross_binding.py
@@ -1,0 +1,159 @@
+"""The headline deliverable: cross-binding byte-identical proof.
+
+A record written via the **Python** binding and the same logical record written
+via the **Node** (napi) binding — both over the same `gitsheets-core` — must
+produce byte-identical trees, blobs, and commits. If these ever diverge it means
+something binding-specific leaked into the on-disk bytes (a bytes-authority
+leak), which is exactly the failure this binding exists to catch.
+
+The Node side is driven through `_node_writer.mjs` (the napi binding). It is
+skipped if the napi addon isn't built or `node` is unavailable; CI builds the
+addon so the proof runs for real there.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+import gitsheets
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_NODE_WRITER = os.path.join(_HERE, "_node_writer.mjs")
+_NAPI_DIR = os.path.abspath(os.path.join(_HERE, "..", "..", "gitsheets-napi"))
+_NAPI_BINDING = os.path.join(_NAPI_DIR, "binding.cjs")
+
+
+def _napi_built() -> bool:
+    if shutil.which("node") is None or not os.path.exists(_NAPI_BINDING):
+        return False
+    # The compiled addon is gitsheets-core.<triple>.node next to index.js.
+    return any(f.endswith(".node") for f in os.listdir(_NAPI_DIR))
+
+
+pytestmark = pytest.mark.skipif(
+    not _napi_built(),
+    reason="napi addon not built (run `npm run build` in rust/gitsheets-napi)",
+)
+
+
+def _run_node(*args) -> dict:
+    env = dict(os.environ, GITSHEETS_NAPI_BINDING=_NAPI_BINDING)
+    proc = subprocess.run(
+        ["node", _NODE_WRITER, *args], capture_output=True, env=env, cwd=_HERE
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"node helper failed: {proc.stderr.decode()}")
+    return json.loads(proc.stdout.decode())
+
+
+def _git(args, cwd=None):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+# Fixtures mirrored from _node_writer.mjs — the same logical data in Python
+# natives. The byte-identity is the assertion.
+PY_FIXTURES = {
+    "basic": {"email": "jane@x.org", "slug": "jane", "tags": ["a", "b"], "age": 30},
+    "typed": {
+        "slug": "jane",
+        "count": 7,
+        "ratio": 1.5,
+        "when": dt.datetime(2026, 6, 26, 12, 0, 0, tzinfo=dt.timezone.utc),
+    },
+}
+
+
+@pytest.mark.parametrize("fixture", ["basic", "typed"])
+def test_tree_and_blob_bytes_identical_across_bindings(fixture):
+    """record_write from Python and Node yields identical tree + blob hashes."""
+    py_dir = tempfile.mkdtemp(prefix="gs-py-")
+    node_dir = tempfile.mkdtemp(prefix="gs-node-")
+    try:
+        _git(["init", "-q", py_dir])
+        _git(["init", "-q", node_dir])
+        py = gitsheets.record_write(
+            os.path.join(py_dir, ".git"),
+            gitsheets.EMPTY_TREE_HASH,
+            "people",
+            ["jane"],
+            [PY_FIXTURES[fixture]],
+        )
+        node = _run_node("record-write", fixture, os.path.join(node_dir, ".git"))
+        assert py["tree_hash"] == node["treeHash"], "tree bytes diverged across bindings"
+        assert py["blob_hashes"] == node["blobHashes"], "blob bytes diverged across bindings"
+    finally:
+        shutil.rmtree(py_dir, ignore_errors=True)
+        shutil.rmtree(node_dir, ignore_errors=True)
+
+
+def test_commit_bytes_identical_across_bindings():
+    """A full upsert→commit produces the same commit hash from both bindings.
+
+    Both bindings start from an identical seed commit (the same repo copied), get
+    identical author/committer/time/message/trailers + the same record, so the
+    resulting commit object must be byte-identical.
+    """
+    seed = tempfile.mkdtemp(prefix="gs-seed-")
+    _git(["init", "-q", "-b", "main", seed])
+    _git(["config", "user.name", "Seed"], cwd=seed)
+    _git(["config", "user.email", "seed@x.org"], cwd=seed)
+    os.makedirs(os.path.join(seed, ".gitsheets"))
+    with open(os.path.join(seed, ".gitsheets", "people.toml"), "w") as fh:
+        fh.write("[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n")
+    _git(["add", ".gitsheets/people.toml"], cwd=seed)
+    # Fixed identity + date so the seed commit is reproducible (identical in both
+    # copies — guaranteed anyway since we copy the dir).
+    env = dict(
+        os.environ,
+        GIT_AUTHOR_DATE="2020-01-01T00:00:00Z",
+        GIT_COMMITTER_DATE="2020-01-01T00:00:00Z",
+    )
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "init"], cwd=seed, check=True, capture_output=True, env=env
+    )
+
+    py_dir = tempfile.mkdtemp(prefix="gs-py-") + "/repo"
+    node_dir = tempfile.mkdtemp(prefix="gs-node-") + "/repo"
+    try:
+        shutil.copytree(seed, py_dir)
+        shutil.copytree(seed, node_dir)
+
+        with gitsheets.transact(
+            os.path.join(py_dir, ".git"),
+            "people: add jane",
+            1_700_000_000,
+            offset_minutes=-300,
+            author=("Jane Doe", "jane@x.org"),
+            branch="refs/heads/main",
+            trailers=[("Action", "person.create")],
+        ) as tx:
+            tx.open_sheet("people", ".gitsheets/people.toml")
+            tx.upsert("people", {"slug": "jane", "email": "jane@x.org"})
+        py_commit = tx.result["commit_hash"]
+
+        node = _run_node("commit", os.path.join(node_dir, ".git"))
+
+        assert py_commit is not None
+        assert py_commit == node["commitHash"], "commit bytes diverged across bindings"
+        assert tx.result["tree_hash"] == node["treeHash"]
+    finally:
+        shutil.rmtree(os.path.dirname(py_dir), ignore_errors=True)
+        shutil.rmtree(os.path.dirname(node_dir), ignore_errors=True)
+        shutil.rmtree(seed, ignore_errors=True)
+
+
+def test_embedded_engine_comparator_identical_across_bindings():
+    """The same definition-embedded JS snippet yields identical results."""
+    rule = "return (a.name > b.name) - (a.name < b.name)"
+    a = {"name": "amy"}
+    b = {"name": "zoe"}
+    py = gitsheets.run_comparator(rule, a, b)
+    node = _run_node("comparator", rule, json.dumps(a), json.dumps(b))
+    assert py == node["result"]

--- a/rust/gitsheets-py/tests/test_smoke.py
+++ b/rust/gitsheets-py/tests/test_smoke.py
@@ -1,0 +1,254 @@
+"""Smoke + behavior tests for the gitsheets Python binding.
+
+Covers marshalling type fidelity, record CRUD over holo-tree, the full
+upsert→commit transaction with the two-phase consumer-validator protocol, the
+embedded JS engine, diff/patch, and typed error mapping.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+import gitsheets
+
+
+# ── fixtures / helpers ─────────────────────────────────────────────────────────
+
+
+def _git(args, cwd=None):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def fresh_repo():
+    d = tempfile.mkdtemp(prefix="gitsheets-py-")
+    _git(["init", "-q", d])
+    try:
+        yield d, os.path.join(d, ".git")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+PEOPLE_CONFIG = "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n"
+
+
+@pytest.fixture()
+def seeded_repo():
+    """A repo with .gitsheets/people.toml committed on `main`."""
+    d = tempfile.mkdtemp(prefix="gitsheets-py-")
+    _git(["init", "-q", "-b", "main", d])
+    _git(["config", "user.name", "Seed"], cwd=d)
+    _git(["config", "user.email", "seed@x.org"], cwd=d)
+    os.makedirs(os.path.join(d, ".gitsheets"))
+    with open(os.path.join(d, ".gitsheets", "people.toml"), "w") as fh:
+        fh.write(PEOPLE_CONFIG)
+    _git(["add", ".gitsheets/people.toml"], cwd=d)
+    _git(["commit", "-q", "-m", "init"], cwd=d)
+    try:
+        yield d, os.path.join(d, ".git")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# ── marshalling fidelity ───────────────────────────────────────────────────────
+
+
+def test_roundtrip_preserves_int_float_str_bool_nested():
+    record = {
+        "slug": "jane",
+        "count": 7,
+        "ratio": 1.5,
+        "active": True,
+        "tags": ["a", "b"],
+        "nested": {"city": "Philly", "zip": "19103"},
+    }
+    [out] = gitsheets.roundtrip([record])
+    assert out == record
+    # int vs float stay distinct types across the boundary.
+    assert isinstance(out["count"], int) and not isinstance(out["count"], bool)
+    assert isinstance(out["ratio"], float)
+    assert isinstance(out["active"], bool)
+
+
+def test_int_and_float_are_distinct():
+    [out] = gitsheets.roundtrip([{"i": 1, "f": 1.0}])
+    assert isinstance(out["i"], int)
+    assert isinstance(out["f"], float)
+    # canonical serialization keeps them distinct (1 vs 1.0).
+    [text] = gitsheets.serialize_records([{"i": 1, "f": 1.0}])
+    assert "i = 1\n" in text
+    assert "f = 1.0\n" in text
+
+
+def test_large_int_keeps_precision():
+    big = 9_007_199_254_740_993  # 2^53 + 1, lossy as a JS number
+    [out] = gitsheets.roundtrip([{"n": big}])
+    assert out["n"] == big
+
+
+def test_int_out_of_i64_range_raises_overflow():
+    with pytest.raises(OverflowError):
+        gitsheets.roundtrip([{"n": 2**64}])
+
+
+def test_datetime_roundtrips_as_same_utc_instant():
+    when = dt.datetime(2026, 6, 26, 12, 0, 0, tzinfo=dt.timezone.utc)
+    [out] = gitsheets.roundtrip([{"when": when}])
+    assert isinstance(out["when"], dt.datetime)
+    assert out["when"] == when
+    # serializes to the canonical offset-datetime form.
+    [text] = gitsheets.serialize_records([{"when": when}])
+    assert "when = 2026-06-26T12:00:00Z\n" in text
+
+
+def test_naive_datetime_is_treated_as_utc():
+    naive = dt.datetime(2026, 6, 26, 12, 0, 0)
+    [text] = gitsheets.serialize_records([{"when": naive}])
+    assert "when = 2026-06-26T12:00:00Z\n" in text
+
+
+# ── record CRUD over holo-tree ──────────────────────────────────────────────────
+
+
+def test_record_write_read_roundtrip(fresh_repo):
+    _, git_dir = fresh_repo
+    rec = {"email": "jane@x.org", "slug": "jane", "tags": ["a", "b"], "age": 30}
+    out = gitsheets.record_write(git_dir, gitsheets.EMPTY_TREE_HASH, "people", ["jane"], [rec])
+    assert len(out["tree_hash"]) == 40
+    assert len(out["blob_hashes"][0]) == 40
+    read = gitsheets.record_read(git_dir, out["tree_hash"], "people", ["jane"])
+    assert read[0] == rec
+
+
+def test_record_list_sorted(fresh_repo):
+    _, git_dir = fresh_repo
+    out = gitsheets.record_write(
+        git_dir, gitsheets.EMPTY_TREE_HASH, "people", ["zoe", "amy"], [{"slug": "zoe"}, {"slug": "amy"}]
+    )
+    listed = gitsheets.record_list(git_dir, out["tree_hash"], "people")
+    assert [e["path"] for e in listed] == ["amy", "zoe"]
+
+
+# ── transaction lifecycle + two-phase consumer-validator protocol ───────────────
+
+
+def test_full_upsert_commits(seeded_repo):
+    d, git_dir = seeded_repo
+    with gitsheets.transact(
+        git_dir,
+        "people: add jane",
+        1_700_000_000,
+        offset_minutes=-300,
+        author=("Jane Doe", "jane@x.org"),
+        branch="refs/heads/main",
+        trailers=[("Action", "person.create")],
+    ) as tx:
+        tx.open_sheet("people", ".gitsheets/people.toml")
+        tx.upsert("people", {"slug": "jane", "email": "jane@x.org"})
+    assert len(tx.result["commit_hash"]) == 40
+    assert tx.result["ref_name"] == "refs/heads/main"
+    blob = subprocess.run(
+        ["git", "--git-dir", git_dir, "show", f"{tx.result['commit_hash']}:people/jane.toml"],
+        check=True,
+        capture_output=True,
+    ).stdout.decode()
+    assert blob == 'email = "jane@x.org"\nslug = "jane"\n'
+
+
+def test_consumer_validator_rejects_before_write(seeded_repo):
+    d, git_dir = seeded_repo
+
+    def validate(record):
+        if not record.get("email"):
+            raise ValueError("email is required")
+
+    with pytest.raises(ValueError, match="email is required"):
+        with gitsheets.transact(
+            git_dir, "bad", 1_700_000_000, author=("J", "j@x.org"), branch="refs/heads/main"
+        ) as tx:
+            tx.open_sheet("people", ".gitsheets/people.toml")
+            tx.upsert("people", {"slug": "bad"}, validate=validate)
+
+    # Nothing was committed: people/bad.toml never landed.
+    res = subprocess.run(
+        ["git", "--git-dir", git_dir, "show", "HEAD:people/bad.toml"], capture_output=True
+    )
+    assert res.returncode != 0
+
+
+def test_pydantic_validator_integration(seeded_repo):
+    pydantic = pytest.importorskip("pydantic")
+
+    class Person(pydantic.BaseModel):
+        slug: str
+        email: str
+
+    d, git_dir = seeded_repo
+    with gitsheets.transact(
+        git_dir, "add jane", 1_700_000_000, author=("J", "j@x.org"), branch="refs/heads/main"
+    ) as tx:
+        tx.open_sheet("people", ".gitsheets/people.toml")
+        tx.upsert("people", {"slug": "jane", "email": "jane@x.org"}, validate=Person.model_validate)
+    assert tx.result["commit_hash"]
+
+
+def test_reupsert_identical_is_noop(seeded_repo):
+    d, git_dir = seeded_repo
+    for _ in range(2):
+        with gitsheets.transact(
+            git_dir, "add", 1_700_000_000, author=("J", "j@x.org"), branch="refs/heads/main"
+        ) as tx:
+            tx.open_sheet("people", ".gitsheets/people.toml")
+            tx.upsert("people", {"slug": "jane", "email": "j@x.org"})
+    # second finalize is a no-op (tree-hash equality → no new commit).
+    assert tx.result["commit_hash"] is None
+
+
+# ── embedded JS engine ──────────────────────────────────────────────────────────
+
+
+def test_run_comparator_uses_core_engine():
+    # Descending numeric sort comparator.
+    assert gitsheets.run_comparator("return b.age - a.age", {"age": 1}, {"age": 5}) > 0
+    assert gitsheets.run_comparator("return b.age - a.age", {"age": 5}, {"age": 1}) < 0
+
+
+def test_compiled_definition_render_and_compare():
+    d = gitsheets.CompiledDefinition("people/${{ slug }}", "return a.n - b.n")
+    assert d.render_path({"slug": "jane"}) == "people/jane"
+    assert d.compare({"n": 1}, {"n": 2}) < 0
+
+
+# ── diff / patch ────────────────────────────────────────────────────────────────
+
+
+def test_create_patch_and_merge_patch():
+    ops = gitsheets.create_patch({"a": 1, "b": 2}, {"a": 1, "b": 20})
+    assert ops == [{"op": "replace", "path": "/b", "value": 20}]
+    merged = gitsheets.apply_merge_patch({"slug": "jane", "bio": "hi"}, {"bio": None})
+    assert merged == {"slug": "jane"}
+
+
+# ── typed error mapping ─────────────────────────────────────────────────────────
+
+
+def test_simulate_core_error_maps_to_typed_exception():
+    with pytest.raises(gitsheets.ValidationError) as ei:
+        gitsheets.simulate_core_error("validation_failed")
+    err = ei.value
+    assert err.code == "validation_failed"
+    assert err.gitsheets_class == "ValidationError"
+    assert isinstance(err, gitsheets.GitsheetsError)
+    assert err.issues and err.issues[0]["path"] == ["email"]
+
+
+def test_index_conflict_error_carries_paths():
+    with pytest.raises(gitsheets.IndexError) as ei:
+        gitsheets.simulate_core_error("index_unique_conflict")
+    assert ei.value.conflicting_paths == ["people/by-email/a@b.com"]


### PR DESCRIPTION
Implements [`plans/python-binding.md`](plans/python-binding.md) — the first
**second** binding, proving the thin-binding / bytes-authority model from
[`specs/rust-core.md`](specs/rust-core.md). Part of the Rust-core evolution
(#127).

A net-new workspace crate `rust/gitsheets-py` (pyo3) over the *same*
`gitsheets-core`. No changes to `gitsheets-core` or the Node binding.

## The headline proof: cross-binding byte-identical commits

A record written via **Python** and the same logical record written via **Node**
(napi) — both over the same core — produce **byte-identical** trees, blobs, and
commit hashes. Demonstrated for real in `tests/test_cross_binding.py` (4 passing
tests). Concrete run of the `typed` fixture (int `7`, float `1.5`, a UTC
`datetime`):

```
PYTHON tree: bf0a0b1e41db18a8406cb99f0b57874886e41a94  blob: 83a5df2b3efe5e4a24aeaefeaa5e29a7f3aaaa66
NODE   tree: bf0a0b1e41db18a8406cb99f0b57874886e41a94  blob: 83a5df2b3efe5e4a24aeaefeaa5e29a7f3aaaa66
blob bytes: count = 7\nratio = 1.5\nslug = "jane"\nwhen = 2026-06-26T12:00:00Z\n
```

The full upsert→commit path also yields identical commit hashes across bindings.

## What's in it

- **Marshalling** Python natives ↔ core `Value` with full TOML fidelity: `int` ↔
  Integer (arbitrary-precision in, out-of-`i64`-range raises `OverflowError`),
  `float` ↔ Float (distinct from int), `datetime.datetime` ↔ Datetime (aware UTC
  instant, same epoch-millis bridge as the Node `Date` mapping), `dict`/`list`.
- The **full napi surface**, batch-first (parse/serialize, path render,
  JSON-Schema validate, the embedded **boa** engine, record CRUD/diff/query/
  index, RFC 6902/7396 patch, and the Sheet/Transaction/Store state machine with
  the **two-phase consumer-validator protocol**).
- **Typed exceptions** mirroring `binding.cjs`, carrying
  `code`/`status`/`gitsheets_class` + `issues`/`conflicting_paths`.
- **Idiomatic Python** surface (`transact` context manager; the consumer
  validator is any callable — Pydantic-or-similar — run on the normalized record).
- **Packaging**: maturin/abi3 mixed layout; one wheel per platform (CPython ≥ 3.9).
- **CI**: a `python` job builds the wheel + the napi peer and runs the
  smoke/parity suite.

## Validation (all run locally)

- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p gitsheets-core` — 110+ passing (core untouched).
- napi `npm test` — **61/61** (independent, unchanged).
- `pytest tests/` — **21/21**, including the 4 cross-binding byte-identity tests
  and datetime/int/float fidelity.
- abi3 wheel builds + installs on linux; smoke round-trips upsert→commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd