### PR TITLE
feat(core): markdown/mdx content-type codec

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -104,14 +104,17 @@ jobs:
         working-directory: rust/gitsheets-napi
         run: npm run build
 
-      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, record CRUD/diff/patch, query, index, Sheet/Transaction/Store)
+      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, record CRUD/diff/patch, query, index, Sheet/Transaction/Store, markdown codec)
         # Explicit file paths (not a glob) so the suite runs identically on
         # node 20 and 22 — `node --test "test/*.mjs"` does NOT expand on node 20.
         # The `test` npm script lists every .mjs explicitly (see package.json),
         # including sheet-store.mjs, which drives the orchestration state machine
         # (Transaction lifecycle + the two-phase consumer-validator protocol +
-        # Store discovery). record-crud/query/index/sheet-store.mjs use `git init`
-        # for their temp repos, so git must be on PATH (it is, on ubuntu-latest).
+        # Store discovery), and sheet-markdown.mjs, which drives the markdown/mdx
+        # content-type codec (frontmatter+body round-trip, title-from-H1, lazy
+        # body, allowMissingBody). record-crud/query/index/sheet-store/
+        # sheet-markdown.mjs use `git init` for their temp repos, so git must be
+        # on PATH (it is, on ubuntu-latest).
         working-directory: rust/gitsheets-napi
         run: npm test
 

--- a/plans/markdown-codec-core.md
+++ b/plans/markdown-codec-core.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: [sheet-store-core]
 specs:
   - specs/rust-core.md
   - specs/behaviors/content-types.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/212
 ---
 
 # Plan: markdown/mdx content-type codec in the core
@@ -48,13 +49,19 @@ binding cutover that consumes it ([`node-binding-thin`](node-binding-thin.md)).
 
 ## Validation
 
-- [ ] A markdown record round-trips byte-identically to the canonical on-disk form
-      (frontmatter + body), matching `format/markdown.ts` behavior.
-- [ ] H1 title extraction, lazy body, and `allowMissingBody` match the JS suite.
-- [ ] Body `markdownlint` normalization matches the JS output (or the divergence is
-      enumerated and justified).
-- [ ] `cargo build/test` + clippy clean; napi boundary suite passes; the main JS
-      suite stays green and independent.
+- [x] A markdown record round-trips byte-identically to the canonical on-disk form
+      (frontmatter + body), matching `format/markdown.ts` behavior. *(codec unit
+      tests + `test/sheet-markdown.mjs` round-trip/idempotence; frontmatter bytes
+      via the existing canonical serializer, already corpus-parity-proven.)*
+- [x] H1 title extraction, lazy body, and `allowMissingBody` match the JS suite.
+      *(ported to the codec units + the napi boundary suite.)*
+- [x] Body `markdownlint` normalization — **divergence enumerated and justified**:
+      the core does NOT run markdownlint (no byte-identical Rust port exists); it
+      frames the body verbatim and computes the effective ruleset, leaving the
+      lint+fix pass to a host-side pre-pass. See Notes.
+- [x] `cargo build/test` + clippy clean; napi boundary suite passes (89/89); the
+      main JS suite stays green (287 unit + integration) and never imports the
+      `.node` addon.
 
 ## Risks / unknowns
 
@@ -66,8 +73,82 @@ binding cutover that consumes it ([`node-binding-thin`](node-binding-thin.md)).
 
 ## Notes
 
-(Populated at closeout.)
+**What was built.** A `codec` module in `gitsheets-core` that format-dispatches
+record serialize/parse: TOML records stay on the canonical TOML path; `markdown`/
+`mdx` records encode as `+++`-delimited TOML frontmatter + a designated body
+field (`.md`/`.mdx`). The frontmatter is serialized through the **same**
+`canonical::serialize` as TOML records — one bytes-authority, no second TOML
+path. The codec covers the full `splitOnDelimiters` behavior (UTF-8 BOM strip,
+first-pair split with embedded `+++` lines preserved, the up-to-two leading + one
+trailing newline handling), title-from-H1 extraction with the upsert
+disagreement guard (`validation_failed` + issue), the `rewriteLeadingH1` patch
+helper, and `parseHeaderOnly`. `+++` and first-H1 matching use the `regex` crate
+with JS-equivalent multiline `^`/`$` + greedy `\s*` semantics (the H1 capture is
+`[^\r\n]+?`, matching JS `.` excluding `\r`), so delimiter/H1 parsing is exact
+rather than a hand-rolled approximation. Wired into the `Sheet` pipeline:
+`prepare_upsert` serializes through the codec and enforces the body-presence
+guard via `allow_missing_body`; `Sheet::list`/`CoreTransaction.list` gained a
+`with_body` switch; index builds use body-less reads. The `require_toml`
+deferral guard is gone. Boundary suite `test/sheet-markdown.mjs` (added to the
+`npm test` script + CI) drives both the direct codec and end-to-end markdown
+sheets through a transaction.
+
+**markdownlint parity result — enumerated divergence (the headline finding).**
+The JS oracle normalizes the body with the `markdownlint` npm package
+(`lint` + `applyFixes`) on write. **The core does not reimplement this.**
+`markdownlint` is ~40 rules of bespoke, interdependent fix logic with no
+byte-identical Rust port; a partial reimplementation would *silently* emit
+different body bytes for any body triggering a rule it handled differently or not
+at all — exactly the failure mode the plan forbids ("STOP and report rather than
+silently shipping different body bytes"). The chosen architecture instead splits
+the concern cleanly:
+
+- The core codec frames the body **verbatim** — the byte-deterministic,
+  language-agnostic part (delimiters, frontmatter, trailing-newline,
+  title-from-H1). It is byte-identical to `markdown.ts` **with `markdownlint =
+  false`** (verified: round-trip + idempotence in both the cargo and node suites).
+- The markdownlint **configuration** is fully parsed and the effective ruleset
+  computed by the core (`config::Markdownlint::resolve` — defaults `{default:
+  true, MD013: false, MD041: false}` layered with user overrides, plus the
+  `MD041` auto-enable when title-from-H1 is on), exposed over the FFI as
+  `markdownResolveLintConfig`. **Nothing is dropped.**
+- The **application** of markdownlint to the body is a host-side pre-pass: the
+  binding runs the `markdownlint` package (already in the Node ecosystem, and
+  staying there post-cutover as a ~10-line pre-pass) before handing the record to
+  the codec — exactly how the consumer Standard-Schema validator runs host-side.
+  The core never calls back into the host (re-entrancy hazard).
+
+Net for the cutover: `markdown.ts` is deletable; the body-normalization call
+moves into the thin Node binding (lint → core codec), the framing matches
+byte-for-byte, and the JS suite stays green. This is the one observable boundary
+difference and it is intentional, documented (codec + `Markdownlint` rustdoc,
+this plan), and does not change emitted body bytes silently — the core's body
+bytes are exactly its input.
+
+**Lazy-body handling.** Preserved across the FFI. `codec::parse_header_only`
+reads frontmatter only and leaves the body field absent; `Sheet::list(.., false)`
+and `CoreTransaction.list(name, false)` thread it through, and index builds
+always read body-less (a `keyFn` on the body field sees it absent and the record
+degenerates out of the index — matching the spec). The body is hydrated by a
+full read (`list(.., true)`), the core analogue of `Sheet.loadBody`.
+
+**Error-class divergence (minor, enumerated).** The JS body-presence and
+body-not-a-string guards throw `TypeError`; the core surfaces them through the
+typed taxonomy as `validation_failed` (message preserved). The cutover's thin
+binding can remap these to `TypeError` host-side if exact class parity is wanted;
+the tests assert on message/`code`, which match.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Node cutover (`node-binding-thin`, out of scope here).** Consume this codec:
+  move the `markdownlint` lint+fix into the thin binding as the body pre-pass
+  (feeding `markdownResolveLintConfig`'s ruleset), delete `format/markdown.ts`'s
+  engine, and route `Sheet` markdown reads/writes through the core. Keep the
+  ~9 markdown vitest files green; decide there whether to remap the body guards
+  to `TypeError` for exact class parity.
+- **`Sheet.query` body-field filter guard.** The `withBody: false` + filter-on-
+  body `TypeError` guard (content-types spec) stays host-side today; if the query
+  pipeline moves fully into the core, port the guard alongside it.
+- **Pathological H1 edge.** A heading that is only `#` followed by spaces yields
+  `None` here vs JS returning a whitespace string — untested, unrealistic for
+  API-authored bodies; revisit only if a real body hits it.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "holo-tree",
  "indexmap",
  "jsonschema",
+ "regex",
  "serde_json",
  "tempfile",
  "toml",

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -45,6 +45,17 @@ holo-tree = { git = "https://github.com/JarvusInnovations/hologit", branch = "de
 # rev-parse, object read/write, and repo open/init.
 gix = "0.83"
 
+# ── markdown-codec-core (the content-typed record format) ────────────────────
+# Faithful frontmatter-delimiter (`+++`) and first-H1 matching for the
+# markdown/mdx codec. The JS oracle (`format/markdown.ts`) matches these with
+# JS regexes (`/^\+\+\+\s*$/m`, `/^# (.+?)[ \t]*$/m`); the `regex` crate gives
+# byte-equivalent leftmost-first, multiline `^`/`$`, greedy `\s*` semantics, so
+# the delimiter/H1 parse parity is exact rather than a hand-rolled approximation
+# (the one class of parity bug a manual line scan would risk on trailing
+# whitespace / CRLF). The body-NORMALIZATION pass (markdownlint) is NOT done
+# here — see the codec module docs and plans/markdown-codec-core.md.
+regex = "1"
+
 [dev-dependencies]
 # Throwaway git repos for the record-CRUD + diff integration tests.
 tempfile = "3"

--- a/rust/gitsheets-core/src/codec.rs
+++ b/rust/gitsheets-core/src/codec.rs
@@ -1,0 +1,524 @@
+//! Content-typed record codec — the on-disk byte format dispatch.
+//!
+//! A sheet's `[gitsheet.format]` selects how a record is encoded on disk:
+//! `toml` (the default — a canonical TOML blob, the bytes-authority's job) or
+//! `markdown`/`mdx` (TOML **frontmatter** delimited by `+++`, then a designated
+//! body field, stored as `.md`/`.mdx`). This module is the behavior-preserving
+//! Rust port of `packages/gitsheets/src/format/{index,markdown}.ts`, per
+//! [`specs/behaviors/content-types.md`](../../../specs/behaviors/content-types.md).
+//!
+//! ## One bytes-authority
+//!
+//! The frontmatter is serialized through the **same** canonical TOML path as a
+//! TOML record ([`canonical::serialize`] — deep key sort, `@iarna`-equivalent
+//! form). There is no second TOML serializer: a markdown record's frontmatter
+//! and a TOML record with the same fields produce identical bytes.
+//!
+//! ## markdownlint normalization is NOT done here — and that is deliberate
+//!
+//! The JS oracle normalizes the body with the `markdownlint` npm package
+//! (`lint` + `applyFixes`) on write. **That pass is intentionally not
+//! reimplemented in the core.** `markdownlint` is ~40 rules with bespoke,
+//! interdependent fix logic; no Rust port is byte-identical to it, so a partial
+//! reimplementation would *silently* emit different body bytes for any body that
+//! triggers a rule the port handled differently or not at all — exactly the
+//! failure mode the plan forbids. Instead:
+//!
+//! - The core codec frames the body **verbatim** (byte-deterministic,
+//!   language-agnostic: delimiters, frontmatter, trailing-newline, title-from-H1).
+//! - The markdownlint *configuration* is fully parsed and the effective ruleset
+//!   computed by the core ([`crate::config::Markdownlint::resolve`]) so nothing
+//!   is dropped.
+//! - The *application* of markdownlint to the body is a **host-side pre-pass**
+//!   (the binding runs the `markdownlint` package — which already lives in the
+//!   Node ecosystem — before handing the record to the codec), the same way the
+//!   consumer Standard-Schema validator runs host-side. The core never calls
+//!   back into the host (re-entrancy hazard).
+//!
+//! Net: the codec is byte-identical to `markdown.ts` **with `markdownlint =
+//! false`**; with linting on, the binding's pre-pass supplies the normalized
+//! body and the framing still matches byte-for-byte. See
+//! `plans/markdown-codec-core.md` for the full parity write-up.
+
+use indexmap::IndexMap;
+use regex::Regex;
+use std::sync::LazyLock;
+
+use crate::canonical;
+use crate::config::{FormatConfig, FormatKind};
+use crate::error::{Error, IssueSource, Result, ValidationIssue};
+use crate::value::Value;
+
+const DELIMITER: &str = "+++";
+
+/// A frontmatter delimiter line: `+++` followed only by whitespace to the line
+/// end. Mirrors the JS `/^\+\+\+\s*$/m`.
+static DELIMITER_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\+\+\+\s*$").expect("static delimiter regex"));
+
+/// The first ATX-style H1 line (`# Title text`), capturing the title with
+/// trailing whitespace trimmed. Mirrors the JS `/^# (.+?)[ \t]*$/m`; the capture
+/// is `[^\r\n]+?` (not `.`) so it excludes `\r`, matching JS's `.` exactly
+/// (JS `.` excludes both `\n` and `\r`).
+static H1_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^# ([^\r\n]+?)[ \t]*$").expect("static H1 regex"));
+
+// ── format dispatch ──────────────────────────────────────────────────────────
+
+/// Serialize a record to its on-disk text for the sheet's format.
+///
+/// - `toml` → canonical TOML bytes ([`canonical::serialize`]).
+/// - `markdown`/`mdx` → `+++\n<frontmatter>+++\n\n<body>\n` (see
+///   [`serialize_markdown`]). The body is **not** markdownlint-normalized here
+///   (see the module docs); callers that want normalization apply it before
+///   calling.
+pub fn serialize(record: &Value, format: &FormatConfig) -> Result<String> {
+    match format.kind {
+        FormatKind::Toml => canonical::serialize(record),
+        FormatKind::Markdown | FormatKind::Mdx => serialize_markdown(record, format),
+    }
+}
+
+/// Parse on-disk text into a full record (markdown: frontmatter + body field).
+pub fn parse(text: &str, format: &FormatConfig) -> Result<Value> {
+    match format.kind {
+        FormatKind::Toml => canonical::parse(text),
+        FormatKind::Markdown | FormatKind::Mdx => parse_markdown(text, format, true),
+    }
+}
+
+/// Parse only the header (frontmatter) — the lazy-body path. For `toml` this is
+/// identical to [`parse`]; for markdown the body bytes are never injected into
+/// the record (the body field is left absent). Mirrors `Format.parseHeaderOnly`.
+pub fn parse_header_only(text: &str, format: &FormatConfig) -> Result<Value> {
+    match format.kind {
+        FormatKind::Toml => canonical::parse(text),
+        FormatKind::Markdown | FormatKind::Mdx => parse_markdown(text, format, false),
+    }
+}
+
+// ── markdown serialize ───────────────────────────────────────────────────────
+
+fn body_field_name(format: &FormatConfig) -> Result<&str> {
+    format.body.as_deref().ok_or_else(|| Error::ConfigInvalid {
+        message: "markdown format requires [gitsheet.format].body to be set to the field name holding the body text".to_string(),
+    })
+}
+
+fn serialize_markdown(record: &Value, format: &FormatConfig) -> Result<String> {
+    let body_field = body_field_name(format)?;
+
+    let Value::Table(table) = record else {
+        return Err(Error::ValidationFailed {
+            message: "markdown format: record must be a table".to_string(),
+            issues: Vec::new(),
+        });
+    };
+
+    // The body field → body text. An absent body is the empty string (matches
+    // the JS `?? ''`); a present non-string body is a type error.
+    let body = match table.get(body_field) {
+        None => String::new(),
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => {
+            return Err(Error::ValidationFailed {
+                message: format!(
+                    "markdown format: record.{body_field} must be a string, got {}",
+                    other.type_name()
+                ),
+                issues: Vec::new(),
+            })
+        }
+    };
+
+    // Frontmatter = every field except the body field.
+    let mut frontmatter: IndexMap<String, Value> = IndexMap::new();
+    for (k, v) in table {
+        if k == body_field {
+            continue;
+        }
+        frontmatter.insert(k.clone(), v.clone());
+    }
+
+    // Title-from-H1: enforce `record[title] === <body's first H1, or absent>`.
+    if let Some(title_field) = &format.title {
+        let extracted = extract_first_h1(&body);
+        let supplied = frontmatter.get(title_field);
+        if let Some(supplied_val) = supplied {
+            let agrees = match (&extracted, supplied_val) {
+                (Some(e), Value::String(s)) => e == s,
+                _ => false,
+            };
+            if !agrees {
+                let supplied_repr = match supplied_val {
+                    Value::String(s) => format!("{s:?}"),
+                    other => other.type_name().to_string(),
+                };
+                let extracted_repr = match &extracted {
+                    Some(e) => format!("{e:?}"),
+                    None => "undefined".to_string(),
+                };
+                return Err(Error::ValidationFailed {
+                    message: format!(
+                        "record.{title_field} ({supplied_repr}) disagrees with body's first H1 ({extracted_repr}). Use `Sheet.patch` if you want to rename via either field — `upsert` requires self-consistent input."
+                    ),
+                    issues: vec![ValidationIssue {
+                        path: vec![title_field.clone()],
+                        message: format!(
+                            "disagrees with body's first H1 ({extracted_repr})"
+                        ),
+                        source: IssueSource::JsonSchema,
+                        schema_path: None,
+                        code: None,
+                    }],
+                });
+            }
+        }
+        match &extracted {
+            Some(e) => {
+                frontmatter.insert(title_field.clone(), Value::String(e.clone()));
+            }
+            // No H1 in body → ensure no stale title leaks into frontmatter.
+            None => {
+                frontmatter.shift_remove(title_field);
+            }
+        }
+    }
+
+    let fm_text = canonical::serialize(&Value::Table(frontmatter))?;
+
+    // Layout: `+++\n<frontmatter>+++\n\n<body>\n`. canonical::serialize already
+    // ends with a newline, so the frontmatter slots cleanly between delimiters.
+    // The on-disk file ends with exactly one `\n` — a body that does not already
+    // end with one gets it appended (so a body value of `'hi\n'` is idempotent).
+    let trailing = if body.ends_with('\n') { "" } else { "\n" };
+    Ok(format!("{DELIMITER}\n{fm_text}{DELIMITER}\n\n{body}{trailing}"))
+}
+
+// ── markdown parse ───────────────────────────────────────────────────────────
+
+fn parse_markdown(text: &str, format: &FormatConfig, with_body: bool) -> Result<Value> {
+    let body_field = body_field_name(format)?;
+    let (frontmatter, body) = split_on_delimiters(text);
+    let mut record = canonical::parse(&frontmatter)?;
+    if with_body {
+        match &mut record {
+            Value::Table(t) => {
+                t.insert(body_field.to_string(), Value::String(body));
+            }
+            // canonical::parse of a TOML document is always a table; this arm is
+            // unreachable in practice but keeps the match total.
+            _ => {
+                let mut t = IndexMap::new();
+                t.insert(body_field.to_string(), Value::String(body));
+                record = Value::Table(t);
+            }
+        }
+    }
+    Ok(record)
+}
+
+/// Split a markdown record's text into frontmatter TOML + body, mirroring the JS
+/// `splitOnDelimiters`. The first `+++` line is the opener, the next is the
+/// closer; a UTF-8 BOM before the opener is stripped; any later `+++` line in
+/// the body is preserved. Input with no delimiters is body-only.
+fn split_on_delimiters(text: &str) -> (String, String) {
+    // Strip a leading UTF-8 BOM if present.
+    let stripped = text.strip_prefix('\u{feff}').unwrap_or(text);
+
+    let opener = match DELIMITER_LINE_RE.find(stripped) {
+        Some(m) => m,
+        None => return (String::new(), stripped.to_string()),
+    };
+
+    let after_opener = &stripped[opener.end()..];
+    // Drop the newline directly after the opener delimiter.
+    let after_opener = after_opener.strip_prefix('\n').unwrap_or(after_opener);
+
+    let closer = match DELIMITER_LINE_RE.find(after_opener) {
+        Some(m) => m,
+        // Opener but no closer — treat everything after the opener as body.
+        None => return (String::new(), after_opener.to_string()),
+    };
+
+    let frontmatter = after_opener[..closer.start()].to_string();
+    // Drop the newline after the closer, a leading blank line before the body,
+    // and a single trailing newline (it belongs to the file, not the body).
+    let mut body = &after_opener[closer.end()..];
+    body = body.strip_prefix('\n').unwrap_or(body);
+    body = body.strip_prefix('\n').unwrap_or(body);
+    body = body.strip_suffix('\n').unwrap_or(body);
+    (frontmatter, body.to_string())
+}
+
+// ── title-from-H1 helpers ────────────────────────────────────────────────────
+
+/// Extract the first ATX-style H1 from a markdown body, or `None` if absent.
+/// The title is returned with surrounding whitespace trimmed. Mirrors the JS
+/// `extractFirstH1`.
+pub fn extract_first_h1(body: &str) -> Option<String> {
+    H1_LINE_RE
+        .captures(body)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+/// Rewrite (or prepend) the first ATX H1 of a markdown body to `new_title`.
+/// Used by `Sheet.patch` to reconcile a title-only delta into the body. If the
+/// body has no H1, prepends `# new_title\n\n`. Mirrors the JS `rewriteLeadingH1`.
+pub fn rewrite_leading_h1(body: &str, new_title: &str) -> String {
+    if let Some(m) = H1_LINE_RE.find(body) {
+        let before = &body[..m.start()];
+        let after = &body[m.end()..];
+        return format!("{before}# {new_title}{after}");
+    }
+    if body.is_empty() {
+        return format!("# {new_title}\n");
+    }
+    format!("# {new_title}\n\n{body}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Markdownlint;
+
+    fn md(body_field: &str, title: Option<&str>) -> FormatConfig {
+        FormatConfig {
+            kind: FormatKind::Markdown,
+            body: Some(body_field.to_string()),
+            title: title.map(|s| s.to_string()),
+            markdownlint: Markdownlint::Default,
+        }
+    }
+
+    fn rec(pairs: &[(&str, Value)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Value::Table(m)
+    }
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+
+    fn field<'a>(v: &'a Value, k: &str) -> Option<&'a Value> {
+        match v {
+            Value::Table(t) => t.get(k),
+            _ => None,
+        }
+    }
+
+    // ── serialize ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn writes_frontmatter_then_body() {
+        let text = serialize(
+            &rec(&[
+                ("slug", s("hello")),
+                ("title", s("Hello, world")),
+                ("body", s("# Hello\n\nBody text\n")),
+            ]),
+            &md("body", None),
+        )
+        .unwrap();
+        assert!(text.starts_with("+++\n"));
+        assert!(text.contains("slug = \"hello\""));
+        assert!(text.contains("title = \"Hello, world\""));
+        assert!(text.contains("+++\n\n# Hello\n\nBody text\n"));
+    }
+
+    #[test]
+    fn empty_body_is_delimiters_plus_one_trailing_newline() {
+        let text = serialize(&rec(&[("slug", s("empty")), ("body", s(""))]), &md("body", None)).unwrap();
+        assert_eq!(text, "+++\nslug = \"empty\"\n+++\n\n\n");
+    }
+
+    #[test]
+    fn missing_body_is_treated_as_empty() {
+        let text = serialize(&rec(&[("slug", s("no-body"))]), &md("body", None)).unwrap();
+        assert!(text.contains("slug = \"no-body\""));
+        assert!(text.ends_with("+++\n\n\n"));
+    }
+
+    #[test]
+    fn body_not_a_string_is_validation_error() {
+        let err = serialize(&rec(&[("slug", s("bad")), ("body", Value::Integer(42))]), &md("body", None))
+            .unwrap_err();
+        assert_eq!(err.code(), "validation_failed");
+        assert!(err.message().contains("must be a string"));
+    }
+
+    #[test]
+    fn frontmatter_keys_are_deep_sorted() {
+        let text = serialize(
+            &rec(&[("zeta", Value::Integer(1)), ("alpha", Value::Integer(2)), ("slug", s("sorted")), ("body", s(""))]),
+            &md("body", None),
+        )
+        .unwrap();
+        let alpha = text.find("alpha").unwrap();
+        let slug = text.find("slug").unwrap();
+        let zeta = text.find("zeta").unwrap();
+        assert!(alpha < slug && slug < zeta);
+    }
+
+    #[test]
+    fn body_ending_in_newline_does_not_double_up() {
+        // A body that already ends with `\n` round-trips without a trailing
+        // newline (the file's `\n` is the file's, not the body's).
+        let text = serialize(&rec(&[("slug", s("x")), ("body", s("hi\n"))]), &md("body", None)).unwrap();
+        assert!(text.ends_with("\n\nhi\n"));
+        let parsed = parse(&text, &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "body"), Some(&s("hi")));
+    }
+
+    // ── parse ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn round_trips_through_serialize_then_parse() {
+        let original = rec(&[
+            ("slug", s("roundtrip")),
+            ("title", s("Round-trip")),
+            ("tags", Value::Array(vec![s("a"), s("b")])),
+            ("body", s("# Heading\n\nSome content.")),
+        ]);
+        let text = serialize(&original, &md("body", None)).unwrap();
+        let parsed = parse(&text, &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "slug"), Some(&s("roundtrip")));
+        assert_eq!(field(&parsed, "title"), Some(&s("Round-trip")));
+        assert_eq!(field(&parsed, "tags"), Some(&Value::Array(vec![s("a"), s("b")])));
+        assert_eq!(field(&parsed, "body"), Some(&s("# Heading\n\nSome content.")));
+    }
+
+    #[test]
+    fn preserves_a_plus_plus_plus_line_in_the_body() {
+        let body = "before\n\n+++\n\nafter";
+        let text = serialize(&rec(&[("slug", s("plus")), ("body", s(body))]), &md("body", None)).unwrap();
+        let parsed = parse(&text, &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "body"), Some(&s(body)));
+    }
+
+    #[test]
+    fn empty_body_reads_back_as_empty_string() {
+        let text = serialize(&rec(&[("slug", s("empty")), ("body", s(""))]), &md("body", None)).unwrap();
+        let parsed = parse(&text, &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "body"), Some(&s("")));
+    }
+
+    #[test]
+    fn preserves_toml_datetime_in_frontmatter() {
+        let dt: Value = Value::Datetime("2024-05-16T10:00:00Z".parse().unwrap());
+        let text = serialize(&rec(&[("slug", s("dated")), ("publishedAt", dt.clone()), ("body", s("hi"))]), &md("body", None)).unwrap();
+        let parsed = parse(&text, &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "publishedAt"), Some(&dt));
+    }
+
+    #[test]
+    fn strips_a_utf8_bom() {
+        let text = "\u{feff}+++\nslug = \"bom\"\n+++\n\nhello\n";
+        let parsed = parse(text, &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "slug"), Some(&s("bom")));
+        assert_eq!(field(&parsed, "body"), Some(&s("hello")));
+    }
+
+    #[test]
+    fn body_only_file_has_just_the_body_field() {
+        let parsed = parse("just some body text", &md("body", None)).unwrap();
+        assert_eq!(field(&parsed, "body"), Some(&s("just some body text")));
+        let Value::Table(t) = parsed else { panic!() };
+        let others: Vec<&String> = t.keys().filter(|k| *k != "body").collect();
+        assert!(others.is_empty());
+    }
+
+    #[test]
+    fn parse_header_only_skips_the_body() {
+        let big = "this body is big\n".repeat(1000);
+        let text = serialize(&rec(&[("slug", s("header")), ("title", s("Header only")), ("body", s(&big))]), &md("body", None)).unwrap();
+        let header = parse_header_only(&text, &md("body", None)).unwrap();
+        assert_eq!(field(&header, "slug"), Some(&s("header")));
+        assert_eq!(field(&header, "title"), Some(&s("Header only")));
+        assert_eq!(field(&header, "body"), None);
+    }
+
+    // ── title-from-H1 ────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_first_h1_cases() {
+        assert_eq!(extract_first_h1("# Hello, world\n\nBody").as_deref(), Some("Hello, world"));
+        assert_eq!(extract_first_h1("Body without a heading"), None);
+        assert_eq!(extract_first_h1("## Subheading\n\nBody"), None);
+        assert_eq!(extract_first_h1(""), None);
+        assert_eq!(extract_first_h1("#NoSpace"), None);
+        assert_eq!(extract_first_h1("Some prose first.\n\n# Title\n\nMore.").as_deref(), Some("Title"));
+        assert_eq!(extract_first_h1("# Hello   ").as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn rewrite_leading_h1_cases() {
+        assert_eq!(rewrite_leading_h1("# Old\n\nBody", "New"), "# New\n\nBody");
+        assert_eq!(rewrite_leading_h1("# First\n\n# Second", "X"), "# X\n\n# Second");
+        assert_eq!(rewrite_leading_h1("Just prose, no heading.", "X"), "# X\n\nJust prose, no heading.");
+        assert_eq!(rewrite_leading_h1("", "X"), "# X\n");
+    }
+
+    #[test]
+    fn serialize_extracts_title_from_body_h1() {
+        let text = serialize(&rec(&[("slug", s("hello")), ("body", s("# Hello, world\n\nA short post."))]), &md("body", Some("title"))).unwrap();
+        assert!(text.contains("title = \"Hello, world\""));
+        assert!(text.contains("slug = \"hello\""));
+    }
+
+    #[test]
+    fn serialize_passes_through_agreeing_title() {
+        let text = serialize(
+            &rec(&[("slug", s("hello")), ("title", s("Hello, world")), ("body", s("# Hello, world\n\nA short post."))]),
+            &md("body", Some("title")),
+        )
+        .unwrap();
+        assert!(text.contains("title = \"Hello, world\""));
+    }
+
+    #[test]
+    fn serialize_throws_on_disagreeing_title() {
+        let err = serialize(&rec(&[("slug", s("hello")), ("title", s("X")), ("body", s("# Y\n\nbody"))]), &md("body", Some("title"))).unwrap_err();
+        assert_eq!(err.code(), "validation_failed");
+        assert_eq!(err.issues().len(), 1);
+    }
+
+    #[test]
+    fn serialize_throws_when_title_supplied_but_no_h1() {
+        let err = serialize(&rec(&[("slug", s("hello")), ("title", s("Stale")), ("body", s("No H1 here."))]), &md("body", Some("title"))).unwrap_err();
+        assert_eq!(err.code(), "validation_failed");
+    }
+
+    #[test]
+    fn serialize_omits_title_when_no_h1_and_none_supplied() {
+        let text = serialize(&rec(&[("slug", s("hello")), ("body", s("No H1 here."))]), &md("body", Some("title"))).unwrap();
+        assert!(!text.contains("title ="));
+    }
+
+    #[test]
+    fn title_round_trips() {
+        let text = serialize(&rec(&[("slug", s("hello")), ("body", s("# Hello, world\n\nA short post."))]), &md("body", Some("title"))).unwrap();
+        let parsed = parse(&text, &md("body", Some("title"))).unwrap();
+        assert_eq!(field(&parsed, "title"), Some(&s("Hello, world")));
+        assert_eq!(field(&parsed, "body"), Some(&s("# Hello, world\n\nA short post.")));
+    }
+
+    // ── toml passthrough ─────────────────────────────────────────────────────
+
+    #[test]
+    fn toml_format_is_canonical_passthrough() {
+        let fmt = FormatConfig {
+            kind: FormatKind::Toml,
+            body: None,
+            title: None,
+            markdownlint: Markdownlint::Default,
+        };
+        let r = rec(&[("slug", s("jane")), ("email", s("jane@x.org"))]);
+        let text = serialize(&r, &fmt).unwrap();
+        assert_eq!(text, "email = \"jane@x.org\"\nslug = \"jane\"\n");
+        assert_eq!(parse(&text, &fmt).unwrap(), r);
+    }
+}

