### PR TITLE
feat(core): native dprint markdown body normalization

### DIFF
--- a/plans/markdown-normalize-core.md
+++ b/plans/markdown-normalize-core.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: [markdown-codec-core]
 specs:
   - specs/behaviors/content-types.md
   - specs/rust-core.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/214
 ---
 
 # Plan: native markdown body normalization (dprint) in the core
@@ -68,17 +69,24 @@ re-baselines the JS vitest markdown expectations (that's
 
 ## Validation
 
-- [ ] `content-types.md` describes native body normalization + the new config
-      surface; it's a standalone reviewable commit.
-- [ ] Body normalization is **deterministic + idempotent** (`normalize(normalize(b))
-      == normalize(b)`); a markdown record round-trips byte-stably.
-- [ ] `normalize = false` (or the chosen toggle) keeps the body verbatim.
-- [ ] The `markdownlint` npm dependency and the host-side resolution plumbing are
-      gone; the core owns normalization.
-- [ ] `cargo build/test` + clippy clean; napi boundary suite passes (markdown
-      fixtures re-baselined); the main JS suite stays green and independent (the
-      JS package still uses its own markdown path until the cutover — don't break
-      it here).
+- [x] `content-types.md` describes native body normalization + the new config
+      surface; it's a standalone reviewable commit (`docs(specs): rebaseline
+      content-types normalization to native dprint`).
+- [x] Body normalization is **deterministic + idempotent** (`normalize(normalize(b))
+      == normalize(b)`); a markdown record round-trips byte-stably. Demonstrated in
+      `codec::tests::normalize_body_is_deterministic_and_idempotent` +
+      `serialize_normalizes_the_body_on_write`, and the napi `normalizeBody is
+      deterministic and idempotent` test.
+- [x] `normalize = false` keeps the body verbatim
+      (`codec::tests::normalize_false_frames_the_body_verbatim`, napi
+      `normalize:false frames the body verbatim`).
+- [x] The `markdownlint` host-side resolution plumbing is gone; the core owns
+      normalization (grep of `rust/` for `Markdownlint`/`resolveLint` is clean; the
+      only residual `markdownlint` mentions are doc comments noting its removal).
+      The `markdownlint` npm dep stays in `packages/gitsheets` until the Node
+      cutover (`node-binding-thin`), as scoped.
+- [x] `cargo build/test` + clippy clean; napi boundary suite passes (markdown
+      fixtures re-baselined); the main JS suite stays green and independent.
 
 ## Risks / unknowns
 
@@ -93,8 +101,56 @@ re-baselines the JS vitest markdown expectations (that's
 
 ## Notes
 
-(Populated at closeout.)
+- **dprint vs comrak: dprint won.** `dprint-plugin-markdown` embeds directly as a
+  normal Rust crate — `dprint_plugin_markdown::format_text(text, &Configuration,
+  format_code_block_cb) -> Result<Option<String>>` — no WASM/CLI plugin harness,
+  no `comrak` fallback needed. Confirmed with a throwaway crate before wiring: it
+  formatted messy input to clean, idempotent output. Pinned **`=0.22.1`** (latest;
+  ~11 transitive crates, incl. `pulldown-cmark`).
+- **Exact config** (`codec::MARKDOWN_CONFIG`, all set explicitly so emitted bytes
+  are nailed down by our file, not a transitive default):
+  `textWrap=never`, `emphasisKind=underscores`, `strongKind=asterisks`,
+  `unorderedListKind=dashes`, `headingKind=atx`, `listIndentKind=commonMark`.
+  `textWrap=never` unwraps each paragraph to one logical line, so `lineWidth` is
+  inert for prose (left at the crate default).
+- **Idempotence demo.** `"#  Hello\n\n\n\nsome   text that\nis soft-wrapped\n\n*
+  one\n*  two\n"` → `"# Hello\n\nsome text that is soft-wrapped\n\n- one\n- two\n"`,
+  and normalizing that again yields the same bytes. Asserted in both the Rust unit
+  tests and the napi boundary suite; also proven end-to-end (`willChange` no-op on
+  a round-tripped record).
+- **Ordering.** Normalization runs **before** title-from-H1 extraction, so a
+  setext H1 (`Title\n====`) is converted to ATX and *then* recognized — a
+  setext-authored title is extracted rather than lost.
+- **Removed plumbing.** `config::Markdownlint` enum + `resolve` (the host-pre-pass
+  ruleset), the napi `markdown_resolve_lint_config` / `markdownResolveLintConfig`
+  entry, and the `markdownlint` re-export. Replaced `FormatConfig.markdownlint`
+  with `FormatConfig.normalize: bool`. Added `codec::normalize_body` (+ napi
+  `markdownNormalizeBody`) and a `normalize?` param on `markdownSerialize`.
+- **Re-baselined fixtures.** `rust/gitsheets-core/src/codec.rs` tests (new:
+  `normalize_body_is_deterministic_and_idempotent`,
+  `normalize_body_rewrites_emphasis_and_setext_headings`,
+  `serialize_normalizes_the_body_on_write`,
+  `normalize_false_frames_the_body_verbatim`,
+  `normalization_feeds_title_from_setext_h1`; helpers switched to `normalize:
+  bool`) and `rust/gitsheets-napi/test/sheet-markdown.mjs` (the 3
+  `resolveLintConfig` tests replaced by 5 native-normalization tests). The
+  *existing* clean-input fixtures were already idempotent under dprint, so only
+  those explicit new cases and the config-surface tests
+  (`rust/gitsheets-core/src/config.rs`: `normalize_*`) changed — no golden-byte
+  fixture files (`.md`/`.toml`) needed regenerating.
+- **Validation results.** `cargo test -p gitsheets-core` = 148 pass; `cargo clippy
+  --workspace --all-targets -- -D warnings` clean; `cargo build --workspace
+  --all-targets` clean; napi `npm test` = 94 pass (30 markdown); root
+  `npm run type-check` clean and `npm test` green (33 files/287 + 8 files/66) —
+  the gitsheets-axi tests require `npm run build` first (unbuilt `dist/` in a fresh
+  worktree; unrelated to this change).
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **Node cutover (`node-binding-thin`).** Delete `packages/gitsheets/src/format/
+  markdown.ts`'s markdownlint pipeline, remove the `markdownlint` npm dependency,
+  and re-baseline the JS vitest markdown expectations to the native formatter —
+  out of scope here (this plan changed only the core + its fixtures).
+- **Config re-emit.** `dprint-plugin-markdown` also supports a `deno()` preset and
+  a code-block formatter callback; gitsheets leaves embedded code blocks verbatim.
+  Revisit if consumers want fenced-code normalization.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +217,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -269,6 +275,9 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecount"
@@ -293,7 +302,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -421,7 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -464,7 +473,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -500,7 +509,47 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dprint-core"
+version = "0.67.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1d827947704a9495f705d6aeed270fa21a67f825f22902c28f38dc3af7a9ae"
+dependencies = [
+ "anyhow",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "rustc-hash",
+ "serde",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "dprint-core-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1675ad2b358481f3cc46202040d64ac7a36c4ade414a696df32e0e45421a6e9f"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "dprint-plugin-markdown"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a049a298ecf0d4579d1cc8875bd5c5861633006e0106c99a7c366b12c331b3d0"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "dprint-core-macros",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -526,7 +575,7 @@ checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -570,7 +619,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -670,6 +719,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -781,6 +836,7 @@ name = "gitsheets-core"
 version = "0.0.0"
 dependencies = [
  "boa_engine",
+ "dprint-plugin-markdown",
  "gix",
  "holo-tree",
  "icu_collator",
@@ -1766,13 +1822,24 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1781,7 +1848,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2008,6 +2075,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2068,7 +2137,7 @@ checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2190,7 +2259,7 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2253,7 +2322,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2268,7 +2337,7 @@ dependencies = [
  "quote",
  "regex",
  "semver 1.0.28",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2391,7 +2460,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2486,7 +2555,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2515,7 +2584,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2593,7 +2662,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2614,6 +2683,17 @@ dependencies = [
  "bytesize",
  "human_format",
  "parking_lot",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+dependencies = [
+ "bitflags 2.13.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -2659,7 +2739,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2671,7 +2751,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2744,7 +2824,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2906,7 +2986,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3025,6 +3105,17 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
@@ -3042,7 +3133,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3099,7 +3190,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3247,6 +3338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3375,18 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf16_iter"
@@ -3364,7 +3473,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -3429,7 +3538,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3440,7 +3549,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3537,7 +3646,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3558,7 +3667,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3578,7 +3687,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3614,7 +3723,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -52,9 +52,21 @@ gix = "0.83"
 # byte-equivalent leftmost-first, multiline `^`/`$`, greedy `\s*` semantics, so
 # the delimiter/H1 parse parity is exact rather than a hand-rolled approximation
 # (the one class of parity bug a manual line scan would risk on trailing
-# whitespace / CRLF). The body-NORMALIZATION pass (markdownlint) is NOT done
-# here — see the codec module docs and plans/markdown-codec-core.md.
+# whitespace / CRLF).
 regex = "1"
+# ── markdown-normalize-core (native body normalization) ───────────────────────
+# The native markdown body formatter. Markdown/mdx bodies are normalized on write
+# directly in the core (NOT via a host-side `markdownlint` pre-pass), so body
+# bytes are byte-identical across every binding (Node, Python, …). Used as a
+# direct Rust library — `dprint_plugin_markdown::format_text(text, &config, …)` —
+# NOT as a WASM/CLI dprint plugin. Configured aggressive with `textWrap: never`
+# (unwrap paragraphs to one logical line; preserve hard breaks + block
+# boundaries; align tables; consistent list/emphasis/heading style; collapse
+# blank lines). The emitted bytes depend on the formatter + its config, so this
+# is part of the canonical-behavior contract and is PINNED EXACTLY (`=`) like the
+# serializer, engine, and collator. See src/codec.rs (`normalize_body`) and
+# specs/behaviors/content-types.md.
+dprint-plugin-markdown = "=0.22.1"
 # ── locale-collation-core (native ICU collation for declarative `sort = true`) ─
 # The ICU4X collator. Declarative `sort = true` (locale-sensitive string-array
 # sorting) is NATIVE — it does NOT route through the boa engine, because boa is

--- a/rust/gitsheets-core/src/codec.rs
+++ b/rust/gitsheets-core/src/codec.rs
@@ -14,32 +14,36 @@
 //! form). There is no second TOML serializer: a markdown record's frontmatter
 //! and a TOML record with the same fields produce identical bytes.
 //!
-//! ## markdownlint normalization is NOT done here — and that is deliberate
+//! ## Body normalization is native — in the core
 //!
-//! The JS oracle normalizes the body with the `markdownlint` npm package
-//! (`lint` + `applyFixes`) on write. **That pass is intentionally not
-//! reimplemented in the core.** `markdownlint` is ~40 rules with bespoke,
-//! interdependent fix logic; no Rust port is byte-identical to it, so a partial
-//! reimplementation would *silently* emit different body bytes for any body that
-//! triggers a rule the port handled differently or not at all — exactly the
-//! failure mode the plan forbids. Instead:
+//! Markdown/mdx bodies are normalized on **write** by the native
+//! [`dprint-plugin-markdown`](https://crates.io/crates/dprint-plugin-markdown)
+//! formatter, embedded directly here as a Rust library (see [`normalize_body`]).
+//! Because the formatter lives in the bytes-authority core, a given body
+//! serializes to **identical bytes across every binding** (Node, Python, …) —
+//! there is no host-side `markdownlint` pre-pass that could let two languages
+//! normalize differently. (The former host-side markdownlint plumbing was
+//! removed by `plans/markdown-normalize-core.md`; this re-baselines body bytes
+//! one time — markdown data is negligible by design.)
 //!
-//! - The core codec frames the body **verbatim** (byte-deterministic,
-//!   language-agnostic: delimiters, frontmatter, trailing-newline, title-from-H1).
-//! - The markdownlint *configuration* is fully parsed and the effective ruleset
-//!   computed by the core ([`crate::config::Markdownlint::resolve`]) so nothing
-//!   is dropped.
-//! - The *application* of markdownlint to the body is a **host-side pre-pass**
-//!   (the binding runs the `markdownlint` package — which already lives in the
-//!   Node ecosystem — before handing the record to the codec), the same way the
-//!   consumer Standard-Schema validator runs host-side. The core never calls
-//!   back into the host (re-entrancy hazard).
+//! The formatter runs **aggressive with `textWrap: never`**: each paragraph is
+//! unwrapped to a single logical line (soft breaks removed; hard breaks + block
+//! boundaries preserved), tables are column-aligned, and list / emphasis /
+//! heading / code-fence styles are made consistent. The exact config is captured
+//! in [`normalize_body`] and pinned (`dprint-plugin-markdown =0.22.1` in
+//! `Cargo.toml`) as a canonical-behavior contract input.
 //!
-//! Net: the codec is byte-identical to `markdown.ts` **with `markdownlint =
-//! false`**; with linting on, the binding's pre-pass supplies the normalized
-//! body and the framing still matches byte-for-byte. See
-//! `plans/markdown-codec-core.md` for the full parity write-up.
+//! Normalization is **deterministic + idempotent** (`normalize(normalize(b)) ==
+//! normalize(b)`) and runs **before** title-from-H1 extraction, so the extracted
+//! title agrees with the body that lands on disk. `normalize = false` in
+//! `[gitsheet.format]` frames the body verbatim (only structural framing —
+//! delimiters, frontmatter, trailing-newline — applies).
 
+use dprint_plugin_markdown::configuration::{
+    Configuration, ConfigurationBuilder, EmphasisKind, HeadingKind, ListIndentKind, StrongKind,
+    TextWrap, UnorderedListKind,
+};
+use dprint_plugin_markdown::format_text;
 use indexmap::IndexMap;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -63,15 +67,62 @@ static DELIMITER_LINE_RE: LazyLock<Regex> =
 static H1_LINE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^# ([^\r\n]+?)[ \t]*$").expect("static H1 regex"));
 
+// ── native body normalization (dprint-plugin-markdown) ───────────────────────
+
+/// The canonical `dprint-plugin-markdown` configuration — a canonical-behavior
+/// contract input, pinned alongside the `=0.22.1` version in `Cargo.toml`.
+///
+/// `textWrap: never` unwraps each paragraph to a single logical line (line width
+/// is therefore inert for prose). The style fields are set explicitly (rather
+/// than relying on the crate's defaults) so the emitted bytes are nailed down by
+/// this file, not by a transitive default:
+///
+/// - `emphasisKind: underscores` → `_italic_`
+/// - `strongKind: asterisks` → `**bold**`
+/// - `unorderedListKind: dashes` → `- item`
+/// - `headingKind: atx` → `# Heading` (setext is converted to ATX)
+/// - `listIndentKind: commonMark`
+static MARKDOWN_CONFIG: LazyLock<Configuration> = LazyLock::new(|| {
+    ConfigurationBuilder::new()
+        .text_wrap(TextWrap::Never)
+        .emphasis_kind(EmphasisKind::Underscores)
+        .strong_kind(StrongKind::Asterisks)
+        .unordered_list_kind(UnorderedListKind::Dashes)
+        .heading_kind(HeadingKind::Atx)
+        .list_indent_kind(ListIndentKind::CommonMark)
+        .build()
+});
+
+/// Normalize a markdown body with the native `dprint-plugin-markdown` formatter
+/// using the pinned [`MARKDOWN_CONFIG`]. Deterministic and idempotent. The
+/// formatter always emits a trailing newline; the codec's framing strips/owns
+/// the file's trailing newline, so callers treat the result as the canonical
+/// body text.
+///
+/// Code blocks are left as-is (the inner-format callback returns the code
+/// unchanged) — gitsheets does not recursively format embedded languages.
+///
+/// `format_text` only fails on a parser-level error; markdown has no such hard
+/// errors in practice (any text is valid CommonMark), so on the off chance of an
+/// error we fall back to the input unchanged rather than losing the body.
+pub fn normalize_body(body: &str) -> String {
+    match format_text(body, &MARKDOWN_CONFIG, |_tag, code, _line| Ok(Some(code.to_string()))) {
+        Ok(Some(out)) => out,
+        // `Ok(None)` means "already formatted / no change".
+        Ok(None) => body.to_string(),
+        Err(_) => body.to_string(),
+    }
+}
+
 // ── format dispatch ──────────────────────────────────────────────────────────
 
 /// Serialize a record to its on-disk text for the sheet's format.
 ///
 /// - `toml` → canonical TOML bytes ([`canonical::serialize`]).
 /// - `markdown`/`mdx` → `+++\n<frontmatter>+++\n\n<body>\n` (see
-///   [`serialize_markdown`]). The body is **not** markdownlint-normalized here
-///   (see the module docs); callers that want normalization apply it before
-///   calling.
+///   [`serialize_markdown`]). The body is normalized natively by
+///   [`normalize_body`] unless `format.normalize` is `false` (see the module
+///   docs).
 pub fn serialize(record: &Value, format: &FormatConfig) -> Result<String> {
     match format.kind {
         FormatKind::Toml => canonical::serialize(record),
@@ -117,7 +168,7 @@ fn serialize_markdown(record: &Value, format: &FormatConfig) -> Result<String> {
 
     // The body field → body text. An absent body is the empty string (matches
     // the JS `?? ''`); a present non-string body is a type error.
-    let body = match table.get(body_field) {
+    let raw_body = match table.get(body_field) {
         None => String::new(),
         Some(Value::String(s)) => s.clone(),
         Some(other) => {
@@ -129,6 +180,15 @@ fn serialize_markdown(record: &Value, format: &FormatConfig) -> Result<String> {
                 issues: Vec::new(),
             })
         }
+    };
+
+    // Native body normalization runs FIRST, so title-from-H1 extraction (below)
+    // sees the bytes that land on disk — e.g. a setext H1 becomes ATX and is then
+    // recognized. `normalize = false` frames the body verbatim.
+    let body = if format.normalize {
+        normalize_body(&raw_body)
+    } else {
+        raw_body
     };
 
     // Frontmatter = every field except the body field.
@@ -281,14 +341,23 @@ pub fn rewrite_leading_h1(body: &str, new_title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Markdownlint;
 
     fn md(body_field: &str, title: Option<&str>) -> FormatConfig {
         FormatConfig {
             kind: FormatKind::Markdown,
             body: Some(body_field.to_string()),
             title: title.map(|s| s.to_string()),
-            markdownlint: Markdownlint::Default,
+            normalize: true,
+        }
+    }
+
+    /// A markdown format with body normalization disabled (verbatim framing).
+    fn md_verbatim(body_field: &str, title: Option<&str>) -> FormatConfig {
+        FormatConfig {
+            kind: FormatKind::Markdown,
+            body: Some(body_field.to_string()),
+            title: title.map(|s| s.to_string()),
+            normalize: false,
         }
     }
 
@@ -506,6 +575,71 @@ mod tests {
         assert_eq!(field(&parsed, "body"), Some(&s("# Hello, world\n\nA short post.")));
     }
 
+    // ── native body normalization ────────────────────────────────────────────
+
+    #[test]
+    fn normalize_body_is_deterministic_and_idempotent() {
+        let messy = "#  Hello\n\n\n\nsome   text that\nis soft-wrapped\n\n*  one\n*  two\n";
+        let once = normalize_body(messy);
+        let twice = normalize_body(&once);
+        assert_eq!(once, twice, "normalize(normalize(b)) == normalize(b)");
+        // The aggressive `textWrap: never` config unwraps the paragraph, collapses
+        // blank lines, and normalizes the list marker + heading.
+        assert_eq!(
+            once,
+            "# Hello\n\nsome text that is soft-wrapped\n\n- one\n- two\n"
+        );
+    }
+
+    #[test]
+    fn normalize_body_rewrites_emphasis_and_setext_headings() {
+        assert_eq!(
+            normalize_body("this is *italic* and __bold__\n"),
+            "this is _italic_ and **bold**\n"
+        );
+        // Setext H1 → ATX (feeds title-from-H1).
+        assert_eq!(normalize_body("Title\n=====\n\nbody\n"), "# Title\n\nbody\n");
+    }
+
+    #[test]
+    fn serialize_normalizes_the_body_on_write() {
+        let text = serialize(
+            &rec(&[("slug", s("x")), ("body", s("hello *there*\n\n\n*  a\n*  b\n"))]),
+            &md("body", None),
+        )
+        .unwrap();
+        assert!(text.ends_with("+++\n\nhello _there_\n\n- a\n- b\n"));
+        // Re-serializing the parsed record is a byte-stable no-op.
+        let parsed = parse(&text, &md("body", None)).unwrap();
+        assert_eq!(serialize(&parsed, &md("body", None)).unwrap(), text);
+    }
+
+    #[test]
+    fn normalize_false_frames_the_body_verbatim() {
+        let body = "hello *there*\n\n\n*  a\n*  b";
+        let text = serialize(
+            &rec(&[("slug", s("x")), ("body", s(body))]),
+            &md_verbatim("body", None),
+        )
+        .unwrap();
+        // The body bytes are untouched (only the file's trailing newline added).
+        assert!(text.ends_with(&format!("+++\n\n{body}\n")));
+        let parsed = parse(&text, &md_verbatim("body", None)).unwrap();
+        assert_eq!(field(&parsed, "body"), Some(&s(body)));
+    }
+
+    #[test]
+    fn normalization_feeds_title_from_setext_h1() {
+        // Setext H1 in the raw body → normalized to ATX → extracted as the title.
+        let text = serialize(
+            &rec(&[("slug", s("x")), ("body", s("Hello, world\n============\n\nBody."))]),
+            &md("body", Some("title")),
+        )
+        .unwrap();
+        assert!(text.contains("title = \"Hello, world\""));
+        assert!(text.contains("+++\n\n# Hello, world\n\nBody.\n"));
+    }
+
     // ── toml passthrough ─────────────────────────────────────────────────────
 
     #[test]
@@ -514,7 +648,7 @@ mod tests {
             kind: FormatKind::Toml,
             body: None,
             title: None,
-            markdownlint: Markdownlint::Default,
+            normalize: true,
         };
         let r = rec(&[("slug", s("jane")), ("email", s("jane@x.org"))]);
         let text = serialize(&r, &fmt).unwrap();

--- a/rust/gitsheets-core/src/config.rs
+++ b/rust/gitsheets-core/src/config.rs
@@ -75,51 +75,6 @@ impl FormatKind {
     }
 }
 
-/// The markdownlint configuration from `[gitsheet.format].markdownlint`.
-///
-/// Carried so the codec config round-trips and **nothing is dropped**, but the
-/// core does NOT apply markdownlint to the body — see the [`crate::codec`]
-/// module docs: the lint+fix pass is a host-side pre-pass (the binding runs the
-/// `markdownlint` package), and the core only computes the effective ruleset via
-/// [`Markdownlint::resolve`].
-#[derive(Clone, Debug, PartialEq)]
-pub enum Markdownlint {
-    /// No `markdownlint` key — apply the defaults only.
-    Default,
-    /// `markdownlint = false` — normalization disabled.
-    Disabled,
-    /// `[gitsheet.format.markdownlint]` — a table of user rule overrides,
-    /// layered on top of the defaults by [`Markdownlint::resolve`].
-    Rules(IndexMap<String, Value>),
-}
-
-impl Markdownlint {
-    /// The effective markdownlint config the host's pre-pass should apply, or
-    /// `None` when normalization is disabled. Mirrors the JS `normalizeBody`
-    /// merge: `{ default: true, MD013: false, MD041: false, ...user }`, and when
-    /// title-from-H1 is enabled (`title_is_set`) and the user didn't pin
-    /// `MD041`, it auto-enables `MD041` (first-line-H1).
-    pub fn resolve(&self, title_is_set: bool) -> Option<Value> {
-        let empty = IndexMap::new();
-        let user = match self {
-            Markdownlint::Disabled => return None,
-            Markdownlint::Default => &empty,
-            Markdownlint::Rules(t) => t,
-        };
-        let mut out: IndexMap<String, Value> = IndexMap::new();
-        out.insert("default".to_string(), Value::Boolean(true));
-        out.insert("MD013".to_string(), Value::Boolean(false));
-        out.insert("MD041".to_string(), Value::Boolean(false));
-        for (k, v) in user {
-            out.insert(k.clone(), v.clone());
-        }
-        if title_is_set && !user.contains_key("MD041") {
-            out.insert("MD041".to_string(), Value::Boolean(true));
-        }
-        Some(Value::Table(out))
-    }
-}
-
 /// Resolved `[gitsheet.format]` config. Defaults to `type = "toml"`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FormatConfig {
@@ -128,9 +83,11 @@ pub struct FormatConfig {
     pub body: Option<String>,
     /// The field denormalized from the body's first H1 (markdown/mdx only).
     pub title: Option<String>,
-    /// The markdownlint configuration (carried, not applied by the core — see
-    /// [`Markdownlint`]).
-    pub markdownlint: Markdownlint,
+    /// Whether to normalize the body on write with the native
+    /// `dprint-plugin-markdown` formatter (markdown/mdx only). Defaults to
+    /// `true`; `normalize = false` frames the body verbatim. See
+    /// [`crate::codec::normalize_body`].
+    pub normalize: bool,
 }
 
 impl FormatConfig {
@@ -274,7 +231,7 @@ fn parse_format(raw: Option<&Value>, source: &str) -> Result<FormatConfig> {
             kind: FormatKind::Toml,
             body: None,
             title: None,
-            markdownlint: Markdownlint::Default,
+            normalize: true,
         });
     };
     let table = as_table(raw).ok_or_else(|| Error::ConfigInvalid {
@@ -288,18 +245,23 @@ fn parse_format(raw: Option<&Value>, source: &str) -> Result<FormatConfig> {
     };
     let body = table.get("body").and_then(as_str).map(|s| s.to_string());
     let title = table.get("title").and_then(as_str).map(|s| s.to_string());
-    // markdownlint: `false` disables; a table is user rules; anything else (or
-    // absent) falls back to the defaults. Matches the JS `resolveFormatConfig`.
-    let markdownlint = match table.get("markdownlint") {
-        Some(Value::Boolean(false)) => Markdownlint::Disabled,
-        Some(Value::Table(t)) => Markdownlint::Rules(t.clone()),
-        _ => Markdownlint::Default,
+    // normalize: defaults to `true` (native dprint body normalization on write);
+    // `normalize = false` frames the body verbatim. A non-boolean value is a
+    // config error.
+    let normalize = match table.get("normalize") {
+        None => true,
+        Some(Value::Boolean(b)) => *b,
+        Some(_) => {
+            return Err(Error::ConfigInvalid {
+                message: format!("{source}: [gitsheet.format].normalize must be a boolean"),
+            })
+        }
     };
     Ok(FormatConfig {
         kind,
         body,
         title,
-        markdownlint,
+        normalize,
     })
 }
 
@@ -437,43 +399,28 @@ mod tests {
     }
 
     #[test]
-    fn markdownlint_defaults_when_absent() {
+    fn normalize_defaults_to_true_when_absent() {
         let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\n").unwrap();
-        assert_eq!(c.format.markdownlint, Markdownlint::Default);
-        let resolved = c.format.markdownlint.resolve(false).unwrap();
-        let Value::Table(t) = resolved else { panic!() };
-        assert_eq!(t["default"], Value::Boolean(true));
-        assert_eq!(t["MD013"], Value::Boolean(false));
-        assert_eq!(t["MD041"], Value::Boolean(false));
+        assert!(c.format.normalize);
     }
 
     #[test]
-    fn markdownlint_false_disables() {
-        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\nmarkdownlint = false\n").unwrap();
-        assert_eq!(c.format.markdownlint, Markdownlint::Disabled);
-        assert!(c.format.markdownlint.resolve(false).is_none());
+    fn normalize_false_disables() {
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\nnormalize = false\n").unwrap();
+        assert!(!c.format.normalize);
     }
 
     #[test]
-    fn markdownlint_user_rules_layer_over_defaults() {
-        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\n[gitsheet.format.markdownlint]\nMD013 = true\nMD033 = false\n").unwrap();
-        let resolved = c.format.markdownlint.resolve(false).unwrap();
-        let Value::Table(t) = resolved else { panic!() };
-        assert_eq!(t["MD013"], Value::Boolean(true), "user override wins");
-        assert_eq!(t["MD033"], Value::Boolean(false));
-        assert_eq!(t["default"], Value::Boolean(true));
+    fn normalize_non_boolean_is_config_invalid() {
+        let err = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\nnormalize = 'yes'\n").unwrap_err();
+        assert_eq!(err.code(), "config_invalid");
+        assert!(err.message().contains("normalize must be a boolean"));
     }
 
     #[test]
-    fn markdownlint_auto_enables_md041_when_title_set() {
-        // Defaults + title-from-H1 → MD041 auto-enabled.
-        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\ntitle = 'title'\n").unwrap();
-        let Value::Table(t) = c.format.markdownlint.resolve(true).unwrap() else { panic!() };
-        assert_eq!(t["MD041"], Value::Boolean(true));
-
-        // …unless the consumer pinned it.
-        let c2 = cfg("[gitsheet]\npath = '${{ slug }}'\n[gitsheet.format]\ntype = 'markdown'\nbody = 'body'\ntitle = 'title'\n[gitsheet.format.markdownlint]\nMD041 = false\n").unwrap();
-        let Value::Table(t2) = c2.format.markdownlint.resolve(true).unwrap() else { panic!() };
-        assert_eq!(t2["MD041"], Value::Boolean(false), "consumer override respected");
+    fn toml_format_defaults_normalize_true() {
+        // The toml-default branch still produces a stable normalize flag.
+        let c = cfg("[gitsheet]\npath = '${{ slug }}'\n").unwrap();
+        assert!(c.format.normalize);
     }
 }

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -35,10 +35,8 @@ pub mod validation;
 pub mod value;
 
 pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};
-pub use codec::{extract_first_h1, rewrite_leading_h1};
-pub use config::{
-    FieldConfig, FormatConfig, FormatKind, Markdownlint, SheetConfig, SortDir, SortRule,
-};
+pub use codec::{extract_first_h1, normalize_body, rewrite_leading_h1};
+pub use config::{FieldConfig, FormatConfig, FormatKind, SheetConfig, SortDir, SortRule};
 pub use diff::{apply_merge_patch, create_patch, MergePatch, PatchOp, PatchOpKind, PatchValue};
 pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
 pub use index::{MultiIndex, UniqueIndex};

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -149,16 +149,17 @@ module.exports = {
   CoreTransaction: addon.CoreTransaction,
   coreDiscoverSheets: wrap(addon.coreDiscoverSheets),
   coreCheckValidators: wrap(addon.coreCheckValidators),
-  // Markdown / mdx content-type codec (markdown-codec-core). serialize/parse can
-  // raise a typed ValidationError/ConfigError; the H1 + lint-config helpers are
-  // pure. The body markdownlint NORMALIZATION is a host-side pre-pass — the core
-  // frames the body verbatim (see the gitsheets_core::codec module docs).
+  // Markdown / mdx content-type codec. serialize/parse can raise a typed
+  // ValidationError/ConfigError; the H1 + normalize helpers are pure. Body
+  // NORMALIZATION is native — `markdownSerialize` runs the embedded
+  // `dprint-plugin-markdown` formatter (unless `normalize: false` is passed), and
+  // `markdownNormalizeBody` exposes it directly (see gitsheets_core::codec docs).
   markdownSerialize: wrap(addon.markdownSerialize),
   markdownParse: wrap(addon.markdownParse),
   markdownParseHeaderOnly: wrap(addon.markdownParseHeaderOnly),
   markdownExtractH1: addon.markdownExtractH1,
   markdownRewriteH1: addon.markdownRewriteH1,
-  markdownResolveLintConfig: addon.markdownResolveLintConfig,
+  markdownNormalizeBody: addon.markdownNormalizeBody,
   // Boundary-test entry: throws the typed class for a given stable code.
   simulateCoreError: wrap(addon.simulateCoreError),
   // Error machinery.

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -248,11 +248,18 @@ export declare function coreCheckValidators(declared: Array<string>, validatorNa
 /**
  * Serialize a record to its on-disk markdown bytes (`+++` frontmatter + body),
  * enforcing the title-from-H1 invariant when `titleField` is set. The body is
- * framed verbatim — markdownlint normalization is the host's pre-pass. A
- * non-string body or a title that disagrees with the body's H1 throws a typed
+ * normalized natively by the embedded `dprint-plugin-markdown` formatter unless
+ * `normalize` is `false` (then it is framed verbatim). A non-string body or a
+ * title that disagrees with the body's (normalized) H1 throws a typed
  * `ValidationError`.
  */
-export declare function markdownSerialize(record: JsValue, bodyField: string, titleField?: string | undefined | null): string
+export declare function markdownSerialize(record: JsValue, bodyField: string, titleField?: string | undefined | null, normalize?: boolean | undefined | null): string
+/**
+ * Normalize a markdown body with the native `dprint-plugin-markdown` formatter
+ * (the pinned aggressive `textWrap: never` config). Deterministic + idempotent.
+ * Exposed so the boundary suite can assert the normalizer directly.
+ */
+export declare function markdownNormalizeBody(body: string): string
 /**
  * Parse on-disk markdown bytes into a full record (frontmatter fields + the
  * body under `bodyField`). Mirrors `markdownFormat.parse`.
@@ -273,14 +280,6 @@ export declare function markdownExtractH1(body: string): string | null
  * `rewriteLeadingH1` — the `Sheet.patch` title-reconciliation helper.
  */
 export declare function markdownRewriteH1(body: string, title: string): string
-/**
- * The effective markdownlint config the host's normalization pre-pass should
- * apply, or `null` when disabled. The defaults (`default: true`, `MD013:
- * false`, `MD041: false`) layered with any `[gitsheet.format.markdownlint]`
- * overrides, plus the `MD041` auto-enable when title-from-H1 is on. The core
- * computes the ruleset but does NOT apply it (see the codec module docs).
- */
-export declare function markdownResolveLintConfig(markdownlint: JsValue, titleIsSet: boolean): JsValue | null
 /**
  * A compiled sheet definition: the embedded engine plus the definition's
  * path template (and optional raw-JS sort comparator), **compiled once** at

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1, markdownResolveLintConfig } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -339,8 +339,8 @@ module.exports.CoreTransaction = CoreTransaction
 module.exports.coreDiscoverSheets = coreDiscoverSheets
 module.exports.coreCheckValidators = coreCheckValidators
 module.exports.markdownSerialize = markdownSerialize
+module.exports.markdownNormalizeBody = markdownNormalizeBody
 module.exports.markdownParse = markdownParse
 module.exports.markdownParseHeaderOnly = markdownParseHeaderOnly
 module.exports.markdownExtractH1 = markdownExtractH1
 module.exports.markdownRewriteH1 = markdownRewriteH1
-module.exports.markdownResolveLintConfig = markdownResolveLintConfig

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -1464,29 +1464,30 @@ pub fn core_check_validators(
 // ── markdown / mdx content-type codec (markdown-codec-core) ─────────────────────
 //
 // The frontmatter+body codec, exposed directly so the boundary suite can assert
-// byte-level parity with the JS oracle (`packages/gitsheets/src/format/markdown.ts`).
-// markdownlint body-NORMALIZATION is NOT applied here — it is a host-side pre-pass
-// (see gitsheets_core::codec module docs); these surface the byte-deterministic
-// framing, title-from-H1, and lazy-body parts of the format.
+// byte-level parity with the core. Body NORMALIZATION is native (the embedded
+// `dprint-plugin-markdown` formatter — see gitsheets_core::codec module docs), so
+// `markdownSerialize` emits normalized bytes unless `normalize: false` is passed.
 
 use gitsheets_core::codec;
-use gitsheets_core::config::{FormatConfig, FormatKind, Markdownlint};
+use gitsheets_core::config::{FormatConfig, FormatKind};
 
-/// Build a markdown `FormatConfig` for the direct codec entry points. The
-/// markdownlint setting is irrelevant to these (the core never applies it).
-fn markdown_format(body_field: String, title_field: Option<String>) -> FormatConfig {
+/// Build a markdown `FormatConfig` for the direct codec entry points. `normalize`
+/// drives native body normalization (only meaningful on serialize); parse paths
+/// pass `true` but never look at it.
+fn markdown_format(body_field: String, title_field: Option<String>, normalize: bool) -> FormatConfig {
     FormatConfig {
         kind: FormatKind::Markdown,
         body: Some(body_field),
         title: title_field,
-        markdownlint: Markdownlint::Default,
+        normalize,
     }
 }
 
 /// Serialize a record to its on-disk markdown bytes (`+++` frontmatter + body),
 /// enforcing the title-from-H1 invariant when `titleField` is set. The body is
-/// framed verbatim — markdownlint normalization is the host's pre-pass. A
-/// non-string body or a title that disagrees with the body's H1 throws a typed
+/// normalized natively by the embedded `dprint-plugin-markdown` formatter unless
+/// `normalize` is `false` (then it is framed verbatim). A non-string body or a
+/// title that disagrees with the body's (normalized) H1 throws a typed
 /// `ValidationError`.
 #[napi]
 pub fn markdown_serialize(
@@ -1494,9 +1495,18 @@ pub fn markdown_serialize(
     record: JsValue,
     body_field: String,
     title_field: Option<String>,
+    normalize: Option<bool>,
 ) -> Result<String> {
-    let cfg = markdown_format(body_field, title_field);
+    let cfg = markdown_format(body_field, title_field, normalize.unwrap_or(true));
     codec::serialize(&record.0, &cfg).map_err(|err| raise_core_error(&env, &err))
+}
+
+/// Normalize a markdown body with the native `dprint-plugin-markdown` formatter
+/// (the pinned aggressive `textWrap: never` config). Deterministic + idempotent.
+/// Exposed so the boundary suite can assert the normalizer directly.
+#[napi]
+pub fn markdown_normalize_body(body: String) -> String {
+    codec::normalize_body(&body)
 }
 
 /// Parse on-disk markdown bytes into a full record (frontmatter fields + the
@@ -1508,7 +1518,7 @@ pub fn markdown_parse(
     body_field: String,
     title_field: Option<String>,
 ) -> Result<JsValue> {
-    let cfg = markdown_format(body_field, title_field);
+    let cfg = markdown_format(body_field, title_field, true);
     codec::parse(&text, &cfg)
         .map(JsValue)
         .map_err(|err| raise_core_error(&env, &err))
@@ -1522,7 +1532,7 @@ pub fn markdown_parse_header_only(
     text: String,
     body_field: String,
 ) -> Result<JsValue> {
-    let cfg = markdown_format(body_field, None);
+    let cfg = markdown_format(body_field, None, true);
     codec::parse_header_only(&text, &cfg)
         .map(JsValue)
         .map_err(|err| raise_core_error(&env, &err))
@@ -1540,24 +1550,4 @@ pub fn markdown_extract_h1(body: String) -> Option<String> {
 #[napi]
 pub fn markdown_rewrite_h1(body: String, title: String) -> String {
     codec::rewrite_leading_h1(&body, &title)
-}
-
-/// The effective markdownlint config the host's normalization pre-pass should
-/// apply, or `null` when disabled. The defaults (`default: true`, `MD013:
-/// false`, `MD041: false`) layered with any `[gitsheet.format.markdownlint]`
-/// overrides, plus the `MD041` auto-enable when title-from-H1 is on. The core
-/// computes the ruleset but does NOT apply it (see the codec module docs).
-#[napi]
-pub fn markdown_resolve_lint_config(
-    markdownlint: JsValue,
-    title_is_set: bool,
-) -> Option<JsValue> {
-    // Marshal the raw `[gitsheet.format].markdownlint` value: `false` → disabled,
-    // a table → user rules, anything else → defaults.
-    let setting = match &markdownlint.0 {
-        Value::Boolean(false) => Markdownlint::Disabled,
-        Value::Table(t) => Markdownlint::Rules(t.clone()),
-        _ => Markdownlint::Default,
-    };
-    setting.resolve(title_is_set).map(JsValue)
 }

--- a/rust/gitsheets-napi/test/sheet-markdown.mjs
+++ b/rust/gitsheets-napi/test/sheet-markdown.mjs
@@ -6,8 +6,8 @@
 //   - the frontmatter+body codec: round-trip byte-identity, empty/embedded-`+++`
 //     bodies, UTF-8 BOM, TOML datetimes in the frontmatter, lazy (header-only) reads;
 //   - title-from-H1 extraction, the H1 rewrite helper, and the disagreement guard;
-//   - the resolved markdownlint ruleset (computed by the core; APPLIED host-side —
-//     see the codec module docs: the core frames the body verbatim);
+//   - native body normalization (the embedded dprint-plugin-markdown formatter):
+//     deterministic + idempotent, applied on serialize, and the normalize:false toggle;
 //   - end-to-end markdown sheets: `.md` on disk, read-back, withBody:false, and
 //     the allowMissingBody opt-in.
 //
@@ -40,7 +40,7 @@ const {
   markdownParseHeaderOnly,
   markdownExtractH1,
   markdownRewriteH1,
-  markdownResolveLintConfig,
+  markdownNormalizeBody,
 } = binding;
 
 // ── direct codec: serialize / parse byte parity ────────────────────────────────
@@ -197,24 +197,43 @@ test('serialize omits the title when the body has no H1 and none is supplied', (
   assert.ok(!/title\s*=/.test(text));
 });
 
-// ── markdownlint config resolution (computed in the core, APPLIED host-side) ─────
+// ── native body normalization (embedded dprint-plugin-markdown) ──────────────────
 
-test('resolveLintConfig returns the layered defaults', () => {
-  const cfg = markdownResolveLintConfig(true, false); // `true` ⇒ no overrides → defaults
-  assert.equal(cfg.default, true);
-  assert.equal(cfg.MD013, false);
-  assert.equal(cfg.MD041, false);
+test('normalizeBody is deterministic and idempotent', () => {
+  const messy = '#  Hello\n\n\n\nsome   text that\nis soft-wrapped\n\n*  one\n*  two\n';
+  const once = markdownNormalizeBody(messy);
+  assert.equal(once, markdownNormalizeBody(once), 'normalize(normalize(b)) == normalize(b)');
+  // textWrap:never unwraps the paragraph; blank lines collapse; markers normalize.
+  assert.equal(once, '# Hello\n\nsome text that is soft-wrapped\n\n- one\n- two\n');
 });
 
-test('resolveLintConfig returns null when disabled', () => {
-  assert.equal(markdownResolveLintConfig(false, false), null);
+test('normalizeBody rewrites emphasis and converts setext headings to ATX', () => {
+  assert.equal(markdownNormalizeBody('this is *italic* and __bold__\n'), 'this is _italic_ and **bold**\n');
+  assert.equal(markdownNormalizeBody('Title\n=====\n\nbody\n'), '# Title\n\nbody\n');
 });
 
-test('resolveLintConfig layers user rules and auto-enables MD041 with a title', () => {
-  const withRules = markdownResolveLintConfig({ MD013: true }, false);
-  assert.equal(withRules.MD013, true, 'user override wins');
-  const withTitle = markdownResolveLintConfig(true, true);
-  assert.equal(withTitle.MD041, true, 'title-from-H1 auto-enables MD041');
+test('serialize normalizes the body on write', () => {
+  const text = markdownSerialize({ slug: 'x', body: 'hello *there*\n\n\n*  a\n*  b\n' }, 'body');
+  assert.ok(text.endsWith('+++\n\nhello _there_\n\n- a\n- b\n'));
+  // Round-trips byte-stably: re-serializing the parsed record is a no-op.
+  assert.equal(markdownSerialize(markdownParse(text, 'body'), 'body'), text);
+});
+
+test('normalize:false frames the body verbatim', () => {
+  const body = 'hello *there*\n\n\n*  a\n*  b';
+  const text = markdownSerialize({ slug: 'x', body }, 'body', undefined, false);
+  assert.ok(text.endsWith(`+++\n\n${body}\n`), 'body bytes untouched (verbatim)');
+  assert.equal(markdownParse(text, 'body').body, body);
+});
+
+test('normalization feeds title-from-H1 from a setext heading', () => {
+  const text = markdownSerialize(
+    { slug: 'x', body: 'Hello, world\n============\n\nBody.' },
+    'body',
+    'title',
+  );
+  assert.match(text, /title = "Hello, world"/);
+  assert.ok(text.includes('+++\n\n# Hello, world\n\nBody.\n'));
 });
 
 // ── end-to-end markdown sheets through a transaction ────────────────────────────

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -23,7 +23,7 @@ Concrete v1.0 ship list lives across [GitHub issues #128–#141 in the 1.0.0 mil
 | Runtime validator (consumer-supplied) | Any **[Standard Schema](https://standardschema.dev)** implementation | Consumer chooses Zod / Valibot / ArkType / Effect Schema. Gitsheets calls `~standard.validate`. |
 | JSON Merge Patch | **inline** in `packages/gitsheets/src/patch.ts` (~40 lines) | RFC 7396 semantics — see [behaviors/patch-semantics.md](behaviors/patch-semantics.md). No external dependency; the `json-merge-patch` package was removed during the v1.0 substrate purge. |
 | JSON Patch (RFC 6902) | **`rfc6902`** | Generates RFC 6902 ops for `Sheet.diffFrom({ patches: true })` (v1.1). |
-| Markdown normalization | **`markdownlint`** (pinned `^0.40`) | Body normalization on write for content-typed sheets (v1.2). See [behaviors/content-types.md](behaviors/content-types.md). |
+| Markdown normalization | **`dprint-plugin-markdown`** (Rust, pinned `=0.22.1` in `rust/gitsheets-core`) | Native body normalization on write for content-typed sheets — embedded in the bytes-authority core (`textWrap: never`, aggressive), so bodies are byte-identical across every binding. Replaced the host-side `markdownlint` pre-pass. See [behaviors/content-types.md](behaviors/content-types.md). |
 | CSV / TSV I/O | **`csv-parse`** + **`csv-stringify`** | CLI `--format=csv\|tsv` on `upsert` / `query` / `read` (v1.1). |
 | Tests | **Vitest** (v4) | TS-native, ESM-native. Replaces Jest + Cypress. |
 | CLI argument parsing | **`yargs`** | Clean TS types for command modules. |

--- a/specs/behaviors/content-types.md
+++ b/specs/behaviors/content-types.md
@@ -26,24 +26,55 @@ path = '${{ slug }}'
 type = 'markdown'           # default: 'toml'. 'mdx' is an alias (same parser, .mdx extension).
 body = 'body'               # field name that holds the body text; required when type='markdown' or 'mdx'
 title = 'title'             # optional — denormalize body's first H1 into this field (see "Title from H1")
-
-[gitsheet.format.markdownlint]
-# Optional. Passed straight through as markdownlint config.
-# Defaults applied on top of consumer settings:
-#   default = true     (all default rules)
-#   MD013 = false      (line-length 80 disabled — prose / long lines OK)
-#   MD041 = false      (first-line H1 not required — many bodies start with prose)
-# When [gitsheet.format].title is set, MD041 is auto-enabled (consumer can override).
+normalize = true            # optional, default true — native body normalization on write (see below)
 ```
 
-Disable normalization entirely with `markdownlint = false`:
+### Body normalization
+
+Markdown/mdx bodies are normalized on **write** by the native Rust
+`dprint-plugin-markdown` formatter, embedded directly in the bytes-authority
+core. The formatter is the **single** source of body bytes across every binding
+(Node, Python, …) — there is no host-side markdownlint pre-pass, so a given body
+serializes to identical bytes regardless of which language drives the write.
+
+The formatter runs **aggressive with `textWrap = "never"`**: each paragraph is
+unwrapped to a single logical line (soft line breaks removed; hard breaks —
+backslash or two-trailing-spaces — and block boundaries preserved), tables are
+column-aligned, list / emphasis / heading / code-fence styles are made
+consistent, and runs of blank lines collapse. Because `textWrap` is `never`, the
+line width never affects prose bytes.
+
+The exact emitted configuration (a canonical-behavior contract input, pinned in
+`rust/gitsheets-core/Cargo.toml` alongside the serializer / engine / collator):
+
+```text
+dprint-plugin-markdown =0.22.1
+  textWrap         = never        # unwrap paragraphs; line width is inert for prose
+  emphasisKind     = underscores  # _italic_
+  strongKind       = asterisks    # **bold**
+  unorderedListKind = dashes      # - item
+  headingKind      = atx          # # Heading (setext is converted to ATX)
+  listIndentKind   = commonMark
+```
+
+Disable normalization with `normalize = false` — the body is then framed
+**verbatim** (only the codec's structural framing applies: delimiters,
+frontmatter, trailing-newline). Use this when bytes must be preserved exactly:
 
 ```toml
 [gitsheet.format]
 type = 'markdown'
 body = 'body'
-markdownlint = false
+normalize = false
 ```
+
+> **One-time re-baseline.** Switching body normalization from the former
+> host-side `markdownlint --fix` pass to the native `dprint-plugin-markdown`
+> formatter re-baselines on-disk body bytes once (e.g. emphasis `*italic*` →
+> `_italic_`, list markers normalized to `-`, setext headings converted to ATX,
+> soft-wrapped paragraphs unwrapped). Markdown data is negligible by design, so
+> the re-baseline is acceptable; the `markdownlint` dependency and its
+> rule-specific config surface are dropped.
 
 ## On-disk format
 
@@ -57,7 +88,7 @@ title = 'Hello, world'
 
 # Hello, world
 
-This is the body, normalized by markdownlint.
+This is the body, normalized by the native dprint formatter.
 ```
 
 - Frontmatter is canonical TOML (deep-sorted keys via the existing `stringifyRecord` path).
@@ -70,7 +101,7 @@ This is the body, normalized by markdownlint.
 
 1. Split the record: body field (the configured `body` name) → body text; everything else → frontmatter record.
 2. Serialize frontmatter via `stringifyRecord` (deep-sorted keys, the existing canonical TOML path).
-3. Normalize body via `markdownlint --fix` with the configured rule set (skipped if `markdownlint = false`).
+3. Normalize body via the native `dprint-plugin-markdown` formatter (skipped if `normalize = false`). Normalization runs **before** title-from-H1 extraction, so the extracted title agrees with the body that lands on disk.
 4. Join `+++\n<frontmatter>+++\n\n<body>\n`.
 5. Write the blob.
 
@@ -80,7 +111,9 @@ This is the body, normalized by markdownlint.
 2. Parse frontmatter as TOML.
 3. Body verbatim → inject under the configured `body` field name.
 
-**Normalization is body-only.** The TOML frontmatter is never seen by markdownlint — that avoids any risk of lint rules mangling TOML content that happens to look like markdown.
+**Normalization is body-only.** The TOML frontmatter is never seen by the formatter — only the body string is handed to `dprint-plugin-markdown`. That avoids any risk of the formatter mangling TOML content that happens to look like markdown.
+
+**Normalization is deterministic and idempotent.** `normalize(normalize(body)) == normalize(body)`, so a record round-trips byte-stably: re-upserting a record read back from disk is a no-op.
 
 ## Validation
 
@@ -213,16 +246,23 @@ Consumer supplies a delta. Patch applies it and reconciles to maintain the invar
 
 The asymmetry between `upsert({title: 'X'})` (throws because body wasn't supplied) and `patch({title: 'X'})` (works — rewrites body's H1) mirrors PUT vs PATCH semantics: `upsert` is a state assertion; `patch` is a reconciled delta.
 
-### Markdownlint interaction
+### Normalization interaction
 
-When `[gitsheet.format].title` is set, **MD041** (first-line-must-be-H1) auto-enables in the markdownlint config so a body that starts with prose fails loud at the body level rather than silently producing `undefined` as the title.
+Body normalization runs **before** title-from-H1 extraction, so the title is
+derived from the bytes that land on disk. This means the formatter's heading
+normalization feeds the invariant — e.g. a setext H1 (`Title\n=====`) is
+converted to ATX (`# Title`) and *then* recognized as the first H1, so a
+setext-authored title is extracted rather than silently lost.
 
-Consumer can override:
+The title invariant is enforced by the codec itself, independent of
+normalization:
 
-```toml
-[gitsheet.format.markdownlint]
-MD041 = false   # opt out of the auto-enable
-```
+- Supplying `title` with a body that has **no** H1 throws `ValidationError`
+  (`{slug, title: 'X', body: 'no heading'}` is self-inconsistent).
+- Supplying **no** `title` with a body that has no H1 simply omits `title` from
+  frontmatter.
+
+(There is no markdownlint `MD041` auto-enable anymore — markdownlint is gone.)
 
 ### Performance
 

--- a/specs/rust-core.md
+++ b/specs/rust-core.md
@@ -198,3 +198,10 @@ binding exists**, or Node and Python will disagree on bytes.
 - Parity passes are required wherever a Rust component replaces a JS one with
   observable output: the TOML serializer (#196), the JSON-Schema validator vs
   `ajv`, and the embedded engine vs `node:vm`.
+- **Markdown body normalization is native.** Content-typed (`markdown`/`mdx`)
+  sheets normalize the body on write with the embedded `dprint-plugin-markdown`
+  formatter rather than a host-side `markdownlint` pre-pass, so body bytes are
+  identical across bindings. Its **version + config are pinned** as a
+  canonical-behavior contract input (like the serializer, engine, validator, and
+  collator); switching off the JS `markdownlint` pass is a one-time documented
+  body re-baseline (see [`behaviors/content-types.md`](behaviors/content-types.md)).


### PR DESCRIPTION
Implements [`plans/markdown-normalize-core.md`](plans/markdown-normalize-core.md) — part of the Rust-core migration (#127).

## What

Replaces the JS `markdownlint` body normalization (a host-side pre-pass the codec merely *configured*) with a **native Rust `dprint-plugin-markdown` formatter embedded directly in the bytes-authority core**, so markdown/mdx body bytes are byte-stable and identical across every binding (Node, Python, …). This closes a bytes-authority gap: the prior design let Python and Node normalize bodies differently.

## Normalizer choice + config

`dprint-plugin-markdown` **embeds directly as a normal Rust library** (`dprint_plugin_markdown::format_text(text, &config, …)`) — no WASM/CLI plugin, no `comrak` fallback needed. Pinned **`=0.22.1`** as a canonical-behavior contract input (alongside the serializer / engine / collator).

Config — **aggressive, `textWrap: never`** (captured in `codec::MARKDOWN_CONFIG`):

| option | value |
|---|---|
| `textWrap` | `never` (unwrap paragraphs; line width inert for prose) |
| `emphasisKind` | `underscores` (`_italic_`) |
| `strongKind` | `asterisks` (`**bold**`) |
| `unorderedListKind` | `dashes` (`- item`) |
| `headingKind` | `atx` (setext → ATX) |
| `listIndentKind` | `commonMark` |

Normalization runs on **serialize** (write) only, **before** title-from-H1 extraction, so the extracted title agrees with the on-disk bytes (a setext H1 becomes ATX and is then recognized). Parse/read stays verbatim. Deterministic + idempotent (`normalize(normalize(b)) == normalize(b)`). New `normalize = false` toggle in `[gitsheet.format]` frames the body verbatim (replaces `markdownlint = false`).

## Re-baseline

The `markdownlint` npm dep and the host-side resolution plumbing (`Markdownlint::resolve` / `markdownResolveLintConfig` napi entry) are gone; the core owns normalization. One-time body re-baseline (emphasis `*` → `_`, list markers → `-`, setext → ATX, soft-wrapped paragraphs unwrapped). Markdown data is negligible by design. Re-baselined fixtures: the Rust codec test suite (`src/codec.rs`) and the napi boundary suite (`test/sheet-markdown.mjs`) — new normalization/idempotence/verbatim tests added; the removed `resolveLintConfig` tests replaced.

> Note: the JS `packages/gitsheets` markdown path still uses its own `markdownlint` pipeline until the Node cutover (`node-binding-thin`); this PR only changes the core + its fixtures.

## Validation (all run)

- `cargo test -p gitsheets-core` — 148 pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --workspace --all-targets` — clean
- napi addon build + `npm test` — 94 pass (30 in the markdown boundary suite)
- root `npm run type-check` + `npm test` — green and independent (33 files/287 + 8 files/66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd