### PR TITLE
feat(core): native ICU collation for declarative locale sort

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -104,10 +104,14 @@ jobs:
         working-directory: rust/gitsheets-napi
         run: npm run build
 
-      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, record CRUD/diff/patch, query, index, Sheet/Transaction/Store, markdown codec)
+      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, ICU locale collation, record CRUD/diff/patch, query, index, Sheet/Transaction/Store, markdown codec)
         # Explicit file paths (not a glob) so the suite runs identically on
         # node 20 and 22 — `node --test "test/*.mjs"` does NOT expand on node 20.
         # The `test` npm script lists every .mjs explicitly (see package.json),
+        # including collator-parity.mjs, which asserts the native ICU collator for
+        # declarative `sort = true` matches this node's `localeCompare` byte-exactly
+        # (the boa-vs-V8 divergence locale-collation-core fixes — it needs Node for
+        # the reference, which this job has), and
         # including sheet-store.mjs, which drives the orchestration state machine
         # (Transaction lifecycle + the two-phase consumer-validator protocol +
         # Store discovery), and sheet-markdown.mjs, which drives the markdown/mdx

--- a/plans/locale-collation-core.md
+++ b/plans/locale-collation-core.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: [sheet-store-core]
 specs:
   - specs/rust-core.md
   - specs/behaviors/normalization.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/213
 ---
 
 # Plan: native ICU locale collation for `sort = true`
@@ -49,14 +50,22 @@ arbitrary raw-JS comparator escape hatch (that stays in boa, correctly).
 
 ## Validation
 
-- [ ] `sort = true` over a fixture set incl. **non-ASCII / mixed-case** strings
+- [x] `sort = true` over a fixture set incl. **non-ASCII / mixed-case** strings
       matches V8 `localeCompare` (the `node:vm` reference) exactly — the cases the
-      boa path diverged on.
-- [ ] No declarative locale sort routes through the boa engine anymore (grep/test).
-- [ ] The collator + data version is pinned and recorded as a behavior-contract
-      input.
-- [ ] `cargo build/test` + clippy clean; napi boundary suite passes; the main JS
-      suite stays green and independent.
+      boa path diverged on. (20,449 all-pairs over 143 strings, zero divergence,
+      during development; shipped as `test/collator-parity.mjs` — boa-divergent
+      cases + curated fixture + 50 randomized arrays, all exact on node 20 + 22.)
+- [x] No declarative locale sort routes through the boa engine anymore. `sort =
+      true` → `SortKind::Locale` → `crate::collator`; `comparator_source` returns
+      `None` for it, so no `localeCompare` snippet is compiled into boa (grep:
+      zero `localeCompare` *code* in the rust sources, only doc comments).
+- [x] The collator + data version is pinned and recorded as a behavior-contract
+      input. `icu_collator = "=2.0.0"` with `compiled_data` (baked CLDR), documented
+      in `Cargo.toml` as a canonical-behavior contract input.
+- [x] `cargo build/test` + clippy clean; napi boundary suite passes; the main JS
+      suite stays green and independent. (core 143 pass; clippy `-D warnings`
+      clean; napi `npm test` 92 pass; root `npm test` 287+66 pass + type-check;
+      main build has zero `.node` references.)
 
 ## Risks / unknowns
 
@@ -69,8 +78,55 @@ arbitrary raw-JS comparator escape hatch (that stays in boa, correctly).
 
 ## Notes
 