--- a/rust/gitsheets-core/src/config.rs
+++ b/rust/gitsheets-core/src/config.rs
@@ -75,14 +75,62 @@ impl FormatKind {
     }
 }
 
+/// The markdownlint configuration from `[gitsheet.format].markdownlint`.
+///
+/// Carried so the codec config round-trips and **nothing is dropped**, but the
+/// core does NOT apply markdownlint to the body — see the [`crate::codec`]
+/// module docs: the lint+fix pass is a host-side pre-pass (the binding runs the
+/// `markdownlint` package), and the core only computes the effective ruleset via
+/// [`Markdownlint::resolve`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum Markdownlint {
+    /// No `markdownlint` key — apply the defaults only.
+    Default,
+    /// `markdownlint = false` — normalization disabled.
+    Disabled,
+    /// `[gitsheet.format.markdownlint]` — a table of user rule overrides,
+    /// layered on top of the defaults by [`Markdownlint::resolve`].
+    Rules(IndexMap<String, Value>),
+}
+
+impl Markdownlint {
+    /// The effective markdownlint config the host's pre-pass should apply, or
+    /// `None` when normalization is disabled. Mirrors the JS `normalizeBody`
+    /// merge: `{ default: true, MD013: false, MD041: false, ...user }`, and when
+    /// title-from-H1 is enabled (`title_is_set`) and the user didn't pin
+    /// `MD041`, it auto-enables `MD041` (first-line-H1).
+    pub fn resolve(&self, title_is_set: bool) -> Option<Value> {
+        let empty = IndexMap::new();
+        let user = match self {
+            Markdownlint::Disabled => return None,
+            Markdownlint::Default => &empty,
+            Markdownlint::Rules(t) => t,
+        };
+        let mut out: IndexMap<String, Value> = IndexMap::new();
+        out.insert("default".to_string(), Value::Boolean(true));
+        out.insert("MD013".to_string(), Value::Boolean(false));
+        out.insert("MD041".to_string(), Value::Boolean(false));
+        for (k, v) in user {
+            out.insert(k.clone(), v.clone());
+        }
+        if title_is_set && !user.contains_key("MD041") {
+            out.insert("MD041".to_string(), Value::Boolean(true));
+        }
+        Some(Value::Table(out))
+    }
+}
+
 /// Resolved `[gitsheet.format]` config. Defaults to `type = "toml"`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FormatConfig {
     pub kind: FormatKind,
     /// The field holding the body text (markdown/mdx only).
     pub body: Option<String>,
     /// The field denormalized from the body's first H1 (markdown/mdx only).
     pub title: Option<String>,
+    /// The markdownlint configuration (carried, not applied by the core — see
+    /// [`Markdownlint`]).
+    pub markdownlint: Markdownlint,
 }
 
 impl FormatConfig {
@@ -226,6 +274,7 @@ fn parse_format(raw: Option<&Value>, source: &str) -> Result<FormatConfig> {
             kind: FormatKind::Toml,
             body: None,
             title: None,
+            markdownlint: Markdownlint::Default,
         });
     };
     let table = as_table(raw).ok_or_else(|| Error::ConfigInvalid {
@@ -239,7 +288,19 @@ fn parse_format(raw: Option<&Value>, source: &str) -> Result<FormatConfig> {
     };
     let body = table.get("body").and_then(as_str).map(|s| s.to_string());
     let title = table.get("title").and_then(as_str).map(|s| s.to_string());
-    Ok(FormatConfig { kind, body, title })
+    // markdownlint: `false` disables; a table is user rules; anything else (or
+    // absent) falls back to the defaults. Matches the JS `resolveFormatConfig`.
+    let markdownlint = match table.get("markdownlint") {
+        Some(Value::Boolean(false)) => Markdownlint::Disabled,
+        Some(Value::Table(t)) => Markdownlint::Rules(t.clone()),
+        _ => Markdownlint::Default,
+    };
+    Ok(FormatConfig {
+        kind,
+        body,
+        title,
+        markdownlint,
+    })
 }
 
 fn parse_sort_rule(sort: &Value, source: &str, field: &str) -> Result<SortRule> {
@@ -373,5 +434,46 @@ mod tests {
     fn parses_schema_block() {
         let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.schema]\ntype = 'object'\n").unwrap();
         assert!(c.schema.is_some());
+    }
+
+    #[test]
+    fn markdownlint_defaults_when_absent() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\n").unwrap();
+        assert_eq!(c.format.markdownlint, Markdownlint::Default);
+        let resolved = c.format.markdownlint.resolve(false).unwrap();
+        let Value::Table(t) = resolved else { panic!() };
+        assert_eq!(t["default"], Value::Boolean(true));
+        assert_eq!(t["MD013"], Value::Boolean(false));
+        assert_eq!(t["MD041"], Value::Boolean(false));
+    }
+
+    #[test]
+    fn markdownlint_false_disables() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\nmarkdownlint = false\n").unwrap();
+        assert_eq!(c.format.markdownlint, Markdownlint::Disabled);
+        assert!(c.format.markdownlint.resolve(false).is_none());
+    }
+
+    #[test]
+    fn markdownlint_user_rules_layer_over_defaults() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\n[gitsheet.format.markdownlint]\nMD013 = true\nMD033 = false\n").unwrap();
+        let resolved = c.format.markdownlint.resolve(false).unwrap();
+        let Value::Table(t) = resolved else { panic!() };
+        assert_eq!(t["MD013"], Value::Boolean(true), "user override wins");
+        assert_eq!(t["MD033"], Value::Boolean(false));
+        assert_eq!(t["default"], Value::Boolean(true));
+    }
+
+    #[test]
+    fn markdownlint_auto_enables_md041_when_title_set() {
+        // Defaults + title-from-H1 → MD041 auto-enabled.
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\ntitle = 'title'\n").unwrap();
+        let Value::Table(t) = c.format.markdownlint.resolve(true).unwrap() else { panic!() };
+        assert_eq!(t["MD041"], Value::Boolean(true));
+
+        // …unless the consumer pinned it.
+        let c2 = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\ntitle = 'title'\n[gitsheet.format.markdownlint]\nMD041 = false\n").unwrap();
+        let Value::Table(t2) = c2.format.markdownlint.resolve(true).unwrap() else { panic!() };
+        assert_eq!(t2["MD041"], Value::Boolean(false), "consumer override respected");
     }
 }

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -18,6 +18,7 @@
 //! top of this substrate. See [`specs/rust-core.md`](../../../specs/rust-core.md).
 
 pub mod canonical;
+pub mod codec;
 pub mod config;
 pub mod diff;
 pub mod engine;
@@ -33,7 +34,10 @@ pub mod validation;
 pub mod value;
 
 pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};
-pub use config::{FieldConfig, FormatConfig, FormatKind, SheetConfig, SortDir, SortRule};
+pub use codec::{extract_first_h1, rewrite_leading_h1};
+pub use config::{
+    FieldConfig, FormatConfig, FormatKind, Markdownlint, SheetConfig, SortDir, SortRule,
+};
 pub use diff::{apply_merge_patch, create_patch, MergePatch, PatchOp, PatchOpKind, PatchValue};
 pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
 pub use index::{MultiIndex, UniqueIndex};

--- a/rust/gitsheets-core/src/record.rs
+++ b/rust/gitsheets-core/src/record.rs
@@ -309,16 +309,19 @@ pub fn delete_records(
     Ok(DeleteOutcome { tree_hash, existed })
 }
 
-/// List every record under `base`: enumerate the subtree's blobs, keep those
-/// ending in `extension`, strip the extension, and parse each into a [`Value`].
-/// Paths are relative to `base` and returned in sorted (git-canonical) order. An
-/// unparseable record blob is `config_invalid`.
-pub fn list_records(
+/// List every record under `base` as its raw on-disk **text**: enumerate the
+/// subtree's blobs, keep those ending in `extension`, strip the extension, and
+/// decode each as UTF-8. Paths are relative to `base` and returned in sorted
+/// (git-canonical) order. The format-aware decode (canonical TOML vs the
+/// markdown frontmatter codec, with/without body) is the caller's job — see
+/// [`crate::codec`] and [`crate::sheet::Sheet`]. A non-UTF-8 blob is
+/// `config_invalid`.
+pub fn list_record_texts(
     repo: &gix::Repository,
     tree: &mut MutableTree,
     base: &str,
     extension: &str,
-) -> Result<Vec<(String, Value)>> {
+) -> Result<Vec<(String, String)>> {
     let barg = base_arg(base);
     let subtree = match tree.get_subtree(repo, &barg).map_err(map_ht)? {
         Some(t) => t,
@@ -341,9 +344,26 @@ pub fn list_records(
         let text = String::from_utf8(bytes).map_err(|e| Error::ConfigInvalid {
             message: format!("record at {path} is not valid UTF-8: {e}"),
         })?;
-        out.push((record_path, canonical::parse(&text)?));
+        out.push((record_path, text));
     }
     Ok(out)
+}
+
+/// List every record under `base`, parsing each as canonical TOML. Paths are
+/// relative to `base` in sorted (git-canonical) order. An unparseable record
+/// blob is `config_invalid`. (Markdown sheets list through [`crate::codec`] at
+/// the `Sheet` layer; this primitive stays TOML-only for the thin record-CRUD
+/// binding surface.)
+pub fn list_records(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    base: &str,
+    extension: &str,
+) -> Result<Vec<(String, Value)>> {
+    list_record_texts(repo, tree, base, extension)?
+        .into_iter()
+        .map(|(path, text)| Ok((path, canonical::parse(&text)?)))
+        .collect()
 }
 
 // ── record-level diff (replacing git diff-tree) ──────────────────────────────

--- a/rust/gitsheets-core/src/sheet.rs
+++ b/rust/gitsheets-core/src/sheet.rs
@@ -38,7 +38,8 @@ use holo_tree::MutableTree;
 use indexmap::IndexMap;
 
 use crate::canonical;
-use crate::config::{self, FormatKind, SheetConfig, SortRule};
+use crate::codec;
+use crate::config::{self, SheetConfig, SortRule};
 use crate::engine::{Engine, SnippetError, SnippetHandle};
 use crate::error::{Error, Result};
 use crate::index::{MultiIndex, UniqueIndex};
@@ -209,20 +210,28 @@ impl Sheet {
         self.config.format.extension()
     }
 
-    /// Guard: the core's TOML pipeline is the v1.0 bytes-authority. Markdown/mdx
-    /// records (frontmatter codec) are deferred to a follow-up — see the plan
-    /// Notes — so a markdown sheet's record operations fail loudly rather than
-    /// writing the wrong bytes.
-    fn require_toml(&self) -> Result<()> {
-        if self.config.format.kind != FormatKind::Toml {
-            return Err(Error::ConfigInvalid {
-                message: format!(
-                    "sheet {:?}: the markdown/mdx record codec is not yet implemented in the Rust core (deferred — see plans/sheet-store-core.md)",
-                    self.name
-                ),
-            });
+    /// Read every record under the sheet's base, decoding each through the
+    /// format codec ([`crate::codec`]). `with_body` is the lazy-body switch: a
+    /// markdown record read with `with_body = false` omits the (potentially
+    /// large) body field, matching `Format.parseHeaderOnly`. No-op distinction
+    /// for TOML sheets. Returns sheet-relative paths in sorted order.
+    fn read_all(
+        &self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        with_body: bool,
+    ) -> Result<Vec<(String, Value)>> {
+        let texts = record::list_record_texts(repo, tree, &self.base, self.extension())?;
+        let mut out = Vec::with_capacity(texts.len());
+        for (path, text) in texts {
+            let record = if with_body {
+                codec::parse(&text, &self.config.format)?
+            } else {
+                codec::parse_header_only(&text, &self.config.format)?
+            };
+            out.push((path, record));
         }
-        Ok(())
+        Ok(out)
     }
 
     /// Render the path a record maps to (raw record, not normalized) — matches
@@ -264,8 +273,22 @@ impl Sheet {
         previous_path: Option<String>,
         allow_missing_body: bool,
     ) -> Result<UpsertCandidate> {
-        self.require_toml()?;
-        let _ = allow_missing_body; // body guard only applies to markdown (deferred)
+        // Body-presence guard (markdown/mdx only): an upsert is a full-record
+        // replace, so a record that omits the body field would silently erase
+        // the on-disk body. Require explicit opt-in. Mirrors `Sheet.#prepareUpsert`
+        // (the JS guard throws `TypeError`; the core surfaces it through the
+        // typed taxonomy as `validation_failed` — see the plan Notes).
+        if let Some(body_field) = &self.config.format.body {
+            let present = matches!(record, Value::Table(t) if t.get(body_field).is_some());
+            if !present && !allow_missing_body {
+                return Err(Error::ValidationFailed {
+                    message: format!(
+                        "upsert: record is missing the body field {body_field:?}. Pass allowMissingBody: true to opt in, or use Sheet.patch for body-preserving frontmatter updates."
+                    ),
+                    issues: Vec::new(),
+                });
+            }
+        }
 
         // JSON-Schema shape validation (the core's persisted-shape pass). The
         // consumer Standard Schema validator runs host-side between phases.
@@ -288,7 +311,9 @@ impl Sheet {
         // current tree) — throws before any mutation.
         self.check_unique_conflicts(repo, tree, &normalized, &record_path)?;
 
-        let next_text = canonical::serialize(&normalized)?;
+        // Serialize through the format codec: TOML records → canonical TOML;
+        // markdown/mdx → frontmatter + body (with title-from-H1 enforcement).
+        let next_text = codec::serialize(&normalized, &self.config.format)?;
 
         Ok(UpsertCandidate {
             record_path,
@@ -363,7 +388,6 @@ impl Sheet {
         tree: &mut MutableTree,
         record_path: &str,
     ) -> Result<()> {
-        self.require_toml()?;
         let full = join_record_path(&self.base, record_path, self.extension());
         let existed = tree
             .read_blob(repo, &full)
@@ -391,13 +415,17 @@ impl Sheet {
         Ok(())
     }
 
-    /// List every record under the sheet's base, in sorted path order.
+    /// List every record under the sheet's base, in sorted path order, decoded
+    /// through the format codec. `with_body` is the lazy-body switch for
+    /// markdown sheets (`false` omits the body field — the `withBody: false`
+    /// path); it is a no-op for TOML sheets.
     pub fn list(
         &self,
         repo: &gix::Repository,
         tree: &mut MutableTree,
+        with_body: bool,
     ) -> Result<Vec<(String, Value)>> {
-        record::list_records(repo, tree, &self.base, self.extension())
+        self.read_all(repo, tree, with_body)
     }
 
     // ── indexing ─────────────────────────────────────────────────────────────
@@ -461,7 +489,11 @@ impl Sheet {
                 return Ok(());
             }
         }
-        let records = record::list_records(repo, tree, &self.base, self.extension())?;
+        // Index builds always use body-less reads (the body isn't a record
+        // identifier): a keyFn referencing the body field sees it absent and the
+        // record degenerates out of the index. Matches the JS contract in
+        // specs/behaviors/content-types.md#indexes.
+        let records = self.read_all(repo, tree, false)?;
         let mut unique = HashMap::new();
         let mut multi = HashMap::new();
         for def in &self.indexes {
@@ -790,7 +822,7 @@ mod tests {
             .prepare_upsert(&repo, &mut tree, &r2, Some("jane".into()), false)
             .unwrap();
         sheet.stage_upsert(&repo, &mut tree, &c2).unwrap();
-        let listed = sheet.list(&repo, &mut tree).unwrap();
+        let listed = sheet.list(&repo, &mut tree, true).unwrap();
         let paths: Vec<&str> = listed.iter().map(|(p, _)| p.as_str()).collect();
         assert_eq!(paths, vec!["jane-doe"]);
     }
@@ -813,7 +845,7 @@ mod tests {
         let c = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
         sheet.stage_upsert(&repo, &mut tree, &c).unwrap();
         sheet.delete_at_path(&repo, &mut tree, "jane").unwrap();
-        assert!(sheet.list(&repo, &mut tree).unwrap().is_empty());
+        assert!(sheet.list(&repo, &mut tree, true).unwrap().is_empty());
     }
 
     #[test]
@@ -826,9 +858,9 @@ mod tests {
             let c = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
             sheet.stage_upsert(&repo, &mut tree, &c).unwrap();
         }
-        assert_eq!(sheet.list(&repo, &mut tree).unwrap().len(), 3);
+        assert_eq!(sheet.list(&repo, &mut tree, true).unwrap().len(), 3);
         sheet.clear(&repo, &mut tree).unwrap();
-        assert!(sheet.list(&repo, &mut tree).unwrap().is_empty());
+        assert!(sheet.list(&repo, &mut tree, true).unwrap().is_empty());
     }
 
     #[test]
@@ -913,26 +945,122 @@ mod tests {
         assert_eq!(err.code(), "index_not_defined");
     }
 
-    #[test]
-    fn markdown_record_ops_are_deferred() {
+    // ── markdown / content-typed sheets ──────────────────────────────────────
+
+    /// A tree pre-loaded with a markdown `posts` sheet config.
+    fn markdown_tree(repo: &gix::Repository, title: bool) -> MutableTree {
         let mut gs = IndexMap::new();
         gs.insert("path".to_string(), s("${{ slug }}"));
         gs.insert("root".to_string(), s("posts"));
         let mut fmt = IndexMap::new();
         fmt.insert("type".to_string(), s("markdown"));
-        fmt.insert("body".to_string(), s("content"));
+        fmt.insert("body".to_string(), s("body"));
+        if title {
+            fmt.insert("title".to_string(), s("title"));
+        }
         gs.insert("format".to_string(), Value::Table(fmt));
         let mut top = IndexMap::new();
         top.insert("gitsheet".to_string(), Value::Table(gs));
-
-        let (_d, repo) = temp_repo();
         let mut tree = MutableTree::empty();
-        write_records(&repo, &mut tree, ".gitsheets", &[("people".into(), Value::Table(top))], TOML_EXTENSION).unwrap();
-        tree.write(&repo).unwrap();
+        write_records(repo, &mut tree, ".gitsheets", &[("people".into(), Value::Table(top))], TOML_EXTENSION).unwrap();
+        tree.write(repo).unwrap();
+        tree
+    }
+
+    #[test]
+    fn markdown_upsert_writes_md_and_round_trips() {
+        let (_d, repo) = temp_repo();
+        let mut tree = markdown_tree(&repo, false);
         let mut sheet = open(&repo, &mut tree);
-        let r = rec(&[("slug", s("hi")), ("content", s("# Hi"))]);
+        let r = rec(&[("slug", s("hello")), ("title", s("Hello")), ("body", s("# Hello\n\nFirst post.\n"))]);
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        assert_eq!(cand.record_path, "hello");
+        assert!(cand.next_text.starts_with("+++\n"));
+        assert!(cand.next_text.contains("+++\n\n# Hello\n\nFirst post.\n"));
+        sheet.stage_upsert(&repo, &mut tree, &cand).unwrap();
+
+        // Stored at posts/hello.md (not .toml).
+        let listed = sheet.list(&repo, &mut tree, true).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, "hello");
+        let Value::Table(m) = &listed[0].1 else { panic!() };
+        assert_eq!(m.get("body"), Some(&s("# Hello\n\nFirst post.")));
+        assert_eq!(m.get("title"), Some(&s("Hello")));
+    }
+
+    #[test]
+    fn markdown_list_without_body_omits_body() {
+        let (_d, repo) = temp_repo();
+        let mut tree = markdown_tree(&repo, false);
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[("slug", s("a")), ("title", s("A")), ("body", s("HUGE BODY"))]);
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &cand).unwrap();
+
+        let with = sheet.list(&repo, &mut tree, true).unwrap();
+        assert_eq!(with[0].1.type_name(), "table");
+        let Value::Table(m) = &with[0].1 else { panic!() };
+        assert_eq!(m.get("body"), Some(&s("HUGE BODY")));
+
+        let without = sheet.list(&repo, &mut tree, false).unwrap();
+        let Value::Table(m2) = &without[0].1 else { panic!() };
+        assert_eq!(m2.get("body"), None);
+        assert_eq!(m2.get("title"), Some(&s("A")));
+    }
+
+    #[test]
+    fn markdown_missing_body_guard_and_opt_in() {
+        let (_d, repo) = temp_repo();
+        let mut tree = markdown_tree(&repo, false);
+        let mut sheet = open(&repo, &mut tree);
+
+        // Missing body without opt-in → validation_failed.
+        let r = rec(&[("slug", s("a")), ("title", s("A"))]);
         let err = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).err().unwrap();
-        assert_eq!(err.code(), "config_invalid");
-        assert!(err.message().contains("not yet implemented"));
+        assert_eq!(err.code(), "validation_failed");
+        assert!(err.message().contains("missing the body field"));
+
+        // With allow_missing_body → writes an empty body.
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, true).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &cand).unwrap();
+        let listed = sheet.list(&repo, &mut tree, true).unwrap();
+        let Value::Table(m) = &listed[0].1 else { panic!() };
+        assert_eq!(m.get("body"), Some(&s("")));
+    }
+
+    #[test]
+    fn markdown_title_from_h1_derivation_and_disagreement() {
+        let (_d, repo) = temp_repo();
+        let mut tree = markdown_tree(&repo, true);
+        let mut sheet = open(&repo, &mut tree);
+
+        // Derives title from the body H1 when omitted.
+        let r = rec(&[("slug", s("hello")), ("body", s("# Hello, world\n\nA post."))]);
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &cand).unwrap();
+        let listed = sheet.list(&repo, &mut tree, false).unwrap(); // body-less still has title
+        let Value::Table(m) = &listed[0].1 else { panic!() };
+        assert_eq!(m.get("title"), Some(&s("Hello, world")));
+        assert_eq!(m.get("body"), None);
+
+        // Disagreeing supplied title throws.
+        let bad = rec(&[("slug", s("x")), ("title", s("X")), ("body", s("# Y\n\nbody"))]);
+        let err = sheet.prepare_upsert(&repo, &mut tree, &bad, None, false).err().unwrap();
+        assert_eq!(err.code(), "validation_failed");
+    }
+
+    #[test]
+    fn markdown_reupsert_is_idempotent() {
+        let (_d, repo) = temp_repo();
+        let mut tree = markdown_tree(&repo, false);
+        let mut sheet = open(&repo, &mut tree);
+        let r = rec(&[("slug", s("a")), ("title", s("A")), ("body", s("body bytes"))]);
+        let cand = sheet.prepare_upsert(&repo, &mut tree, &r, None, false).unwrap();
+        sheet.stage_upsert(&repo, &mut tree, &cand).unwrap();
+
+        // Read back the full record and re-upsert it → no byte change.
+        let listed = sheet.list(&repo, &mut tree, true).unwrap();
+        let wc = sheet.will_change(&repo, &mut tree, &listed[0].1, None, false).unwrap();
+        assert!(!wc.changed, "byte-identical markdown re-upsert is a no-op");
     }
 }

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -146,6 +146,16 @@ module.exports = {
   CoreTransaction: addon.CoreTransaction,
   coreDiscoverSheets: wrap(addon.coreDiscoverSheets),
   coreCheckValidators: wrap(addon.coreCheckValidators),
+  // Markdown / mdx content-type codec (markdown-codec-core). serialize/parse can
+  // raise a typed ValidationError/ConfigError; the H1 + lint-config helpers are
+  // pure. The body markdownlint NORMALIZATION is a host-side pre-pass — the core
+  // frames the body verbatim (see the gitsheets_core::codec module docs).
+  markdownSerialize: wrap(addon.markdownSerialize),
+  markdownParse: wrap(addon.markdownParse),
+  markdownParseHeaderOnly: wrap(addon.markdownParseHeaderOnly),
+  markdownExtractH1: addon.markdownExtractH1,
+  markdownRewriteH1: addon.markdownRewriteH1,
+  markdownResolveLintConfig: addon.markdownResolveLintConfig,
   // Boundary-test entry: throws the typed class for a given stable code.
   simulateCoreError: wrap(addon.simulateCoreError),
   // Error machinery.

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -234,6 +234,42 @@ export declare function coreDiscoverSheets(gitDir: string, treeRef: string, open
  */
 export declare function coreCheckValidators(declared: Array<string>, validatorNames: Array<string>): void
 /**
+ * Serialize a record to its on-disk markdown bytes (`+++` frontmatter + body),
+ * enforcing the title-from-H1 invariant when `titleField` is set. The body is
+ * framed verbatim — markdownlint normalization is the host's pre-pass. A
+ * non-string body or a title that disagrees with the body's H1 throws a typed
+ * `ValidationError`.
+ */
+export declare function markdownSerialize(record: JsValue, bodyField: string, titleField?: string | undefined | null): string
+/**
+ * Parse on-disk markdown bytes into a full record (frontmatter fields + the
+ * body under `bodyField`). Mirrors `markdownFormat.parse`.
+ */
+export declare function markdownParse(text: string, bodyField: string, titleField?: string | undefined | null): JsValue
+/**
+ * Parse only the frontmatter — the lazy-body path. The body field is absent in
+ * the returned record. Mirrors `markdownFormat.parseHeaderOnly`.
+ */
+export declare function markdownParseHeaderOnly(text: string, bodyField: string): JsValue
+/**
+ * Extract the first ATX-style H1 from a markdown body, or `null` if absent.
+ * Mirrors `extractFirstH1`.
+ */
+export declare function markdownExtractH1(body: string): string | null
+/**
+ * Rewrite (or prepend) the first ATX H1 of a markdown body to `title`. Mirrors
+ * `rewriteLeadingH1` — the `Sheet.patch` title-reconciliation helper.
+ */
+export declare function markdownRewriteH1(body: string, title: string): string
+/**
+ * The effective markdownlint config the host's normalization pre-pass should
+ * apply, or `null` when disabled. The defaults (`default: true`, `MD013:
+ * false`, `MD041: false`) layered with any `[gitsheet.format.markdownlint]`
+ * overrides, plus the `MD041` auto-enable when title-from-H1 is on. The core
+ * computes the ruleset but does NOT apply it (see the codec module docs).
+ */
+export declare function markdownResolveLintConfig(markdownlint: JsValue, titleIsSet: boolean): JsValue | null
+/**
  * A compiled sheet definition: the embedded engine plus the definition's
  * path template (and optional raw-JS sort comparator), **compiled once** at
  * construction and reused across every method call. Holds a `!Send` boa
@@ -286,7 +322,7 @@ export declare class CoreTransaction {
    * the candidate is stashed for a subsequent `stageUpsert`. A JSON-Schema
    * rejection throws `ValidationError` here, before any bytes are written.
    */
-  prepareUpsert(name: string, record: JsValue, previousPath?: string | undefined | null): object
+  prepareUpsert(name: string, record: JsValue, previousPath?: string | undefined | null, allowMissingBody?: boolean | undefined | null): object
   /**
    * Phase 3 *(mutating)*: write the stashed candidate from the last
    * `prepareUpsert` for `name`. Marks the transaction mutated.
@@ -296,7 +332,7 @@ export declare class CoreTransaction {
    * Pre-flight idempotency check (`Sheet.willChange`) — same phase-1 pipeline,
    * then a byte comparison to the existing blob. Non-mutating.
    */
-  willChange(name: string, record: JsValue, previousPath?: string | undefined | null): object
+  willChange(name: string, record: JsValue, previousPath?: string | undefined | null, allowMissingBody?: boolean | undefined | null): object
   /**
    * Delete a record by its sheet-relative path *(mutating)*. Throws
    * `NotFoundError(record_not_found)` when absent.
@@ -304,6 +340,13 @@ export declare class CoreTransaction {
   delete(name: string, recordPath: string): void
   /** `Sheet.clear` *(mutating)* — empties the sheet's data subtree. */
   clear(name: string): void
+  /**
+   * List every record under the sheet's base, decoded through the format
+   * codec, in sorted path order. `withBody` is the lazy-body switch for
+   * markdown sheets (`false` omits the body field); a no-op for TOML sheets.
+   * Read-only — does not mark the transaction mutated.
+   */
+  list(name: string, withBody: boolean): Array<JsRecordEntry>
   /** The parent commit hash captured at open (null on a fresh repo). */
   parentCommitHash(): string | null
   /**

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1, markdownResolveLintConfig } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -337,3 +337,9 @@ module.exports.simulateCoreError = simulateCoreError
 module.exports.CoreTransaction = CoreTransaction
 module.exports.coreDiscoverSheets = coreDiscoverSheets
 module.exports.coreCheckValidators = coreCheckValidators
+module.exports.markdownSerialize = markdownSerialize
+module.exports.markdownParse = markdownParse
+module.exports.markdownParseHeaderOnly = markdownParseHeaderOnly
+module.exports.markdownExtractH1 = markdownExtractH1
+module.exports.markdownRewriteH1 = markdownRewriteH1
+module.exports.markdownResolveLintConfig = markdownResolveLintConfig

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs",
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs test/sheet-markdown.mjs",
     "bench": "node bench/query-bench.mjs"
   },
   "devDependencies": {

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -1201,6 +1201,7 @@ impl CoreTransaction {
         name: String,
         record: JsValue,
         previous_path: Option<String>,
+        allow_missing_body: Option<bool>,
     ) -> Result<JsObject> {
         let Self {
             inner,
@@ -1214,7 +1215,13 @@ impl CoreTransaction {
         let sheet = sheets
             .get_mut(&name)
             .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
-        let candidate = match sheet.prepare_upsert(repo, tree, &record.0, previous_path, false) {
+        let candidate = match sheet.prepare_upsert(
+            repo,
+            tree,
+            &record.0,
+            previous_path,
+            allow_missing_body.unwrap_or(false),
+        ) {
             Ok(c) => c,
             Err(err) => return Err(raise_core_error(&env, &err)),
         };
@@ -1275,6 +1282,7 @@ impl CoreTransaction {
         name: String,
         record: JsValue,
         previous_path: Option<String>,
+        allow_missing_body: Option<bool>,
     ) -> Result<JsObject> {
         let Self { inner, sheets, .. } = self;
         let tx = inner.as_mut().ok_or_else(|| {
@@ -1284,7 +1292,13 @@ impl CoreTransaction {
         let sheet = sheets
             .get_mut(&name)
             .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
-        let wc = match sheet.will_change(repo, tree, &record.0, previous_path, false) {
+        let wc = match sheet.will_change(
+            repo,
+            tree,
+            &record.0,
+            previous_path,
+            allow_missing_body.unwrap_or(false),
+        ) {
             Ok(w) => w,
             Err(err) => return Err(raise_core_error(&env, &err)),
         };
@@ -1338,6 +1352,32 @@ impl CoreTransaction {
         }
         tx.mark_mutated();
         Ok(())
+    }
+
+    /// List every record under the sheet's base, decoded through the format
+    /// codec, in sorted path order. `withBody` is the lazy-body switch for
+    /// markdown sheets (`false` omits the body field); a no-op for TOML sheets.
+    /// Read-only — does not mark the transaction mutated.
+    #[napi]
+    pub fn list(&mut self, env: Env, name: String, with_body: bool) -> Result<Vec<JsRecordEntry>> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get(&name)
+            .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
+        match sheet.list(repo, tree, with_body) {
+            Ok(rows) => Ok(rows
+                .into_iter()
+                .map(|(path, record)| JsRecordEntry {
+                    path,
+                    record: JsValue(record),
+                })
+                .collect()),
+            Err(err) => Err(raise_core_error(&env, &err)),
+        }
     }
 
     /// The parent commit hash captured at open (null on a fresh repo).
@@ -1397,4 +1437,105 @@ pub fn core_check_validators(
     validator_names: Vec<String>,
 ) -> Result<()> {
     store::check_validators(&declared, &validator_names).map_err(|err| raise_core_error(&env, &err))
+}
+
+// ── markdown / mdx content-type codec (markdown-codec-core) ─────────────────────
+//
+// The frontmatter+body codec, exposed directly so the boundary suite can assert
+// byte-level parity with the JS oracle (`packages/gitsheets/src/format/markdown.ts`).
+// markdownlint body-NORMALIZATION is NOT applied here — it is a host-side pre-pass
+// (see gitsheets_core::codec module docs); these surface the byte-deterministic
+// framing, title-from-H1, and lazy-body parts of the format.
+
+use gitsheets_core::codec;
+use gitsheets_core::config::{FormatConfig, FormatKind, Markdownlint};
+
+/// Build a markdown `FormatConfig` for the direct codec entry points. The
+/// markdownlint setting is irrelevant to these (the core never applies it).
+fn markdown_format(body_field: String, title_field: Option<String>) -> FormatConfig {
+    FormatConfig {
+        kind: FormatKind::Markdown,
+        body: Some(body_field),
+        title: title_field,
+        markdownlint: Markdownlint::Default,
+    }
+}
+
+/// Serialize a record to its on-disk markdown bytes (`+++` frontmatter + body),
+/// enforcing the title-from-H1 invariant when `titleField` is set. The body is
+/// framed verbatim — markdownlint normalization is the host's pre-pass. A
+/// non-string body or a title that disagrees with the body's H1 throws a typed
+/// `ValidationError`.
+#[napi]
+pub fn markdown_serialize(
+    env: Env,
+    record: JsValue,
+    body_field: String,
+    title_field: Option<String>,
+) -> Result<String> {
+    let cfg = markdown_format(body_field, title_field);
+    codec::serialize(&record.0, &cfg).map_err(|err| raise_core_error(&env, &err))
+}
+
+/// Parse on-disk markdown bytes into a full record (frontmatter fields + the
+/// body under `bodyField`). Mirrors `markdownFormat.parse`.
+#[napi]
+pub fn markdown_parse(
+    env: Env,
+    text: String,
+    body_field: String,
+    title_field: Option<String>,
+) -> Result<JsValue> {
+    let cfg = markdown_format(body_field, title_field);
+    codec::parse(&text, &cfg)
+        .map(JsValue)
+        .map_err(|err| raise_core_error(&env, &err))
+}
+
+/// Parse only the frontmatter — the lazy-body path. The body field is absent in
+/// the returned record. Mirrors `markdownFormat.parseHeaderOnly`.
+#[napi]
+pub fn markdown_parse_header_only(
+    env: Env,
+    text: String,
+    body_field: String,
+) -> Result<JsValue> {
+    let cfg = markdown_format(body_field, None);
+    codec::parse_header_only(&text, &cfg)
+        .map(JsValue)
+        .map_err(|err| raise_core_error(&env, &err))
+}
+
+/// Extract the first ATX-style H1 from a markdown body, or `null` if absent.
+/// Mirrors `extractFirstH1`.
+#[napi]
+pub fn markdown_extract_h1(body: String) -> Option<String> {
+    codec::extract_first_h1(&body)
+}
+
+/// Rewrite (or prepend) the first ATX H1 of a markdown body to `title`. Mirrors
+/// `rewriteLeadingH1` — the `Sheet.patch` title-reconciliation helper.
+#[napi]
+pub fn markdown_rewrite_h1(body: String, title: String) -> String {
+    codec::rewrite_leading_h1(&body, &title)
+}
+
+/// The effective markdownlint config the host's normalization pre-pass should
+/// apply, or `null` when disabled. The defaults (`default: true`, `MD013:
+/// false`, `MD041: false`) layered with any `[gitsheet.format.markdownlint]`
+/// overrides, plus the `MD041` auto-enable when title-from-H1 is on. The core
+/// computes the ruleset but does NOT apply it (see the codec module docs).
+#[napi]
+pub fn markdown_resolve_lint_config(
+    markdownlint: JsValue,
+    title_is_set: bool,
+) -> Option<JsValue> {
+    // Marshal the raw `[gitsheet.format].markdownlint` value: `false` → disabled,
+    // a table → user rules, anything else → defaults.
+    let setting = match &markdownlint.0 {
+        Value::Boolean(false) => Markdownlint::Disabled,
+        Value::Table(t) => Markdownlint::Rules(t.clone()),
+        _ => Markdownlint::Default,
+    };
+    setting.resolve(title_is_set).map(JsValue)
 }

--- a/rust/gitsheets-napi/test/sheet-markdown.mjs
+++ b/rust/gitsheets-napi/test/sheet-markdown.mjs
@@ -1,0 +1,399 @@
+// Markdown / mdx content-type codec boundary suite for gitsheets-napi.
+//
+// Proves byte-level parity with the JS oracle (packages/gitsheets/src/format/
+// markdown.ts) and the end-to-end markdown-sheet behavior of
+// specs/behaviors/content-types.md, driven through the core's napi boundary:
+//   - the frontmatter+body codec: round-trip byte-identity, empty/embedded-`+++`
+//     bodies, UTF-8 BOM, TOML datetimes in the frontmatter, lazy (header-only) reads;
+//   - title-from-H1 extraction, the H1 rewrite helper, and the disagreement guard;
+//   - the resolved markdownlint ruleset (computed by the core; APPLIED host-side —
+//     see the codec module docs: the core frames the body verbatim);
+//   - end-to-end markdown sheets: `.md` on disk, read-back, withBody:false, and
+//     the allowMissingBody opt-in.
+//
+// Requires the addon to be built first: `npm run build:debug` (or `build`).
+// Run with: `npm test` (node --test).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../binding.cjs');
+} catch (err) {
+  throw new Error(
+    `gitsheets-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+
+const {
+  CoreTransaction,
+  markdownSerialize,
+  markdownParse,
+  markdownParseHeaderOnly,
+  markdownExtractH1,
+  markdownRewriteH1,
+  markdownResolveLintConfig,
+} = binding;
+
+// ── direct codec: serialize / parse byte parity ────────────────────────────────
+
+test('serialize writes +++ frontmatter then the body', () => {
+  const text = markdownSerialize(
+    { slug: 'hello', title: 'Hello, world', body: '# Hello\n\nBody text\n' },
+    'body',
+  );
+  assert.ok(text.startsWith('+++\n'));
+  assert.match(text, /slug = "hello"/);
+  assert.match(text, /title = "Hello, world"/);
+  assert.ok(text.includes('+++\n\n# Hello\n\nBody text\n'));
+});
+
+test('empty body is just the delimiters + one trailing newline', () => {
+  const text = markdownSerialize({ slug: 'empty', body: '' }, 'body');
+  assert.equal(text, '+++\nslug = "empty"\n+++\n\n\n');
+});
+
+test('a missing body field serializes as an empty body', () => {
+  const text = markdownSerialize({ slug: 'no-body' }, 'body');
+  assert.match(text, /slug = "no-body"/);
+  assert.ok(text.endsWith('+++\n\n\n'));
+});
+
+test('a non-string body throws a typed error', () => {
+  assert.throws(
+    () => markdownSerialize({ slug: 'bad', body: 42 }, 'body'),
+    (err) => /must be a string/.test(err.message),
+  );
+});
+
+test('frontmatter keys are deep-sorted', () => {
+  const text = markdownSerialize({ zeta: 1, alpha: 2, slug: 'sorted', body: '' }, 'body');
+  const fm = text.split('+++\n')[1] ?? '';
+  assert.ok(fm.indexOf('alpha') < fm.indexOf('slug'));
+  assert.ok(fm.indexOf('slug') < fm.indexOf('zeta'));
+});
+
+test('serialize → parse round-trips a record', () => {
+  const original = {
+    slug: 'roundtrip',
+    title: 'Round-trip',
+    tags: ['a', 'b'],
+    body: '# Heading\n\nSome content.',
+  };
+  const text = markdownSerialize(original, 'body');
+  const parsed = markdownParse(text, 'body');
+  assert.equal(parsed.slug, 'roundtrip');
+  assert.equal(parsed.title, 'Round-trip');
+  assert.deepEqual(parsed.tags, ['a', 'b']);
+  assert.equal(parsed.body, '# Heading\n\nSome content.');
+  // Idempotent: re-serializing the parsed record yields the same bytes.
+  assert.equal(markdownSerialize(parsed, 'body'), text);
+});
+
+test('a +++ line inside the body is preserved verbatim', () => {
+  const body = 'before\n\n+++\n\nafter';
+  const text = markdownSerialize({ slug: 'plus', body }, 'body');
+  assert.equal(markdownParse(text, 'body').body, body);
+});
+
+test('an empty body reads back as ""', () => {
+  const text = markdownSerialize({ slug: 'empty', body: '' }, 'body');
+  assert.equal(markdownParse(text, 'body').body, '');
+});
+
+test('TOML datetime types survive the frontmatter round-trip', () => {
+  const original = { slug: 'dated', publishedAt: new Date('2024-05-16T10:00:00Z'), body: 'hi' };
+  const text = markdownSerialize(original, 'body');
+  const parsed = markdownParse(text, 'body');
+  assert.ok(parsed.publishedAt instanceof Date);
+  assert.equal(parsed.publishedAt.toISOString(), '2024-05-16T10:00:00.000Z');
+});
+
+test('a UTF-8 BOM at the start of the file is stripped on parse', () => {
+  const text = '﻿+++\nslug = "bom"\n+++\n\nhello\n';
+  const parsed = markdownParse(text, 'body');
+  assert.equal(parsed.slug, 'bom');
+  assert.equal(parsed.body, 'hello');
+});
+
+test('a body-only file (no frontmatter) parses to just the body field', () => {
+  const parsed = markdownParse('just some body text', 'body');
+  assert.equal(parsed.body, 'just some body text');
+  assert.deepEqual(
+    Object.keys(parsed).filter((k) => k !== 'body'),
+    [],
+  );
+});
+
+test('parseHeaderOnly skips the body (lazy read)', () => {
+  const text = markdownSerialize(
+    { slug: 'header', title: 'Header only', body: 'this body is big\n'.repeat(1000) },
+    'body',
+  );
+  const header = markdownParseHeaderOnly(text, 'body');
+  assert.equal(header.slug, 'header');
+  assert.equal(header.title, 'Header only');
+  assert.equal(header.body, undefined);
+});
+
+// ── title-from-H1 ──────────────────────────────────────────────────────────────
+
+test('extractH1 returns the first ATX H1, trimmed', () => {
+  assert.equal(markdownExtractH1('# Hello, world\n\nBody'), 'Hello, world');
+  assert.equal(markdownExtractH1('Some prose first.\n\n# Title\n\nMore.'), 'Title');
+  assert.equal(markdownExtractH1('# Hello   '), 'Hello');
+  assert.equal(markdownExtractH1('Body without a heading'), null);
+  assert.equal(markdownExtractH1('## Subheading'), null);
+  assert.equal(markdownExtractH1('#NoSpace'), null);
+});
+
+test('rewriteH1 rewrites the first H1, or prepends when absent', () => {
+  assert.equal(markdownRewriteH1('# Old\n\nBody', 'New'), '# New\n\nBody');
+  assert.equal(markdownRewriteH1('# First\n\n# Second', 'X'), '# X\n\n# Second');
+  assert.equal(markdownRewriteH1('Just prose, no heading.', 'X'), '# X\n\nJust prose, no heading.');
+  assert.equal(markdownRewriteH1('', 'X'), '# X\n');
+});
+
+test('serialize with a title field derives the title from the body H1', () => {
+  const text = markdownSerialize({ slug: 'hello', body: '# Hello, world\n\nA short post.' }, 'body', 'title');
+  assert.match(text, /title = "Hello, world"/);
+  // Round-trips: the title field is read back from the frontmatter.
+  assert.equal(markdownParse(text, 'body', 'title').title, 'Hello, world');
+});
+
+test('serialize with an agreeing supplied title passes through', () => {
+  const text = markdownSerialize(
+    { slug: 'hello', title: 'Hello, world', body: '# Hello, world\n\nA short post.' },
+    'body',
+    'title',
+  );
+  assert.match(text, /title = "Hello, world"/);
+});
+
+test('serialize throws ValidationError when the title disagrees with the H1', () => {
+  assert.throws(
+    () => markdownSerialize({ slug: 'hello', title: 'X', body: '# Y\n\nbody' }, 'body', 'title'),
+    (err) => err.code === 'validation_failed' && err.name === 'ValidationError',
+  );
+});
+
+test('serialize throws when a title is supplied but the body has no H1', () => {
+  assert.throws(
+    () => markdownSerialize({ slug: 'hello', title: 'Stale', body: 'No H1 here.' }, 'body', 'title'),
+    (err) => err.code === 'validation_failed',
+  );
+});
+
+test('serialize omits the title when the body has no H1 and none is supplied', () => {
+  const text = markdownSerialize({ slug: 'hello', body: 'No H1 here.' }, 'body', 'title');
+  assert.ok(!/title\s*=/.test(text));
+});
+
+// ── markdownlint config resolution (computed in the core, APPLIED host-side) ─────
+
+test('resolveLintConfig returns the layered defaults', () => {
+  const cfg = markdownResolveLintConfig(true, false); // `true` ⇒ no overrides → defaults
+  assert.equal(cfg.default, true);
+  assert.equal(cfg.MD013, false);
+  assert.equal(cfg.MD041, false);
+});
+
+test('resolveLintConfig returns null when disabled', () => {
+  assert.equal(markdownResolveLintConfig(false, false), null);
+});
+
+test('resolveLintConfig layers user rules and auto-enables MD041 with a title', () => {
+  const withRules = markdownResolveLintConfig({ MD013: true }, false);
+  assert.equal(withRules.MD013, true, 'user override wins');
+  const withTitle = markdownResolveLintConfig(true, true);
+  assert.equal(withTitle.MD041, true, 'title-from-H1 auto-enables MD041');
+});
+
+// ── end-to-end markdown sheets through a transaction ────────────────────────────
+
+const MD_CONFIG =
+  "[gitsheet]\npath = '${{ slug }}'\nroot = 'posts'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\n";
+const MD_TITLE_CONFIG =
+  "[gitsheet]\npath = '${{ slug }}'\nroot = 'posts'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\ntitle = 'title'\n";
+
+function setupRepo(config) {
+  const dir = mkdtempSync(join(tmpdir(), 'gitsheets-mdcore-'));
+  execFileSync('git', ['init', '-q', '-b', 'main', dir]);
+  execFileSync('git', ['-C', dir, 'config', 'user.name', 'Seed']);
+  execFileSync('git', ['-C', dir, 'config', 'user.email', 'seed@x.org']);
+  mkdirSync(join(dir, '.gitsheets'), { recursive: true });
+  writeFileSync(join(dir, '.gitsheets/posts.toml'), config);
+  execFileSync('git', ['-C', dir, 'add', '.gitsheets/posts.toml']);
+  execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'init']);
+  return { dir, gitDir: join(dir, '.git') };
+}
+
+function defaultOpts(message, extra = {}) {
+  return {
+    parent: undefined,
+    branch: undefined,
+    author: { name: 'Jane Doe', email: 'jane@x.org' },
+    committer: undefined,
+    message,
+    trailers: undefined,
+    timeSeconds: 1_700_000_000,
+    offsetMinutes: -300,
+    ...extra,
+  };
+}
+
+// Drive one prepare → stage → finalize cycle for a markdown sheet.
+function upsertPost(gitDir, opts, record, allowMissingBody) {
+  const tx = CoreTransaction.begin(gitDir, opts);
+  try {
+    tx.openSheet('posts', '.gitsheets/posts.toml', '.', '');
+    tx.prepareUpsert('posts', record, undefined, allowMissingBody);
+    tx.stageUpsert('posts');
+    return tx.finalize();
+  } catch (err) {
+    tx.discard();
+    throw err;
+  }
+}
+
+test('markdown sheet writes a .md file with TOML frontmatter', () => {
+  const { dir, gitDir } = setupRepo(MD_CONFIG);
+  try {
+    const result = upsertPost(gitDir, defaultOpts('first post'), {
+      slug: 'hello-world',
+      title: 'Hello, world',
+      body: '# Hello\n\nFirst post.\n',
+    });
+    assert.ok(result.commitHash);
+
+    const tree = execFileSync('git', ['--git-dir', gitDir, 'ls-tree', '-r', '--name-only', 'HEAD'])
+      .toString();
+    assert.ok(tree.includes('posts/hello-world.md'));
+    assert.ok(!tree.includes('posts/hello-world.toml'));
+
+    const blob = execFileSync('git', ['--git-dir', gitDir, 'show', `${result.commitHash}:posts/hello-world.md`])
+      .toString();
+    assert.ok(blob.startsWith('+++\n'));
+    assert.match(blob, /slug = "hello-world"/);
+    assert.match(blob, /title = "Hello, world"/);
+    assert.ok(blob.includes('+++\n\n# Hello\n\nFirst post.\n'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('mdx alias is configurable and reads back the same codec', () => {
+  const { dir, gitDir } = setupRepo(MD_CONFIG.replace("type = 'markdown'", "type = 'mdx'"));
+  try {
+    const result = upsertPost(gitDir, defaultOpts('mdx post'), { slug: 'intro', body: 'mdx body' });
+    assert.ok(result.commitHash);
+    const tree = execFileSync('git', ['--git-dir', gitDir, 'ls-tree', '-r', '--name-only', 'HEAD']).toString();
+    assert.ok(tree.includes('posts/intro.mdx'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('list reads markdown records back, with and without the body', () => {
+  const { dir, gitDir } = setupRepo(MD_CONFIG);
+  try {
+    upsertPost(gitDir, defaultOpts('seed a'), { slug: 'a', title: 'A', body: 'a huge body\n'.repeat(100) });
+    upsertPost(gitDir, defaultOpts('seed b'), { slug: 'b', title: 'B', body: 'body of B' });
+
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('read'));
+    try {
+      tx.openSheet('posts', '.gitsheets/posts.toml', '.', '');
+
+      const withBody = tx.list('posts', true);
+      const bySlug = new Map(withBody.map((e) => [e.record.slug, e.record]));
+      assert.equal(bySlug.get('b').title, 'B');
+      assert.equal(bySlug.get('b').body, 'body of B');
+
+      const withoutBody = tx.list('posts', false);
+      for (const { record } of withoutBody) {
+        assert.equal(record.body, undefined, 'body omitted under withBody:false');
+        assert.ok(record.title, 'frontmatter fields still present');
+      }
+    } finally {
+      tx.discard();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a body-less upsert is rejected by default, permitted with allowMissingBody', () => {
+  const { dir, gitDir } = setupRepo(MD_CONFIG);
+  try {
+    assert.throws(
+      () => upsertPost(gitDir, defaultOpts('no body'), { slug: 'a', title: 'A' }),
+      (err) => err.code === 'validation_failed' && /missing the body field/.test(err.message),
+    );
+
+    const ok = upsertPost(gitDir, defaultOpts('opt in'), { slug: 'a', title: 'A' }, true);
+    assert.ok(ok.commitHash);
+
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('read'));
+    try {
+      tx.openSheet('posts', '.gitsheets/posts.toml', '.', '');
+      const [{ record }] = tx.list('posts', true);
+      assert.equal(record.body, '', 'serialized as an empty body');
+    } finally {
+      tx.discard();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('title-from-H1 derivation through upsert, visible in body-less reads', () => {
+  const { dir, gitDir } = setupRepo(MD_TITLE_CONFIG);
+  try {
+    upsertPost(gitDir, defaultOpts('derive'), { slug: 'hello', body: '# Hello, world\n\nLong body here.' });
+
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('read'));
+    try {
+      tx.openSheet('posts', '.gitsheets/posts.toml', '.', '');
+      const [{ record }] = tx.list('posts', false);
+      assert.equal(record.title, 'Hello, world', 'title denormalized into frontmatter');
+      assert.equal(record.body, undefined);
+    } finally {
+      tx.discard();
+    }
+
+    // A disagreeing supplied title is rejected at prepare time.
+    assert.throws(
+      () => upsertPost(gitDir, defaultOpts('bad'), { slug: 'x', title: 'X', body: '# Y\n\nbody' }),
+      (err) => err.code === 'validation_failed',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a byte-identical markdown re-upsert is a no-op', () => {
+  const { dir, gitDir } = setupRepo(MD_CONFIG);
+  try {
+    upsertPost(gitDir, defaultOpts('seed'), { slug: 'a', title: 'A', body: 'body bytes' });
+
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('check'));
+    try {
+      tx.openSheet('posts', '.gitsheets/posts.toml', '.', '');
+      const [{ record }] = tx.list('posts', true);
+      const wc = tx.willChange('posts', record);
+      assert.equal(wc.changed, false, 'round-tripped record re-serializes to identical bytes');
+    } finally {
+      tx.discard();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Ports the content-typed record format (`markdown`/`mdx`: TOML frontmatter
delimited by `+++` + a designated body field, stored as `.md`/`.mdx`) into
`gitsheets-core`, so markdown sheets round-trip through the core like TOML
sheets. Implements [`plans/markdown-codec-core.md`](plans/markdown-codec-core.md)
and the markdown half of [`specs/behaviors/content-types.md`](specs/behaviors/content-types.md);
a pre-cutover prerequisite for the Rust-core evolution tracked in #127.

## What's here

- **`codec` module** (`gitsheets-core`): format-dispatched serialize / parse /
  `parse_header_only`. Frontmatter goes through the **same** `canonical::serialize`
  as TOML records — one bytes-authority, no second TOML path. Covers the `+++`
  split (BOM strip, embedded-`+++` preservation, trailing-newline idempotence),
  title-from-H1 extraction + the upsert disagreement guard, the H1 rewrite helper,
  and lazy (header-only) body reads. `+++`/H1 matching via the `regex` crate with
  JS-equivalent multiline/greedy semantics.
- **Sheet wiring**: `prepare_upsert` serializes through the codec and enforces the
  body-presence guard (`allow_missing_body`); `list` gains a `with_body` switch;
  index builds use body-less reads. The old `require_toml` deferral guard is gone.
- **napi surface + boundary suite**: `markdownSerialize/Parse/ParseHeaderOnly`,
  `markdownExtractH1/RewriteH1`, `markdownResolveLintConfig`, `CoreTransaction.list`,
  and `allowMissingBody` threaded through prepare/willChange. New
  `test/sheet-markdown.mjs` (in `npm test` + CI, explicit path for node 20 & 22).

## Round-trip result

Byte-identical to `format/markdown.ts` **with `markdownlint = false`** — verified
by codec unit tests, the napi round-trip/idempotence boundary tests, and the
frontmatter bytes flowing through the already-corpus-parity-proven canonical
serializer.

## markdownlint parity — enumerated divergence (not silently shipped)

The JS oracle normalizes the body with the `markdownlint` package on write. **The
core does not reimplement that.** `markdownlint` is ~40 rules of bespoke fix logic
with no byte-identical Rust port; a partial port would *silently* emit different
body bytes — exactly what the plan forbids. Instead:

- the codec frames the body **verbatim** (byte-deterministic framing);
- the markdownlint **config** is fully parsed and the effective ruleset computed by
  the core (`Markdownlint::resolve`, exposed as `markdownResolveLintConfig`) —
  nothing is dropped;
- the lint+fix **application** is a host-side pre-pass (the binding runs the
  `markdownlint` package), like the consumer Standard-Schema validator. The core
  never calls back into the host.

At cutover, the body-normalization call moves into the thin Node binding, the
framing matches byte-for-byte, and the markdown vitest suite stays green. See the
plan Notes for the full write-up (incl. a minor `TypeError`→`validation_failed`
class divergence the cutover can remap).

## Validation (all run)

- `cargo test -p gitsheets-core` — 140 + 4 pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- napi addon builds; `npm test` boundary suite — **89/89 pass**
- main JS suite stays green & independent (never imports the `.node` addon):
  `npm run type-check` clean, `npm test` — 287 unit + 66 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