-(Populated at closeout.)
+- **Crate chosen: `icu_collator` (ICU4X), pinned `=2.0.0`.** ICU4X is the same
+  ICU/CLDR lineage V8 uses, and its docs spell out the exact ECMA-402 `sensitivity`
+  → `Strength` mapping, so configuring it to V8's `localeCompare` was direct rather
+  than guesswork. `feruca` (the other candidate) was not needed once ICU4X matched
+  exactly. Held to **2.0.x** not the latest 2.2.x: `boa_engine` 0.21.1 pins
+  `icu_normalizer ~2.0`, and `icu_collator` 2.2.x wants `~2.2` — irreconcilable on
+  that shared transitive dep. 2.0.0 reuses boa's existing `icu_normalizer 2.0.1`;
+  only 4 net-new locked packages (`icu_collator{,_data}`, `icu_locale{,_data}`).
+- **Exact V8-matching config** (in `src/collator.rs`), matching
+  `localeCompare(b, undefined, { sensitivity: 'base', ignorePunctuation: true,
+  numeric: true })`:
+  - `sensitivity: 'base'` → `Strength::Primary` (case + accents fold)
+  - `ignorePunctuation: true` → `AlternateHandling::Shifted`
+  - `numeric: true` → `CollationNumericOrdering::True` (a BCP47 `kn` *preference*,
+    set on `CollatorPreferences`, not `CollatorOptions`)
+  - locale `undefined` (en-US in Node) → **root** collator (default prefs). CLDR
+    `en` carries no tailoring over root, so root is byte-identical to en-US here
+    *and* deterministic across hosts (no dependence on a runtime's resolved default
+    locale) — which the canonical-bytes contract needs.
+- **Parity result.** Byte-exact vs node's `localeCompare`: an all-pairs sign
+  comparison of **20,449 pairs over 143 strings** (accents, mixed case, ligatures
+  `ﬁ`/`ﬀ`, fullwidth `２`/`５`, CJK `北京`, Cyrillic/Greek, punctuation, whitespace,
+  emoji, numeric `file2`/`file10`) diverged on **zero** pairs. The headline boa
+  divergences now match: `["B","a"]` → `["a","B"]` (boa gave `["B","a"]`), `["é",
+  "e","z"]` stable-folds, `["10","2","1"]` → `["1","2","10"]`, `co-op`/`coop`/`co
+  op` collate equal.
+- **Stability.** `Array.prototype.sort` is stable; `collator::sort_array` uses
+  `slice::sort_by` (stable) over a coerced-key/value pairing, so base-equal
+  elements keep input order — matching V8.
+- **Pinned version.** `icu_collator = "=2.0.0"` (+ `compiled_data` baked CLDR), a
+  canonical-behavior contract input alongside the serializer and the engine.
+- **Engine split.** Only `sort = true` moved. Raw-JS comparators and relational
+  `{field: dir}` / `[field]` directives stay in boa: the directives use JS `<`/`>`
+  (code-unit, deterministic across boa and V8), not locale collation, so they do
+  not have the boa-vs-V8 divergence locale sort had.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Non-string `sort = true` coercion.** `collator::sort_array` coerces non-string
+  elements to a JS-`String()`-equivalent before collating (the prior boa path did
+  `String(a)`). Faithful for scalars (int/bool/float-integral); composite values
+  (array/table) and exotic floats fall back to JS's degenerate forms. The spec
+  scopes `sort = true` to string arrays, so this only matters for misconfigured
+  data — but if non-string locale sort ever becomes load-bearing, give it its own
+  parity fixtures.
+- **Per-sheet/per-field locale.** v1.0 uses one fixed root collator. If a future
+  sheet wants a tailored locale (`de` phonebook, `sv`, …), thread a locale through
+  `SortRule` and build a per-sheet collator — and re-pin/pin-document the data.
+- **boa's shared `icu_normalizer` ceiling.** The `=2.0.0` pin is coupled to
+  boa_engine 0.21.1's `icu_normalizer ~2.0`. A boa upgrade that moves that floor is
+  the moment to revisit the collator version (and re-run the parity gate, since the
+  baked CLDR data version is part of the contract).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "boa_engine",
  "gix",
  "holo-tree",
+ "icu_collator",
  "indexmap",
  "jsonschema",
  "regex",
@@ -1842,6 +1843,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ad4c6a556938dfd31f75a8c54141079e8821dc697ffb799cfe0f0fa11f2edc"
+dependencies = [
+ "displaydoc",
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d880b8e680799eabd90c054e1b95526cd48db16c95269f3c89fb3117e1ac92c5"
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1878,22 @@ dependencies = [
  "potential_utf",
  "yoke",
  "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae5921528335e91da1b6c695dbf1ec37df5ac13faa3f91e5640be93aa2fbefd"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
  "zerovec",
 ]
 
@@ -1867,6 +1910,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fdef0c124749d06a743c69e938350816554eb63ac979166590e2b4ee4252765"
 
 [[package]]
 name = "icu_normalizer"
@@ -2496,6 +2545,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -55,6 +55,22 @@ gix = "0.83"
 # whitespace / CRLF). The body-NORMALIZATION pass (markdownlint) is NOT done
 # here — see the codec module docs and plans/markdown-codec-core.md.
 regex = "1"
+# ── locale-collation-core (native ICU collation for declarative `sort = true`) ─
+# The ICU4X collator. Declarative `sort = true` (locale-sensitive string-array
+# sorting) is NATIVE — it does NOT route through the boa engine, because boa is
+# built without `Intl` and its `localeCompare` falls back to code-unit order,
+# diverging from V8/`node:vm` on non-ASCII / mixed-case input. ICU4X is the same
+# ICU/CLDR lineage V8 uses, configured (Strength::Primary + AlternateHandling::
+# Shifted + CollationNumericOrdering::True, root locale) to match V8's
+# `localeCompare(b, undefined, { sensitivity: 'base', ignorePunctuation: true,
+# numeric: true })` exactly — see src/collator.rs and specs/behaviors/
+# normalization.md. The collator + its baked CLDR data determine sort order, hence
+# the canonical bytes of sorted arrays, so this is part of the canonical-behavior
+# contract and is PINNED EXACTLY (`=`) like the serializer and the engine. The
+# `compiled_data` default feature bakes the CLDR collation data into the binary
+# (no runtime data load). Held to 2.0.x because boa_engine 0.21.1 pins
+# `icu_normalizer ~2.0`; a newer icu_collator would diverge that shared dep.
+icu_collator = "=2.0.0"
 
 [dev-dependencies]
 # Throwaway git repos for the record-CRUD + diff integration tests.

--- a/rust/gitsheets-core/src/collator.rs
+++ b/rust/gitsheets-core/src/collator.rs
@@ -1,0 +1,205 @@
+//! Native ICU collation for declarative `sort = true`.
+//!
+//! Declarative `sort = true` (locale-sensitive string-array sorting) is **native**
+//! — it does NOT route through the boa engine. boa is built without `Intl`, so its
+//! `localeCompare` falls back to code-unit comparison and diverges from V8 /
+//! `node:vm` on non-ASCII / mixed-case input (e.g. `["B","a"]` sorts to `["a","B"]`
+//! under V8 but `["B","a"]` under boa's code-unit order). This module uses the
+//! ICU4X collator — the same ICU/CLDR lineage V8 uses — configured to match the
+//! exact options the JS oracle passes:
+//!
+//! ```js
+//! String(a).localeCompare(String(b), undefined, {
+//!   sensitivity: 'base',     // → Strength::Primary
+//!   ignorePunctuation: true, // → AlternateHandling::Shifted
+//!   numeric: true,           // → CollationNumericOrdering::True
+//! })
+//! ```
+//!
+//! The locale is `undefined`, i.e. the host default — `en-US` in Node. The CLDR
+//! `en` collation carries no tailoring over the CLDR root, so the **root** collator
+//! (default preferences) is byte-identical to `en-US` here and is deterministic
+//! across hosts (no dependency on a runtime's resolved default locale). That
+//! determinism is the point: the collator's order defines the canonical bytes of
+//! sorted arrays, so it is part of the canonical-behavior contract and the crate
+//! version is pinned exactly (see `Cargo.toml`).
+
+use std::cmp::Ordering;
+use std::sync::OnceLock;
+
+use icu_collator::{
+    options::{AlternateHandling, CollatorOptions, Strength},
+    preferences::CollationNumericOrdering,
+    Collator, CollatorBorrowed, CollatorPreferences,
+};
+
+use crate::value::Value;
+
+/// The process-wide collator matching V8's `localeCompare` with
+/// `{ sensitivity: 'base', ignorePunctuation: true, numeric: true }`.
+///
+/// Built once from the baked-in (`compiled_data`) CLDR collation data; the
+/// configuration is fixed (root locale, no per-sheet locale in v1.0).
+fn collator() -> &'static CollatorBorrowed<'static> {
+    static COLLATOR: OnceLock<CollatorBorrowed<'static>> = OnceLock::new();
+    COLLATOR.get_or_init(|| {
+        // numeric:true is a BCP47 `kn` *preference*, not a `CollatorOptions` field.
+        let mut prefs = CollatorPreferences::default();
+        prefs.numeric_ordering = Some(CollationNumericOrdering::True);
+
+        let mut options = CollatorOptions::default();
+        // sensitivity:'base' → only base letters distinguished (case + accents
+        // folded). The crate documents this exact ECMA-402 mapping.
+        options.strength = Some(Strength::Primary);
+        // ignorePunctuation:true → variable (punctuation/whitespace) elements are
+        // shifted below the primary level and thus ignored at Primary strength.
+        options.alternate_handling = Some(AlternateHandling::Shifted);
+
+        Collator::try_new(prefs, options)
+            .expect("baked CLDR root collation data is always present (compiled_data)")
+    })
+}
+
+/// Compare two strings with the locale collator (the `sort = true` order).
+pub fn compare(a: &str, b: &str) -> Ordering {
+    collator().compare(a, b)
+}
+
+/// Stable in-place sort of an array under the locale collator — the native
+/// replacement for the boa `String(a).localeCompare(String(b), …)` comparator.
+///
+/// Each element is coerced to a string the way JS `String(value)` would before
+/// comparison; the spec ([`normalization.md`]) scopes `sort = true` to arrays of
+/// strings, so the coercion only matters for misconfigured non-string arrays,
+/// where it mirrors `String()` for scalars.
+///
+/// `slice::sort_by` is a stable sort, matching `Array.prototype.sort`'s stability,
+/// so base-equal elements (`é`/`e`, `B`/`b`) keep their input order.
+///
+/// [`normalization.md`]: ../../../../specs/behaviors/normalization.md
+pub fn sort_array(items: &mut [Value]) {
+    // Pair each element with its coerced comparison key once (so the key is
+    // computed n times, not on every comparison), stable-sort the pairs, then
+    // write the elements back in order.
+    let mut paired: Vec<(String, Value)> = items
+        .iter()
+        .map(|v| (js_string_coerce(v), v.clone()))
+        .collect();
+    paired.sort_by(|a, b| compare(&a.0, &b.0));
+    for (slot, (_, v)) in items.iter_mut().zip(paired) {
+        *slot = v;
+    }
+}
+
+/// Coerce a [`Value`] to the string `String(value)` yields in JS — the coercion
+/// the prior boa comparator applied via `String(a)`. Strings pass through;
+/// scalars match JS exactly; composite values fall back to JS's degenerate forms
+/// (they do not occur for a spec-conformant `sort = true` field).
+fn js_string_coerce(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Integer(i) => i.to_string(),
+        Value::Boolean(b) => b.to_string(),
+        Value::Float(f) => js_number_to_string(*f),
+        Value::Datetime(d) => d.to_string(),
+        // JS: String([a, b]) === a.join(',') with String() of each element.
+        Value::Array(items) => items
+            .iter()
+            .map(js_string_coerce)
+            .collect::<Vec<_>>()
+            .join(","),
+        // JS: String({}) === "[object Object]".
+        Value::Table(_) => "[object Object]".to_string(),
+    }
+}
+
+/// `String(number)` per ECMAScript: integral finite values render without a
+/// fractional part, NaN/±Infinity render as their JS spellings. The general
+/// shortest-round-trip case matches Rust's `f64` Display for the values a TOML
+/// float carries.
+fn js_number_to_string(f: f64) -> String {
+    if f.is_nan() {
+        "NaN".to_string()
+    } else if f.is_infinite() {
+        if f > 0.0 {
+            "Infinity".to_string()
+        } else {
+            "-Infinity".to_string()
+        }
+    } else if f == f.trunc() && f.abs() < 1e21 {
+        // Integral floats print without a decimal point in JS (String(2.0) === "2").
+        format!("{}", f as i64)
+    } else {
+        f.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sort a list of `&str` via the public `sort_array` and collect back.
+    fn sorted(input: &[&str]) -> Vec<String> {
+        let mut items: Vec<Value> = input.iter().map(|s| Value::String((*s).to_string())).collect();
+        sort_array(&mut items);
+        items
+            .into_iter()
+            .map(|v| match v {
+                Value::String(s) => s,
+                _ => unreachable!(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn matches_v8_localecompare_on_the_boa_divergent_cases() {
+        // These are exactly the inputs the boa (code-unit) path got wrong. Each
+        // expected order is V8's `localeCompare(b, undefined, { sensitivity:
+        // 'base', ignorePunctuation: true, numeric: true })`, verified against
+        // `node` during development.
+
+        // `["B","a"]`: code-unit puts 'B'(0x42) before 'a'(0x61); V8 base-folds
+        // case so 'a' < 'B'. This is the headline divergence.
+        assert_eq!(sorted(&["B", "a"]), vec!["a", "B"]);
+
+        // Accents fold at base sensitivity; stable sort preserves input order for
+        // base-equal elements (é before e because é came first).
+        assert_eq!(sorted(&["é", "e", "z"]), vec!["é", "e", "z"]);
+        assert_eq!(sorted(&["z", "é", "e"]), vec!["é", "e", "z"]);
+
+        // numeric:true → "2" < "10" (not code-point "10" < "2").
+        assert_eq!(sorted(&["10", "2", "1"]), vec!["1", "2", "10"]);
+        assert_eq!(sorted(&["file10", "file2", "file1"]), vec!["file1", "file2", "file10"]);
+
+        // ignorePunctuation:true → hyphen/space ignored: "co-op" == "coop" == "co op".
+        assert_eq!(sorted(&["coop", "co-op", "co op"]), vec!["coop", "co-op", "co op"]);
+
+        // Mixed case + accents + digits together (Äpfel base-folds to "apfel",
+        // and "apfel" < "apple" at the third letter).
+        assert_eq!(
+            sorted(&["Banana", "apple", "Äpfel", "10", "2"]),
+            vec!["2", "10", "Äpfel", "apple", "Banana"]
+        );
+    }
+
+    #[test]
+    fn compare_is_a_total_order_signum() {
+        use std::cmp::Ordering;
+        assert_eq!(compare("a", "B"), Ordering::Less);
+        assert_eq!(compare("B", "a"), Ordering::Greater);
+        assert_eq!(compare("e", "é"), Ordering::Equal); // base-equal
+        assert_eq!(compare("apple", "apple"), Ordering::Equal);
+    }
+
+    #[test]
+    fn js_string_coercion_matches_string_for_scalars() {
+        assert_eq!(js_string_coerce(&Value::String("hi".into())), "hi");
+        assert_eq!(js_string_coerce(&Value::Integer(42)), "42");
+        assert_eq!(js_string_coerce(&Value::Integer(-7)), "-7");
+        assert_eq!(js_string_coerce(&Value::Boolean(true)), "true");
+        assert_eq!(js_string_coerce(&Value::Boolean(false)), "false");
+        // String(2.0) === "2"; String(1.5) === "1.5".
+        assert_eq!(js_string_coerce(&Value::Float(2.0)), "2");
+        assert_eq!(js_string_coerce(&Value::Float(1.5)), "1.5");
+    }
+}

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod canonical;
 pub mod codec;
+pub mod collator;
 pub mod config;
 pub mod diff;
 pub mod engine;

--- a/rust/gitsheets-core/src/sheet.rs
+++ b/rust/gitsheets-core/src/sheet.rs
@@ -35,10 +35,10 @@
 use std::collections::HashMap;
 
 use holo_tree::MutableTree;
-use indexmap::IndexMap;
 
 use crate::canonical;
 use crate::codec;
+use crate::collator;
 use crate::config::{self, SheetConfig, SortRule};
 use crate::engine::{Engine, SnippetError, SnippetHandle};
 use crate::error::{Error, Result};
@@ -94,6 +94,19 @@ pub struct StageOutcome {
     pub path: String,
 }
 
+/// How a field's array-sort rule is evaluated.
+enum SortKind {
+    /// Declarative `sort = true` — native ICU collation matching V8's
+    /// `localeCompare(b, undefined, { sensitivity: 'base', ignorePunctuation:
+    /// true, numeric: true })`. Evaluated in [`crate::collator`], NOT the engine.
+    Locale,
+    /// A raw-JS comparator string or a `{field: dir}` / `[field]` relational
+    /// directive, compiled to a boa snippet. The escape hatch genuinely needs the
+    /// engine; relational directives use JS `<`/`>` (code-unit, deterministic
+    /// across boa and V8) rather than locale collation.
+    Engine(SnippetHandle),
+}
+
 /// A compiled sheet handle.
 ///
 /// Holds a `!Send` boa [`Engine`] (path/sort/index snippets), so it is
@@ -108,9 +121,12 @@ pub struct Sheet {
     base: String,
     template: Template,
     schema: Option<CompiledSchema>,
-    /// Per-field array-sort comparators, keyed by field name. `All(false)` rules
-    /// have no entry (they are a no-op).
-    sort_handles: IndexMap<String, SnippetHandle>,
+    /// Per-field array-sort plan, in config-field order. `All(false)` rules have
+    /// no entry (a no-op). Declarative `sort = true` ([`SortKind::Locale`]) is the
+    /// **native ICU collator** ([`crate::collator`]) — it does NOT route through
+    /// the boa engine; only raw-JS / relational-directive comparators
+    /// ([`SortKind::Engine`]) do.
+    sort_plan: Vec<(String, SortKind)>,
     indexes: Vec<IndexDef>,
     index_cache: Option<IndexCache>,
     engine: Engine,
@@ -169,13 +185,21 @@ impl Sheet {
             None => None,
         };
 
-        // Compile array-field sort comparators once.
-        let mut sort_handles = IndexMap::new();
+        // Build the array-field sort plan once, in config-field order. `sort =
+        // true` is native ICU collation (no engine snippet); raw-JS and relational
+        // directives compile to a boa comparator; `sort = false` is a no-op.
+        let mut sort_plan: Vec<(String, SortKind)> = Vec::new();
         for (field, fcfg) in &config.fields {
-            if let Some(rule) = &fcfg.sort {
-                if let Some(src) = comparator_source(rule) {
-                    let handle = engine.compile(&src)?;
-                    sort_handles.insert(field.clone(), handle);
+            match &fcfg.sort {
+                Some(SortRule::All(true)) => {
+                    sort_plan.push((field.clone(), SortKind::Locale));
+                }
+                Some(SortRule::All(false)) | None => {}
+                Some(rule) => {
+                    if let Some(src) = comparator_source(rule) {
+                        let handle = engine.compile(&src)?;
+                        sort_plan.push((field.clone(), SortKind::Engine(handle)));
+                    }
                 }
             }
         }
@@ -186,7 +210,7 @@ impl Sheet {
             base,
             template,
             schema,
-            sort_handles,
+            sort_plan,
             indexes: Vec::new(),
             index_cache: None,
             engine,
@@ -245,9 +269,12 @@ impl Sheet {
     pub fn normalize_record(&mut self, record: &Value) -> Result<Value> {
         let mut out = record.clone();
         if let Value::Table(map) = &mut out {
-            for (field, handle) in &self.sort_handles {
+            for (field, kind) in &self.sort_plan {
                 if let Some(Value::Array(items)) = map.get_mut(field) {
-                    sort_array(&mut self.engine, *handle, items)?;
+                    match kind {
+                        SortKind::Locale => collator::sort_array(items),
+                        SortKind::Engine(handle) => sort_array(&mut self.engine, *handle, items)?,
+                    }
                 }
             }
         }
@@ -582,14 +609,19 @@ impl Sheet {
 
 // ── comparator source generation (matches the JS `buildSorter`) ───────────────
 
-/// Generate the comparator JS source for a sort rule, or `None` for `All(false)`
-/// (a no-op). Mirrors `buildSorter` in `sheet.ts` so the engine runs the same
-/// comparator the host's `node:vm` path would.
+/// Generate the comparator JS source for an **engine** sort rule (raw JS or a
+/// relational `{field: dir}` / `[field]` directive), or `None` for the rules that
+/// never reach the engine. `All(true)` (declarative locale sort) is native ICU
+/// collation ([`crate::collator`]), so it returns `None` here and must not be
+/// engine-compiled; `All(false)` is a no-op. Mirrors `buildSorter` in `sheet.ts`
+/// for the cases that *do* run JS, so the engine runs the same comparator the
+/// host's `node:vm` path would.
 fn comparator_source(rule: &SortRule) -> Option<String> {
     match rule {
-        SortRule::All(true) => Some(
-            "(a, b) => ( String(a).localeCompare(String(b), undefined, { sensitivity: 'base', ignorePunctuation: true, numeric: true }) )".to_string(),
-        ),
+        // Locale sort is native (handled in `Sheet::open` → `SortKind::Locale`);
+        // it must NOT route through boa, whose `Intl`-less `localeCompare`
+        // diverges from V8 on non-ASCII input.
+        SortRule::All(true) => None,
         SortRule::All(false) => None,
         SortRule::Raw(rule) => Some(format!("(a, b) => {{ {rule} }}")),
         SortRule::Fields(fields) => {

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -114,6 +114,9 @@ module.exports = {
   renderPathsBatch: wrap(addon.renderPathsBatch),
   validateBatch: wrap(addon.validateBatch),
   runComparator: wrap(addon.runComparator),
+  // Native locale array sort (declarative `sort = true`) — the ICU collator
+  // matching V8 `localeCompare`. Pure (no structured errors), so unwrapped.
+  collatorSort: addon.collatorSort,
   // Stateful compiled definition (compile-once / reuse). Raw class — its
   // structured errors carry `gitsheetsClass`; map with `mapCoreError` if needed.
   CompiledDefinition: addon.CompiledDefinition,

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -61,6 +61,18 @@ export declare function validateBatch(schema: JsValue, records: Array<JsValue>):
  */
 export declare function runComparator(rule: string, a: JsValue, b: JsValue): number
 /**
+ * Native locale array sort — the declarative `sort = true` path. Sorts the
+ * strings with the ICU collator that matches V8's `localeCompare(b, undefined,
+ * { sensitivity: 'base', ignorePunctuation: true, numeric: true })`. This is the
+ * exact function `Sheet::normalize_record` applies for a `sort = true` field, and
+ * it does **NOT** route through the boa engine (boa lacks `Intl`, so its
+ * `localeCompare` falls back to code-unit order and diverges from `node:vm` on
+ * non-ASCII / mixed-case input). Exposed so a `node --test` harness asserts
+ * byte-exact parity against `node`'s `localeCompare` — see
+ * `test/collator-parity.mjs`.
+ */
+export declare function collatorSort(strings: Array<string>): Array<string>
+/**
  * Read a batch of records by path. Each result is the record (a plain object
  * with full TOML type fidelity) or `null` when no blob lives at that path.
  */

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1, markdownResolveLintConfig } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1, markdownResolveLintConfig } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -318,6 +318,7 @@ module.exports.serializeRecords = serializeRecords
 module.exports.renderPathsBatch = renderPathsBatch
 module.exports.validateBatch = validateBatch
 module.exports.runComparator = runComparator
+module.exports.collatorSort = collatorSort
 module.exports.CompiledDefinition = CompiledDefinition
 module.exports.recordRead = recordRead
 module.exports.recordWrite = recordWrite

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs test/sheet-markdown.mjs",
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/collator-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs test/sheet-markdown.mjs",
     "bench": "node bench/query-bench.mjs"
   },
   "devDependencies": {

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -366,6 +366,28 @@ pub fn run_comparator(env: Env, rule: String, a: JsValue, b: JsValue) -> Result<
         .map_err(|err| raise_core_error(&env, &err))
 }
 
+/// Native locale array sort — the declarative `sort = true` path. Sorts the
+/// strings with the ICU collator that matches V8's `localeCompare(b, undefined,
+/// { sensitivity: 'base', ignorePunctuation: true, numeric: true })`. This is the
+/// exact function `Sheet::normalize_record` applies for a `sort = true` field, and
+/// it does **NOT** route through the boa engine (boa lacks `Intl`, so its
+/// `localeCompare` falls back to code-unit order and diverges from `node:vm` on
+/// non-ASCII / mixed-case input). Exposed so a `node --test` harness asserts
+/// byte-exact parity against `node`'s `localeCompare` — see
+/// `test/collator-parity.mjs`.
+#[napi]
+pub fn collator_sort(strings: Vec<String>) -> Vec<String> {
+    let mut items: Vec<Value> = strings.into_iter().map(Value::String).collect();
+    gitsheets_core::collator::sort_array(&mut items);
+    items
+        .into_iter()
+        .map(|v| match v {
+            Value::String(s) => s,
+            _ => unreachable!("collator_sort is constructed from String values only"),
+        })
+        .collect()
+}
+
 /// A compiled sheet definition: the embedded engine plus the definition's
 /// path template (and optional raw-JS sort comparator), **compiled once** at
 /// construction and reused across every method call. Holds a `!Send` boa

--- a/rust/gitsheets-napi/test/collator-parity.mjs
+++ b/rust/gitsheets-napi/test/collator-parity.mjs
@@ -1,0 +1,88 @@
+// Locale-collation parity: the declarative `sort = true` path is evaluated by a
+// NATIVE ICU collator in the Rust core (gitsheets_core::collator), NOT the boa
+// engine. boa is built without `Intl`, so its `localeCompare` falls back to
+// code-unit comparison and diverges from V8 / node:vm on non-ASCII / mixed-case
+// input (e.g. ["B","a"]: node sorts to ["a","B"], boa leaves ["B","a"]). This is
+// THE gate that the native collator matches V8's `localeCompare` byte-exactly.
+//
+// `collatorSort` is the exact function `Sheet::normalize_record` applies for a
+// `sort = true` field, so asserting it against node's `localeCompare` proves the
+// wired normalization path is both native and parity-exact.
+//
+// Requires the addon built first (`npm run build:debug`). Run: `npm test`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { collatorSort } = require('../binding.cjs');
+
+// The exact options the JS oracle (`buildSorter` in sheet.ts) passes, and the
+// locale-default (`undefined` → en-US in Node). This is the reference order the
+// native collator must reproduce byte-for-byte.
+const OPTS = { sensitivity: 'base', ignorePunctuation: true, numeric: true };
+function v8Sort(arr) {
+  return [...arr].sort((a, b) => a.localeCompare(b, undefined, OPTS));
+}
+
+// The headline divergence: code-unit order puts 'B' (0x42) before 'a' (0x61);
+// V8 base-folds case so 'a' < 'B'. boa got this wrong; the native collator must
+// not.
+test('boa-divergent cases match V8 localeCompare exactly', () => {
+  assert.deepEqual(collatorSort(['B', 'a']), ['a', 'B']);
+  assert.deepEqual(collatorSort(['é', 'e', 'z']), ['é', 'e', 'z']);
+  assert.deepEqual(collatorSort(['10', '2', '1']), ['1', '2', '10']);
+  assert.deepEqual(collatorSort(['file10', 'file2', 'file1']), ['file1', 'file2', 'file10']);
+  assert.deepEqual(collatorSort(['coop', 'co-op', 'co op']), ['coop', 'co-op', 'co op']);
+  // Each of these also matches node's own localeCompare reference.
+  for (const arr of [
+    ['B', 'a'],
+    ['é', 'e', 'z'],
+    ['10', '2', '1'],
+    ['file10', 'file2', 'file1'],
+  ]) {
+    assert.deepEqual(collatorSort(arr), v8Sort(arr));
+  }
+});
+
+// A curated fixture spanning accents, case, ligatures, fullwidth digits, CJK
+// numerals, Cyrillic/Greek, punctuation, whitespace, numeric strings, and
+// duplicates (to exercise stability).
+const CURATED = [
+  'B', 'a', 'é', 'e', 'z', 'apple', 'Apple', '10', '2', 'ä', 'Z', 'café', 'cafe',
+  'naïve', 'naive', 'Müller', 'Mueller', 'résumé', 'resume', 'co-op', 'coop', 'co op',
+  'file2', 'file10', 'file1', 'File1', 'ñ', 'n', 'Ñ', 'ç', 'ö', 'ø', 'Straße',
+  'strasse', 'ß', '!bang', '#hash', '@at', '_under', '-dash', '100', '99', 'α', 'β',
+  'Привет', 'привет', '1.5', '1.10', '1.2', 'v1.2.10', 'v1.2.2', '', ' ', '.', '...',
+  'a.b', 'ab', 'Hello, World', 'hello world', 'ﬁle', 'file', 'ﬀ', 'ff', '①', 'Ⅻ',
+  '😀a', 'a😀', 'Łódź', 'lodz', 'Æsop', 'aesop', '3', '30', '300', '3a', 'A3', '２',
+  '５', 'tag-a', 'tag_a', 'tag a', 'taga', '北京', '東京', 'tokyo', 'ABC', 'abc', 'aBc',
+  // duplicates for stability
+  'é', 'e', 'Apple', 'apple', 'B', 'b', '2', '10',
+];
+
+test('curated fixture matches V8 localeCompare exactly', () => {
+  assert.deepEqual(collatorSort(CURATED), v8Sort(CURATED));
+});
+
+// Randomized breadth: deterministic LCG over a Unicode pool, several arrays.
+test('randomized fixtures match V8 localeCompare exactly', () => {
+  let rng = 0x2bad4c0d;
+  const rand = () => ((rng = (Math.imul(rng, 1103515245) + 12345) & 0x7fffffff) / 0x7fffffff);
+  const pool = [...'abcAB0129 .-_éèäöüçñßﬁα北😀ZzＡ５①'];
+  let total = 0;
+  for (let t = 0; t < 50; t++) {
+    const arr = [];
+    const n = 2 + Math.floor(rand() * 30);
+    for (let i = 0; i < n; i++) {
+      let len = 1 + Math.floor(rand() * 6);
+      let s = '';
+      for (let j = 0; j < len; j++) s += pool[Math.floor(rand() * pool.length)];
+      arr.push(s);
+    }
+    assert.deepEqual(collatorSort(arr), v8Sort(arr), `randomized array #${t}: ${JSON.stringify(arr)}`);
+    total += arr.length;
+  }
+  console.log(`  randomized parity: 50 arrays, ${total} strings, exact match`);
+});

--- a/rust/gitsheets-napi/test/engine-parity.mjs
+++ b/rust/gitsheets-napi/test/engine-parity.mjs
@@ -7,8 +7,9 @@
 //   2. CompiledDefinition: compile-once-on-open / reuse-across-operations — the
 //      snippet count stays constant across many renderPath/compare calls.
 //   3. An Intl/locale PROBE (localeCompare) — characterizes boa's documented
-//      divergence boundary; reported, not asserted (gitsheets' declarative
-//      locale sort is native in the binding, not an embedded snippet).
+//      divergence boundary; reported, not asserted. gitsheets' declarative
+//      `sort = true` locale sort is native (the ICU collator in the core, NOT an
+//      embedded snippet) — its parity gate is `test/collator-parity.mjs`.
 //
 // Requires the addon built first (`npm run build:debug`). Run: `npm test`.
 
@@ -89,9 +90,10 @@ test('separate definitions hold independent persistent engines', () => {
 
 // PROBE (reported, not asserted): localeCompare is Intl-adjacent — exactly the
 // boa-vs-node:vm divergence boundary the spec flags. gitsheets' locale-aware
-// sort is the declarative `sort = true` path, evaluated NATIVELY in the binding,
-// not an embedded snippet — so a divergence here is not a gate failure. We
-// surface it so the boundary is documented honestly.
+// sort is the declarative `sort = true` path, evaluated NATIVELY by the core's
+// ICU collator (see test/collator-parity.mjs), not an embedded snippet — so a
+// divergence here is not a gate failure. We surface it so the boundary is
+// documented honestly (and motivates why locale sort does not use the engine).
 test('PROBE: localeCompare boundary (Intl) — reported, not gating', () => {
   const rule = 'return String(a).localeCompare(String(b));';
   const vm = vmComparator(rule);


### PR DESCRIPTION
Implements [`plans/locale-collation-core.md`](plans/locale-collation-core.md) (issue #127).

## What

Move declarative locale-sensitive array sorting (`sort = true`) **off the embedded boa engine and onto a native Rust ICU collator** that matches V8's `localeCompare`. boa is built without `Intl`, so its `localeCompare` falls back to code-unit comparison and diverges from V8 / `node:vm` on non-ASCII / mixed-case input — e.g. `["B","a"]`: V8 sorts to `["a","B"]`, boa leaves `["B","a"]`. This also realigns the implementation with `specs/rust-core.md` "Embedded code execution" point 1: declarative `sort = true` is native, not engine-routed; the engine stays for *arbitrary* raw-JS comparators only.

## Collator + V8-matching config

- **Crate:** `icu_collator` (ICU4X — the same ICU/CLDR lineage V8 uses), pinned **`=2.0.0`** (held to 2.0.x because `boa_engine` 0.21.1 pins `icu_normalizer ~2.0`). `compiled_data` bakes the CLDR collation data into the binary. The pin is a canonical-behavior-contract input (it defines the canonical bytes of sorted arrays).
- **Config** matching `localeCompare(b, undefined, { sensitivity: 'base', ignorePunctuation: true, numeric: true })`:
  - `sensitivity: 'base'` → `Strength::Primary`
  - `ignorePunctuation: true` → `AlternateHandling::Shifted`
  - `numeric: true` → `CollationNumericOrdering::True`
  - locale `undefined` (en-US) → root collation (CLDR `en` has no tailoring over root → byte-identical, and deterministic across hosts).

## Parity result (the cases boa diverged on)

Verified **byte-exact against node's `localeCompare`**:
- All-pairs sign comparison: **20,449 pairs over 143 strings** (accents, case, ligatures, fullwidth/CJK digits, Cyrillic, Greek, punctuation, emoji, numeric) — **zero divergence**.
- The headline boa divergence `["B","a"]` → `["a","B"]` now matches (boa gave `["B","a"]`).
- Shipped gate `test/collator-parity.mjs` (runs on node 20 + 22): boa-divergent cases + curated fixture + 50 randomized arrays, all exact.

## No locale sort routes through boa

`sort = true` no longer compiles a `localeCompare` snippet into boa (`comparator_source` returns `None` for it; `Sheet` dispatches it to `SortKind::Locale` → the native collator). Raw-JS and relational `{field:dir}` comparators stay in boa (they use JS `<`/`>`, which is code-unit and deterministic across boa and V8).

## Validation (all run, all green)

- `cargo build --workspace --all-targets`, `cargo test -p gitsheets-core` (143 pass), `cargo clippy --workspace --all-targets -- -D warnings` clean.
- napi addon builds; `npm test` boundary suite (92 tests incl. the 3 new collator-parity tests) passes.
- Root `npm test` (287 + 66) and `npm run type-check` pass; the main JS build never imports the `.node` addon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd