### PR TITLE
feat(core): attachment + blob staging + diff rename detection

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -104,7 +104,7 @@ jobs:
         working-directory: rust/gitsheets-napi
         run: npm run build
 
-      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, ICU locale collation, record CRUD/diff/patch, query, index, Sheet/Transaction/Store, markdown codec)
+      - name: Boundary + parity tests (canonical, path templates, ajv, node:vm engine, ICU locale collation, record CRUD/diff/patch, query, index, Sheet/Transaction/Store, markdown codec, attachments)
         # Explicit file paths (not a glob) so the suite runs identically on
         # node 20 and 22 — `node --test "test/*.mjs"` does NOT expand on node 20.
         # The `test` npm script lists every .mjs explicitly (see package.json),
@@ -116,9 +116,12 @@ jobs:
         # (Transaction lifecycle + the two-phase consumer-validator protocol +
         # Store discovery), and sheet-markdown.mjs, which drives the markdown/mdx
         # content-type codec (frontmatter+body round-trip, title-from-H1, lazy
-        # body, allowMissingBody). record-crud/query/index/sheet-store/
-        # sheet-markdown.mjs use `git init` for their temp repos, so git must be
-        # on PATH (it is, on ubuntu-latest).
+        # body, allowMissingBody), and sheet-attachments.mjs, which drives the
+        # blob-write primitive + atomic attachment staging (record + attachment in
+        # ONE commit) + diff rename detection vs `git diff-tree -M`.
+        # record-crud/query/index/sheet-store/sheet-markdown/sheet-attachments.mjs
+        # use `git init` for their temp repos, so git must be on PATH (it is, on
+        # ubuntu-latest).
         working-directory: rust/gitsheets-napi
         run: npm test
 
@@ -180,5 +183,9 @@ jobs:
           uv pip install --no-index --find-links dist gitsheets
 
       - name: Smoke + cross-binding byte-identical parity tests
+        # tests/ auto-discovers test_smoke.py (incl. the attachment surface + the
+        # blob-write primitive + diff rename detection) and test_cross_binding.py
+        # (incl. the attachment-staging byte-identical Node↔Python commit proof,
+        # which drives the napi peer through _node_writer.mjs).
         working-directory: rust/gitsheets-py
         run: .venv/bin/pytest tests/ -v

--- a/plans/attachment-staging-core.md
+++ b/plans/attachment-staging-core.md
@@ -1,11 +1,12 @@
 ---
-status: in-progress
+status: done
 depends: [sheet-store-core]
 specs:
   - specs/behaviors/attachments.md
   - specs/rust-core.md
   - specs/api/sheet.md
 issues: [127]
+pr: https://github.com/JarvusInnovations/gitsheets/pull/215
 ---
 
 # Plan: attachment + blob staging in the core (+ diff rename detection)
@@ -64,21 +65,29 @@ rename detection (`-M`) in the core diff to restore the documented `'renamed'`
 
 ## Validation
 
-- [ ] A record + an attachment upserted in the same `CoreTransaction` land in **one
-      commit** (atomic) — the tree contains both, one commit hash; matches the JS
-      `sheet-attachments.test.ts` / `cli-attachments.test.ts` behavior.
-- [ ] `setAttachment(s)` / `deleteAttachment(s)` / attachment reads + iterator match
-      the JS behavior on a fixture set.
-- [ ] `writeBlob(bytes)` hashes binary content verbatim to the expected git blob
-      hash (independently computed).
-- [ ] The core diff emits `'renamed'` (with from/to) for a moved record, matching
-      `git diff-tree -M` / JS `Sheet.diffFrom` on a fixture set.
-- [ ] **Cross-binding:** an attachment staged via Python and via Node for the same
-      input produces byte-identical commits (extends the existing cross-binding
-      proof to attachments).
-- [ ] `cargo build/test` + clippy clean; napi + py boundary suites pass; the main JS
-      suite stays green and independent (it still uses its own attachment path until
-      the cutover — don't break it here).
+- [x] A record + an attachment upserted in the same `CoreTransaction` land in **one
+      commit** (atomic) — the tree contains both, one commit hash. Rust:
+      `transaction.rs::record_and_attachment_land_in_one_commit_atomically`; napi:
+      `sheet-attachments.mjs` (verified via `git ls-tree`/`rev-parse`); py:
+      `test_smoke.py::test_record_and_attachment_commit_atomically`.
+- [x] `setAttachment(s)` / `deleteAttachment(s)` / attachment reads match the JS
+      behavior (overwrite, strict single-delete `record_not_found`, idempotent
+      bulk-delete no-op, cascade-on-record-delete) on a fixture set — Rust
+      `sheet.rs` tests + napi + py suites. (The `attachments()` iterator's
+      `mimeType`/`.read()`/`.stream()` sugar is host-side and stays in the JS
+      package; the core exposes the `name → hash` map it's built on.)
+- [x] `writeBlob(bytes)` hashes binary content verbatim to the expected git blob
+      hash (independently computed `sha1("blob <len>\0<bytes>")`) — Rust
+      `write_blob_hashes_bytes_to_the_git_blob_hash`, napi + py parity tests.
+- [x] The core diff emits `'renamed'` (with from/to) for a moved record, matching a
+      **live `git diff-tree -M`** oracle on a fixture set (Rust + napi assert the
+      real git output agrees); dissimilar records stay add + delete.
+- [x] **Cross-binding:** an attachment staged via Python and via Node for the same
+      input produces byte-identical blob + tree + commit hashes
+      (`test_cross_binding.py::test_attachment_commit_bytes_identical_across_bindings`).
+- [x] `cargo test` (159 core), clippy `-D warnings` clean; napi (`npm test`, 100) +
+      py (`pytest`, 26) suites pass. `packages/gitsheets` untouched — the main JS
+      suite stays independent until the cutover.
 
 ## Risks / unknowns
 
@@ -94,8 +103,63 @@ rename detection (`-M`) in the core diff to restore the documented `'renamed'`
 
 ## Notes
 
-(Populated at closeout.)
+**Atomicity design (the crux).** `CoreTransaction` owns the live `MutableTree`
+its records stage into (via `Transaction::split() -> (&repo, &mut tree)`). The new
+`Sheet::set_attachments(record_path, [(name, blobHash)])` places each blob at
+`<base>/<recordPath>/<name>` in **that same tree, before `finalize`** — so the
+record file and its attachment blobs are children of the one tree
+`Transaction::finalize` commits. Result: a record upsert + its attachments land in
+a **single commit** (proven three ways: the Rust transaction test inspects the
+committed tree + asserts a single parent; napi verifies via `git ls-tree`/
+`rev-parse`; py via `git ls-tree`). The blob-write primitive
+`record::write_blob(bytes) -> hash` writes the loose object to the ODB
+(content-addressed), and `set_attachments` places it by hash — matching the JS
+two-step `repo.writeBlob(bytes)` → `setAttachments(record, {name: blob})` flow.
+
+**Rename-detection approach + git-parity result.** The core diff previously did a
+pure blob-map add/modify/delete comparison (no renames). It now runs gix
+`Repository::diff_tree_to_tree` over the sheet's **base subtrees** (scoping the
+detection to the sheet, the way `Sheet.diffFrom`'s `-- <effectiveRoot>` pathspec
+does) with an **explicit** `gix::diff::Rewrites::default()` = `percentage:
+Some(0.5)`, `copies: None` — i.e. 50% similarity, renames only. This is exactly
+`git diff-tree -M`'s default, and passing explicit options (rather than
+`Options::from_configuration`) makes it **independent of the repo's `diff.renames`
+config** so the classification is deterministic. gix's rewrite tracker did match a
+live `git diff-tree -M` on the fixtures (a 4-field record moved with a one-field
+change → `R`, ~75% similar; a wholly-different record → `A` + `D`), so no STOP was
+needed. `gix`'s `blob-diff` feature is already on via its default features
+(`basic`), so **no new dependency** — no `cargo add`. A `Renamed` change carries
+`previous_path` (source) and `path` (destination); its src record is read from
+`previous_path`, and its patch is the src→dst field delta. `RecordStatus::Renamed`
+- `RecordChange.previous_path` are surfaced as `status: 'renamed'` / `previousPath`
+on both bindings' `diffRecords`.
+
+**Cross-binding attachment proof.** `_node_writer.mjs` gained a `commit-attachment`
+op; `test_cross_binding.py::test_attachment_commit_bytes_identical_across_bindings`
+stages a record + a fixed-bytes attachment in one transaction via Python and via
+Node and asserts **byte-identical blob hash, tree hash, and commit hash**.
+
+**holo-tree finding (upstream, not worked around).** holo-tree exposes no
+place-a-blob-by-hash primitive on `MutableTree`. `set_attachments` therefore reads
+the (already-written) blob by hash via `find_object` — which also validates it
+exists and is a blob, matching the JS path's `content.read()` safety — then
+re-places it with `write_child_bytes`, which re-hashes to the same content-
+addressed id (byte-identical result). For large attachments this is one redundant
+ODB read; a `MutableTree::write_child_hash(path, hash, mode)` upstream would avoid
+it. Reported here as a hardening opportunity, not a blocker — the result is
+correct and byte-identical.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **holo-tree `write_child_hash` primitive** — place an existing blob by hash at a
+  deep path without reading its bytes back (the efficiency note above). Upstream
+  hologit hardening; not blocking v1.x.
+- **`node-binding-thin` (the cutover)** rewires `packages/gitsheets` to route
+  `Sheet.setAttachment(s)` / `deleteAttachment(s)` / `repo.writeBlob` and
+  `Sheet.diffFrom` through this core surface (replacing the direct
+  `@hologit/holo-tree` `writeBlob` and the `git diff-tree -M` shell-out). The
+  iterator's `mimeType`/`.read()`/`.stream()` sugar stays host-side over the
+  core's `name → hash` map.
+- **Attachment-blob diffs in `diffFrom`** remain intentionally out of scope
+  (specs/api/sheet.md: `*.toml` records only; consumers diff attachment blob
+  hashes directly).

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -42,8 +42,8 @@ pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
 pub use index::{MultiIndex, UniqueIndex};
 pub use query::{matches as query_matches, query_candidate_paths, query_records, Filter, FilterPred};
 pub use record::{
-    DeleteOutcome, RecordChange, RecordDiff, RecordStatus, WriteOutcome, EMPTY_TREE_HASH,
-    TOML_EXTENSION,
+    write_blob, write_blob_at_dir, DeleteOutcome, RecordChange, RecordDiff, RecordStatus,
+    WriteOutcome, EMPTY_TREE_HASH, TOML_EXTENSION,
 };
 pub use sheet::{Sheet, StageOutcome, UpsertCandidate, WillChange};
 pub use transaction::{Author, Transaction, TransactionOptions, TransactionResult};

--- a/rust/gitsheets-core/src/record.rs
+++ b/rust/gitsheets-core/src/record.rs
@@ -27,6 +27,7 @@
 //! handle and the trees navigated through it stay on one thread — the same
 //! discipline the embedded engine ([`crate::engine`]) already requires.
 
+use gix::bstr::ByteSlice;
 use holo_tree::{MutableTree, ObjectId};
 
 use crate::canonical;
@@ -187,6 +188,49 @@ pub(crate) fn read_blob_value(repo: &gix::Repository, hash: ObjectId) -> Result<
         message: format!("record blob {hash} is not valid UTF-8: {e}"),
     })?;
     canonical::parse(&text)
+}
+
+// ── blob-write primitive (the attachment / arbitrary-blob seam) ───────────────
+
+/// Hash `bytes` into the object database as a loose blob and return its git
+/// blob hash. This is the core's authoritative blob-write primitive — the ODB
+/// write goes through the core (holo-tree's `gix::Repository::write_blob`), so
+/// every binding hashes binary content identically. The hash is a pure function
+/// of the bytes (`sha1("blob <len>\0<bytes>")`), so two bindings writing the
+/// same attachment agree byte-for-byte. Staging that blob into a record's
+/// attachment tree is [`crate::sheet::Sheet::set_attachments`].
+pub fn write_blob(repo: &gix::Repository, bytes: &[u8]) -> Result<String> {
+    let id = repo.write_blob(bytes).map_err(|e| Error::CommitFailed {
+        message: format!("could not write blob to object database: {e}"),
+    })?;
+    Ok(id.detach().to_string())
+}
+
+/// Open the repo at `git_dir` and [`write_blob`] `bytes` into it — the
+/// ref-string wrapper a binding calls (it never handles a `gix::Repository`).
+pub fn write_blob_at_dir(git_dir: &str, bytes: &[u8]) -> Result<String> {
+    let repo = open_repo(git_dir)?;
+    write_blob(&repo, bytes)
+}
+
+/// Read a blob's raw bytes by its hex hash, validating it exists in the ODB and
+/// is a blob (not a tree/commit) — the read half of attachment staging. A
+/// missing object is [`Error::RecordNotFound`]; a non-blob is
+/// [`Error::ConfigInvalid`]. Used to place an already-written blob (by hash)
+/// into a tree at a deep path.
+pub(crate) fn read_blob_bytes_by_hash(repo: &gix::Repository, hash: &str) -> Result<Vec<u8>> {
+    let oid = ObjectId::from_hex(hash.as_bytes()).map_err(|e| Error::CommitFailed {
+        message: format!("invalid blob hash {hash:?}: {e}"),
+    })?;
+    let obj = repo.find_object(oid).map_err(|e| Error::RecordNotFound {
+        message: format!("blob {hash} not found in object database: {e}"),
+    })?;
+    if obj.kind != gix::object::Kind::Blob {
+        return Err(Error::ConfigInvalid {
+            message: format!("object {hash} is not a blob (it is a {:?})", obj.kind),
+        });
+    }
+    Ok(obj.data.to_vec())
 }
 
 // ── join / path helpers ──────────────────────────────────────────────────────
@@ -368,14 +412,17 @@ pub fn list_records(
 
 // ── record-level diff (replacing git diff-tree) ──────────────────────────────
 
-/// The status of one record between two trees. No `renamed`: this primitive does
-/// not do similarity-based rename detection (`git diff-tree -M`); a moved record
-/// surfaces as a `Deleted` + an `Added`. See the plan Notes.
+/// The status of one record between two trees. `Renamed` is emitted by
+/// gix similarity-based rename detection (the `git diff-tree -M` analogue,
+/// 50% default threshold) — a moved record whose content is similar enough
+/// surfaces as a single `Renamed` (carrying `previous_path`) rather than a
+/// `Deleted` + `Added` pair.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RecordStatus {
     Added,
     Modified,
     Deleted,
+    Renamed,
 }
 
 impl RecordStatus {
@@ -384,47 +431,83 @@ impl RecordStatus {
             RecordStatus::Added => "added",
             RecordStatus::Modified => "modified",
             RecordStatus::Deleted => "deleted",
+            RecordStatus::Renamed => "renamed",
         }
     }
 }
 
 /// One record-level change between two trees. `path` is relative to `base`,
-/// without the extension; hashes are `None` on the side where the record is
-/// absent.
+/// without the extension; for a `Renamed` change it is the **destination** (new)
+/// path, matching `Sheet.diffFrom`'s `canonicalPath = dstPath`. `previous_path`
+/// is the rename **source** (old) path, `Some` only for `Renamed`. Hashes are
+/// `None` on the side where the record is absent.
 #[derive(Clone, Debug)]
 pub struct RecordChange {
     pub path: String,
     pub status: RecordStatus,
+    pub previous_path: Option<String>,
     pub src_hash: Option<String>,
     pub dst_hash: Option<String>,
 }
 
-fn record_blob_map(
+/// The tree id of the subtree under `base`, or `None` when that subtree doesn't
+/// exist or is empty (git's empty-tree hash) — scoping the diff to the sheet's
+/// records the way `Sheet.diffFrom`'s `-- <effectiveRoot>` pathspec does.
+fn subtree_id_for_diff(
     repo: &gix::Repository,
     tree: &mut MutableTree,
     base: &str,
-    extension: &str,
-) -> Result<std::collections::BTreeMap<String, String>> {
+) -> Result<Option<ObjectId>> {
     let barg = base_arg(base);
-    let mut out = std::collections::BTreeMap::new();
-    let subtree = match tree.get_subtree(repo, &barg).map_err(map_ht)? {
-        Some(t) => t,
-        None => return Ok(out),
-    };
-    for (path, info) in subtree.get_blob_map(repo).map_err(map_ht)? {
-        if !path.ends_with(extension) {
-            continue;
+    match tree.get_subtree(repo, &barg).map_err(map_ht)? {
+        Some(sub) => {
+            let id = sub.write(repo).map_err(map_ht)?;
+            if id.to_string() == EMPTY_TREE_HASH {
+                Ok(None)
+            } else {
+                Ok(Some(id))
+            }
         }
-        let record_path = path[..path.len() - extension.len()].to_string();
-        out.insert(record_path, hex(info.hash));
+        None => Ok(None),
     }
-    Ok(out)
 }
 
-/// Diff records between two trees under `base`: added (only in dst), deleted
-/// (only in src), modified (present in both, blob hash differs). Identical
-/// blobs are skipped. Yielded in sorted path order (git-canonical), matching
-/// `git diff-tree -r`'s ordering for the add/modify/delete cases.
+/// Load a subtree id as a `gix::Tree`, or `None` for the empty side (so
+/// [`gix::Repository::diff_tree_to_tree`] substitutes its empty tree).
+fn load_gix_tree<'r>(
+    repo: &'r gix::Repository,
+    id: Option<ObjectId>,
+) -> Result<Option<gix::Tree<'r>>> {
+    match id {
+        Some(id) => {
+            let obj = repo.find_object(id).map_err(|e| Error::CommitFailed {
+                message: format!("could not load tree {id}: {e}"),
+            })?;
+            let tree = obj.try_into_tree().map_err(|_| Error::CommitFailed {
+                message: format!("object {id} is not a tree"),
+            })?;
+            Ok(Some(tree))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Strip `extension` off a diff location (relative to `base`), returning the
+/// record path — `None` when the entry isn't a record file for this format
+/// (attachments, hidden files, or a directory), which the caller skips.
+fn record_path_of(location: &gix::bstr::BStr, extension: &str) -> Option<String> {
+    let s = location.to_str().ok()?;
+    s.strip_suffix(extension).map(|p| p.to_string())
+}
+
+/// Diff records between two trees under `base` with git-parity rename detection:
+/// added (only in dst), deleted (only in src), modified (present in both, blob
+/// differs), and **renamed** (a moved record with ≥ 50% content similarity —
+/// the `git diff-tree -M` default). Runs gix's `tree_with_rewrites` over the
+/// `base` subtrees (explicit `Rewrites::default()` = 50%, renames only, no
+/// copies, so the result is independent of any `diff.renames` git config).
+/// Non-record entries (attachments, directories) are filtered by `extension`.
+/// Yielded in sorted destination-path order.
 pub fn diff_record_changes(
     repo: &gix::Repository,
     src_tree: &mut MutableTree,
@@ -432,45 +515,117 @@ pub fn diff_record_changes(
     base: &str,
     extension: &str,
 ) -> Result<Vec<RecordChange>> {
-    let src_map = record_blob_map(repo, src_tree, base, extension)?;
-    let dst_map = record_blob_map(repo, dst_tree, base, extension)?;
+    use gix::diff::{Options, Rewrites};
+    use gix::object::tree::diff::ChangeDetached;
 
-    let mut paths: std::collections::BTreeSet<&String> = std::collections::BTreeSet::new();
-    paths.extend(src_map.keys());
-    paths.extend(dst_map.keys());
+    let src_id = subtree_id_for_diff(repo, src_tree, base)?;
+    let dst_id = subtree_id_for_diff(repo, dst_tree, base)?;
+    let src_gix = load_gix_tree(repo, src_id)?;
+    let dst_gix = load_gix_tree(repo, dst_id)?;
+
+    // Explicit 50%-rename options (the `-M` default), NOT config-derived, so the
+    // classification is deterministic regardless of the repo's diff.renames.
+    let opts = Options::default().with_rewrites(Some(Rewrites::default()));
+    let changes = repo
+        .diff_tree_to_tree(src_gix.as_ref(), dst_gix.as_ref(), Some(opts))
+        .map_err(|e| Error::CommitFailed {
+            message: format!("gix diff_tree_to_tree failed: {e}"),
+        })?;
 
     let mut out = Vec::new();
-    for path in paths {
-        let src = src_map.get(path);
-        let dst = dst_map.get(path);
-        let change = match (src, dst) {
-            (Some(s), Some(d)) => {
-                if s == d {
+    for change in changes {
+        match change {
+            ChangeDetached::Addition {
+                location,
+                entry_mode,
+                id,
+                ..
+            } => {
+                if entry_mode.is_tree() {
                     continue;
                 }
-                RecordChange {
-                    path: path.clone(),
-                    status: RecordStatus::Modified,
-                    src_hash: Some(s.clone()),
-                    dst_hash: Some(d.clone()),
+                if let Some(path) = record_path_of(location.as_ref(), extension) {
+                    out.push(RecordChange {
+                        path,
+                        status: RecordStatus::Added,
+                        previous_path: None,
+                        src_hash: None,
+                        dst_hash: Some(id.to_string()),
+                    });
                 }
             }
-            (None, Some(d)) => RecordChange {
-                path: path.clone(),
-                status: RecordStatus::Added,
-                src_hash: None,
-                dst_hash: Some(d.clone()),
-            },
-            (Some(s), None) => RecordChange {
-                path: path.clone(),
-                status: RecordStatus::Deleted,
-                src_hash: Some(s.clone()),
-                dst_hash: None,
-            },
-            (None, None) => unreachable!(),
-        };
-        out.push(change);
+            ChangeDetached::Deletion {
+                location,
+                entry_mode,
+                id,
+                ..
+            } => {
+                if entry_mode.is_tree() {
+                    continue;
+                }
+                if let Some(path) = record_path_of(location.as_ref(), extension) {
+                    out.push(RecordChange {
+                        path,
+                        status: RecordStatus::Deleted,
+                        previous_path: None,
+                        src_hash: Some(id.to_string()),
+                        dst_hash: None,
+                    });
+                }
+            }
+            ChangeDetached::Modification {
+                location,
+                entry_mode,
+                previous_id,
+                id,
+                ..
+            } => {
+                if entry_mode.is_tree() {
+                    continue;
+                }
+                if let Some(path) = record_path_of(location.as_ref(), extension) {
+                    out.push(RecordChange {
+                        path,
+                        status: RecordStatus::Modified,
+                        previous_path: None,
+                        src_hash: Some(previous_id.to_string()),
+                        dst_hash: Some(id.to_string()),
+                    });
+                }
+            }
+            ChangeDetached::Rewrite {
+                source_location,
+                source_id,
+                location,
+                entry_mode,
+                id,
+                ..
+            } => {
+                if entry_mode.is_tree() {
+                    continue;
+                }
+                // A rename (or copy) whose destination is a record file for this
+                // format. `git diff-tree -M`'s R and C both map to `'renamed'`.
+                let (Some(path), Some(prev)) = (
+                    record_path_of(location.as_ref(), extension),
+                    record_path_of(source_location.as_ref(), extension),
+                ) else {
+                    continue;
+                };
+                out.push(RecordChange {
+                    path,
+                    status: RecordStatus::Renamed,
+                    previous_path: Some(prev),
+                    src_hash: Some(source_id.to_string()),
+                    dst_hash: Some(id.to_string()),
+                });
+            }
+        }
     }
+
+    // Deterministic destination-path order (gix emits additions/deletions in
+    // traversal order then appends rewrites).
+    out.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(out)
 }
 
@@ -499,8 +654,11 @@ pub fn diff_records(
     let changes = diff_record_changes(repo, src_tree, dst_tree, base, extension)?;
     let mut out = Vec::with_capacity(changes.len());
     for change in changes {
+        // The src side of a rename lives at `previous_path`; every other status
+        // has src and dst at the same `path`.
+        let src_path = change.previous_path.as_deref().unwrap_or(&change.path);
         let src = match &change.src_hash {
-            Some(_) => read_one(repo, src_tree, base, &change.path, extension)?,
+            Some(_) => read_one(repo, src_tree, base, src_path, extension)?,
             None => None,
         };
         let dst = match &change.dst_hash {
@@ -784,5 +942,125 @@ mod tests {
         let diffs = diff_records(&repo, &mut empty, &mut dst2, "people", TOML_EXTENSION).unwrap();
         assert_eq!(diffs.len(), 1);
         assert_eq!(diffs[0].change.status, RecordStatus::Added);
+    }
+
+    // ── blob-write primitive ─────────────────────────────────────────────────
+
+    #[test]
+    fn write_blob_hashes_bytes_to_the_git_blob_hash() {
+        let (_dir, repo) = temp_repo();
+        // Binary content (includes a NUL + high bytes) — proves it's byte-verbatim.
+        let bytes: &[u8] = &[0xde, 0xad, 0xbe, 0xef, 0x00, 0xff, b'h', b'i'];
+        let hash = write_blob(&repo, bytes).unwrap();
+        // Independently computed git blob hash: sha1("blob <len>\0<bytes>").
+        assert_eq!(hash, git_blob_hash(bytes));
+        // And the object is retrievable + byte-identical.
+        let read = read_blob_bytes_by_hash(&repo, &hash).unwrap();
+        assert_eq!(read, bytes);
+    }
+
+    #[test]
+    fn read_blob_bytes_by_hash_rejects_missing_and_non_blob() {
+        let (_dir, repo) = temp_repo();
+        // A well-formed but absent hash → record_not_found.
+        let absent = "0".repeat(40);
+        let err = read_blob_bytes_by_hash(&repo, &absent).err().unwrap();
+        assert_eq!(err.code(), "record_not_found");
+        // A tree hash (the empty tree) is not a blob → config_invalid.
+        let mut t = MutableTree::empty();
+        write_records(&repo, &mut t, "people", &[("jane".into(), rec(&[("slug", s("jane"))]))], TOML_EXTENSION)
+            .unwrap();
+        let tree_hash = t.write(&repo).unwrap().to_string();
+        let err = read_blob_bytes_by_hash(&repo, &tree_hash).err().unwrap();
+        assert_eq!(err.code(), "config_invalid");
+    }
+
+    // ── rename detection (git diff-tree -M parity) ───────────────────────────
+
+    /// Whether the `git` CLI is on PATH (the parity oracle needs it).
+    fn git_available() -> bool {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// A 4-field record whose slug drives the path; changing only the slug keeps
+    /// ~75% of the lines identical → well above git's 50% rename threshold.
+    fn person(slug: &str) -> Value {
+        rec(&[
+            ("bio", s("A reasonably long biography line that stays put.")),
+            ("email", s("jane@example.org")),
+            ("name", s("Jane Q. Doe")),
+            ("slug", s(slug)),
+        ])
+    }
+
+    #[test]
+    fn diff_detects_a_moved_record_as_renamed() {
+        let (_dir, repo) = temp_repo();
+        let mut src = MutableTree::empty();
+        write_records(&repo, &mut src, "people", &[("jane".into(), person("jane"))], TOML_EXTENSION).unwrap();
+        let src_hash = src.write(&repo).unwrap().to_string();
+
+        // Move jane → jane-doe (slug change re-renders the path); content stays
+        // ~75% identical.
+        let mut dst = MutableTree::empty();
+        write_records(&repo, &mut dst, "people", &[("jane-doe".into(), person("jane-doe"))], TOML_EXTENSION)
+            .unwrap();
+        let dst_hash = dst.write(&repo).unwrap().to_string();
+
+        let mut src2 = resolve_tree(&repo, &src_hash).unwrap();
+        let mut dst2 = resolve_tree(&repo, &dst_hash).unwrap();
+        let changes = diff_record_changes(&repo, &mut src2, &mut dst2, "people", TOML_EXTENSION).unwrap();
+
+        assert_eq!(changes.len(), 1, "one rename, not an add + a delete");
+        assert_eq!(changes[0].status, RecordStatus::Renamed);
+        assert_eq!(changes[0].path, "jane-doe");
+        assert_eq!(changes[0].previous_path.as_deref(), Some("jane"));
+        assert!(changes[0].src_hash.is_some());
+        assert!(changes[0].dst_hash.is_some());
+
+        // The rename's patch is the src→dst field delta (the slug replace).
+        let diffs = diff_records(&repo, &mut resolve_tree(&repo, &src_hash).unwrap(), &mut resolve_tree(&repo, &dst_hash).unwrap(), "people", TOML_EXTENSION).unwrap();
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].patch.len(), 1);
+        assert_eq!(diffs[0].patch[0].path, "/slug");
+
+        // Parity: real `git diff-tree -M` classifies the same move as a rename.
+        if git_available() {
+            let out = std::process::Command::new("git")
+                .args(["diff-tree", "-M", "-r", "--name-status", "--no-commit-id", &src_hash, &dst_hash, "--", "people"])
+                .current_dir(_dir.path())
+                .output()
+                .unwrap();
+            let text = String::from_utf8(out.stdout).unwrap();
+            assert!(
+                text.lines().any(|l| l.starts_with('R') && l.contains("people/jane.toml") && l.contains("people/jane-doe.toml")),
+                "git diff-tree -M should report a rename, got: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn diff_dissimilar_records_are_add_plus_delete_not_rename() {
+        // Totally different content on both sides → git (and the core) do NOT
+        // pair them as a rename.
+        let (_dir, repo) = temp_repo();
+        let mut src = MutableTree::empty();
+        write_records(&repo, &mut src, "people", &[("bob".into(), rec(&[("slug", s("bob"))]))], TOML_EXTENSION).unwrap();
+        let src_hash = src.write(&repo).unwrap().to_string();
+        let mut dst = MutableTree::empty();
+        write_records(&repo, &mut dst, "people", &[("amy".into(), rec(&[("slug", s("amy"))]))], TOML_EXTENSION).unwrap();
+        let dst_hash = dst.write(&repo).unwrap().to_string();
+
+        let mut src2 = resolve_tree(&repo, &src_hash).unwrap();
+        let mut dst2 = resolve_tree(&repo, &dst_hash).unwrap();
+        let changes = diff_record_changes(&repo, &mut src2, &mut dst2, "people", TOML_EXTENSION).unwrap();
+        let statuses: std::collections::HashMap<&str, RecordStatus> =
+            changes.iter().map(|c| (c.path.as_str(), c.status)).collect();
+        assert_eq!(statuses["amy"], RecordStatus::Added);
+        assert_eq!(statuses["bob"], RecordStatus::Deleted);
     }
 }

--- a/rust/gitsheets-core/src/sheet.rs
+++ b/rust/gitsheets-core/src/sheet.rs
@@ -442,6 +442,149 @@ impl Sheet {
         Ok(())
     }
 
+    // ── attachments ──────────────────────────────────────────────────────────
+    //
+    // Attachments are arbitrary blobs colocated with a record: for a record at
+    // `<base>/<recordPath>.toml`, they live in the sibling directory
+    // `<base>/<recordPath>/<name>`. They stage into the SAME `MutableTree` this
+    // sheet's records write into — so a record upsert + its attachments commit
+    // atomically in one transaction (specs/behaviors/attachments.md). Reads and
+    // deletes scope to the `<recordPath>/` subtree; the record's own
+    // `<recordPath>.toml` is a sibling, never inside it, so it's never touched.
+
+    /// Full tree path of a record's attachment directory (`<base>/<recordPath>`).
+    fn attachment_dir(&self, record_path: &str) -> String {
+        join_path(&[&self.base, record_path])
+    }
+
+    /// Full tree path of a single attachment (`<base>/<recordPath>/<name>`).
+    fn attachment_path(&self, record_path: &str, name: &str) -> String {
+        join_path(&[&self.base, record_path, name])
+    }
+
+    /// Stage attachments for a record *(mutating)*: place each `(name, blobHash)`
+    /// at `<base>/<recordPath>/<name>` in the transaction's live tree. The blob
+    /// must already exist in the ODB (write it with
+    /// [`crate::record::write_blob`]); the hash is content-addressed, so the
+    /// placed bytes are exactly the written bytes. An existing attachment of the
+    /// same name is overwritten. Matches `Sheet.setAttachments`.
+    pub fn set_attachments(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record_path: &str,
+        attachments: &[(String, String)],
+    ) -> Result<()> {
+        for (name, blob_hash) in attachments {
+            let full = self.attachment_path(record_path, name);
+            // Re-read the (already-written) blob by hash and place it at `full`.
+            // holo-tree lacks a place-by-hash primitive (upstream hardening
+            // finding — a `MutableTree::write_child_hash(path, hash, mode)` would
+            // avoid this read); `write_child_bytes` re-hashes to the same content-
+            // addressed id, so the placed object is byte-identical.
+            let bytes = record::read_blob_bytes_by_hash(repo, blob_hash)?;
+            tree.write_child_bytes(repo, &full, &bytes)
+                .map_err(record::map_ht)?;
+        }
+        self.index_cache = None;
+        Ok(())
+    }
+
+    /// The blob-hash map of a record's attachments (`name → hash`), sorted by
+    /// name; `None` when the record has no attachment directory. Matches
+    /// `Sheet.getAttachments` (returns `null` for no dir).
+    pub fn get_attachments(
+        &self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record_path: &str,
+    ) -> Result<Option<Vec<(String, String)>>> {
+        let dir = self.attachment_dir(record_path);
+        let barg = if dir.is_empty() { ".".to_string() } else { dir };
+        match tree.get_subtree(repo, &barg).map_err(record::map_ht)? {
+            Some(sub) => {
+                let blob_map = sub.get_blob_map(repo).map_err(record::map_ht)?;
+                Ok(Some(
+                    blob_map
+                        .into_iter()
+                        .map(|(name, info)| (name, info.hash.to_string()))
+                        .collect(),
+                ))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// The blob hash of a single named attachment, or `None` if absent. Matches
+    /// `Sheet.getAttachment`.
+    pub fn get_attachment(
+        &self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record_path: &str,
+        name: &str,
+    ) -> Result<Option<String>> {
+        let full = self.attachment_path(record_path, name);
+        match tree.get_child(repo, &full).map_err(record::map_ht)? {
+            Some(holo_tree::Child::Blob { hash, .. }) => Ok(Some(hash.to_string())),
+            _ => Ok(None),
+        }
+    }
+
+    /// Remove a single named attachment *(mutating)*. Strict:
+    /// [`Error::RecordNotFound`] when the named attachment doesn't exist, so
+    /// callers can't silently miss bugs. Sibling attachments are left intact.
+    /// Matches `Sheet.deleteAttachment`.
+    pub fn delete_attachment(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record_path: &str,
+        name: &str,
+    ) -> Result<()> {
+        let full = self.attachment_path(record_path, name);
+        let is_blob = matches!(
+            tree.get_child(repo, &full).map_err(record::map_ht)?,
+            Some(holo_tree::Child::Blob { .. })
+        );
+        if !is_blob {
+            return Err(Error::RecordNotFound {
+                message: format!(
+                    "{}: no attachment at {}",
+                    self.name,
+                    join_path(&[record_path, name])
+                ),
+            });
+        }
+        tree.delete_child_deep(repo, &full).map_err(record::map_ht)?;
+        self.index_cache = None;
+        Ok(())
+    }
+
+    /// Remove all attachments for a record (drops the entire attachment
+    /// directory) *(mutating)*. Returns whether anything was removed — `false`
+    /// is the idempotent no-op when the record has no attachment directory (the
+    /// caller then leaves the transaction unmutated). Matches
+    /// `Sheet.deleteAttachments`.
+    pub fn delete_attachments(
+        &mut self,
+        repo: &gix::Repository,
+        tree: &mut MutableTree,
+        record_path: &str,
+    ) -> Result<bool> {
+        let full = self.attachment_dir(record_path);
+        let is_tree = matches!(
+            tree.get_child(repo, &full).map_err(record::map_ht)?,
+            Some(holo_tree::Child::Tree(_))
+        );
+        if !is_tree {
+            return Ok(false);
+        }
+        tree.delete_child_deep(repo, &full).map_err(record::map_ht)?;
+        self.index_cache = None;
+        Ok(true)
+    }
+
     /// List every record under the sheet's base, in sorted path order, decoded
     /// through the format codec. `with_body` is the lazy-body switch for
     /// markdown sheets (`false` omits the body field — the `withBody: false`
@@ -1094,5 +1237,126 @@ mod tests {
         let listed = sheet.list(&repo, &mut tree, true).unwrap();
         let wc = sheet.will_change(&repo, &mut tree, &listed[0].1, None, false).unwrap();
         assert!(!wc.changed, "byte-identical markdown re-upsert is a no-op");
+    }
+
+    // ── attachments ──────────────────────────────────────────────────────────
+
+    /// Stage a record at `record_path` in `tree`.
+    fn stage_record(sheet: &mut Sheet, repo: &gix::Repository, tree: &mut MutableTree, slug: &str) {
+        let r = rec(&[("slug", s(slug))]);
+        let c = sheet.prepare_upsert(repo, tree, &r, None, false).unwrap();
+        sheet.stage_upsert(repo, tree, &c).unwrap();
+    }
+
+    /// Write `bytes` to the ODB and place it as attachment `name` on `record_path`.
+    fn attach(sheet: &mut Sheet, repo: &gix::Repository, tree: &mut MutableTree, record_path: &str, name: &str, bytes: &[u8]) {
+        let hash = crate::record::write_blob(repo, bytes).unwrap();
+        sheet.set_attachments(repo, tree, record_path, &[(name.to_string(), hash)]).unwrap();
+    }
+
+    #[test]
+    fn set_get_attachments_round_trips_by_hash() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+
+        let avatar_hash = crate::record::write_blob(&repo, b"AVATAR-BYTES").unwrap();
+        let cover_hash = crate::record::write_blob(&repo, b"COVER-BYTES").unwrap();
+        sheet
+            .set_attachments(&repo, &mut tree, "jane", &[
+                ("avatar.jpg".into(), avatar_hash.clone()),
+                ("cover.png".into(), cover_hash.clone()),
+            ])
+            .unwrap();
+
+        let got = sheet.get_attachments(&repo, &mut tree, "jane").unwrap().unwrap();
+        assert_eq!(
+            got,
+            vec![
+                ("avatar.jpg".to_string(), avatar_hash.clone()),
+                ("cover.png".to_string(), cover_hash),
+            ]
+        );
+        // Single lookup + absent name.
+        assert_eq!(sheet.get_attachment(&repo, &mut tree, "jane", "avatar.jpg").unwrap(), Some(avatar_hash));
+        assert_eq!(sheet.get_attachment(&repo, &mut tree, "jane", "nope.png").unwrap(), None);
+
+        // The record file is NOT reported as an attachment (it's a sibling).
+        let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["avatar.jpg", "cover.png"]);
+    }
+
+    #[test]
+    fn get_attachments_is_none_without_a_dir() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+        assert_eq!(sheet.get_attachments(&repo, &mut tree, "jane").unwrap(), None);
+    }
+
+    #[test]
+    fn overwrite_attachment_replaces_the_blob() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+        attach(&mut sheet, &repo, &mut tree, "jane", "avatar.jpg", b"V1");
+        attach(&mut sheet, &repo, &mut tree, "jane", "avatar.jpg", b"V2");
+        let got = sheet.get_attachments(&repo, &mut tree, "jane").unwrap().unwrap();
+        assert_eq!(got.len(), 1);
+        let expected = crate::record::write_blob(&repo, b"V2").unwrap();
+        assert_eq!(got[0].1, expected);
+    }
+
+    #[test]
+    fn delete_attachment_is_strict_and_leaves_siblings() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+        attach(&mut sheet, &repo, &mut tree, "jane", "avatar.jpg", b"A");
+        attach(&mut sheet, &repo, &mut tree, "jane", "cover.png", b"C");
+
+        // Missing → RecordNotFound.
+        let err = sheet.delete_attachment(&repo, &mut tree, "jane", "nope.png").err().unwrap();
+        assert_eq!(err.code(), "record_not_found");
+
+        // Existing → removed, sibling intact.
+        sheet.delete_attachment(&repo, &mut tree, "jane", "avatar.jpg").unwrap();
+        let got = sheet.get_attachments(&repo, &mut tree, "jane").unwrap().unwrap();
+        let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["cover.png"]);
+    }
+
+    #[test]
+    fn delete_attachments_removes_dir_and_no_ops_when_absent() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+
+        // No attachment dir → no-op (returns false, caller leaves tx unmutated).
+        assert!(!sheet.delete_attachments(&repo, &mut tree, "jane").unwrap());
+
+        attach(&mut sheet, &repo, &mut tree, "jane", "a.bin", b"a");
+        attach(&mut sheet, &repo, &mut tree, "jane", "b.bin", b"b");
+        assert!(sheet.delete_attachments(&repo, &mut tree, "jane").unwrap());
+        assert_eq!(sheet.get_attachments(&repo, &mut tree, "jane").unwrap(), None);
+        // The record itself is intact.
+        assert_eq!(sheet.list(&repo, &mut tree, true).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn deleting_the_record_cascades_its_attachments() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+        attach(&mut sheet, &repo, &mut tree, "jane", "avatar.jpg", b"A");
+        sheet.delete_at_path(&repo, &mut tree, "jane").unwrap();
+        assert_eq!(sheet.get_attachments(&repo, &mut tree, "jane").unwrap(), None);
+        assert!(sheet.list(&repo, &mut tree, true).unwrap().is_empty());
     }
 }

--- a/rust/gitsheets-core/src/transaction.rs
+++ b/rust/gitsheets-core/src/transaction.rs
@@ -599,6 +599,54 @@ mod tests {
     }
 
     #[test]
+    fn record_and_attachment_land_in_one_commit_atomically() {
+        let (dir, git_dir, parent) = setup(config_value("${{ slug }}", "people"));
+
+        // One transaction: upsert the record AND stage an attachment for it.
+        let mut tx = Transaction::begin(&git_dir, default_opts("add jane + avatar")).unwrap();
+        let attach_hash;
+        {
+            let (repo, tree) = tx.split();
+            let mut sheet =
+                Sheet::open(repo, tree, "people", ".gitsheets/people.toml", ".", "").unwrap();
+            let rec = record_value(&[("slug", "jane")]);
+            let candidate = sheet.prepare_upsert(repo, tree, &rec, None, false).unwrap();
+            sheet.stage_upsert(repo, tree, &candidate).unwrap();
+            // Blob-write primitive → set_attachments (place-by-hash into the SAME
+            // live tree the record staged into).
+            attach_hash = record::write_blob(repo, b"AVATAR").unwrap();
+            sheet
+                .set_attachments(repo, tree, "jane", &[("avatar.jpg".into(), attach_hash.clone())])
+                .unwrap();
+        }
+        tx.mark_mutated();
+        let result = tx.finalize().unwrap();
+
+        let commit_hash = result.commit_hash.expect("one commit produced");
+
+        // The new commit is a single child of the parent (one commit, not two).
+        let repo = record::open_repo(&git_dir).unwrap();
+        let obj = repo.rev_parse_single(commit_hash.as_str()).unwrap().object().unwrap();
+        let commit = obj.try_into_commit().unwrap();
+        let parents: Vec<_> = commit.parent_ids().collect();
+        assert_eq!(parents.len(), 1);
+        assert_eq!(parents[0].to_string(), parent.to_string());
+
+        // That ONE commit's tree contains BOTH the record and the attachment.
+        let mut committed = record::resolve_tree(&repo, &commit_hash).unwrap();
+        let record_blob = committed.read_blob(&repo, "people/jane.toml").unwrap();
+        assert!(record_blob.is_some(), "record file is in the commit");
+        let attach_child = committed.get_child(&repo, "people/jane/avatar.jpg").unwrap();
+        match attach_child {
+            Some(holo_tree::Child::Blob { hash, .. }) => {
+                assert_eq!(hash.to_string(), attach_hash, "attachment blob is the written one");
+            }
+            _ => panic!("attachment blob missing from the committed tree"),
+        }
+        drop(dir);
+    }
+
+    #[test]
     fn full_upsert_commits_with_identity_trailers_and_record() {
         let (dir, git_dir, parent) = setup(config_value("${{ slug }}", "people"));
         let mut opts = default_opts("people: add jane");

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -127,6 +127,9 @@ module.exports = {
   recordDelete: wrap(addon.recordDelete),
   recordList: wrap(addon.recordList),
   diffRecords: wrap(addon.diffRecords),
+  // Blob-write primitive: hash raw attachment bytes into the ODB. A substrate
+  // failure surfaces as a typed core error.
+  writeBlob: wrap(addon.writeBlob),
   // Query traversal + filtering (batch-first): the template prunes the walk and
   // the filter (equality / nested / `$pred` engine snippets) runs in the core.
   recordQuery: wrap(addon.recordQuery),

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -116,6 +116,15 @@ export interface JsRecordEntry {
  */
 export declare function recordList(gitDir: string, treeRef: string, base: string, extension?: string | undefined | null): Array<JsRecordEntry>
 /**
+ * Hash raw bytes into the object database as a loose blob, returning its git
+ * blob hash — the core's blob-write primitive (replaces the JS package's direct
+ * `@hologit/holo-tree` `writeBlob`). Used by the CLI/host to hash a binary
+ * attachment before staging it into a record's attachment tree with
+ * `CoreTransaction.setAttachment(s)`. The hash is a pure function of the bytes,
+ * so Node and Python hashing the same content produce the same object.
+ */
+export declare function writeBlob(gitDir: string, content: Buffer): string
+/**
  * A snapshot of holo-tree's process-wide tree/blob counters — read-side
  * instrumentation for the bulk benchmark and the hologit#464 perf finding.
  */
@@ -236,6 +245,14 @@ export interface JsStageOutcome {
   path: string
 }
 /**
+ * One attachment entry from `CoreTransaction.getAttachments`: its filename and
+ * blob hash (name → hash).
+ */
+export interface JsAttachmentEntry {
+  name: string
+  hash: string
+}
+/**
  * Discover every sheet declared in `<openRoot>/.gitsheets/*.toml` in the tree
  * `treeRef`. Sorted bare names. The `Store` discovery half (`openStore`).
  */
@@ -351,6 +368,34 @@ export declare class CoreTransaction {
   delete(name: string, recordPath: string): void
   /** `Sheet.clear` *(mutating)* — empties the sheet's data subtree. */
   clear(name: string): void
+  /**
+   * Stage attachments for a record *(mutating)*: place each `name → blobHash`
+   * at `<recordPath>/<name>` in this transaction's live tree, so the record
+   * and its attachments commit atomically. Write the blob first with the
+   * top-level `writeBlob`. Marks the transaction mutated.
+   */
+  setAttachments(name: string, recordPath: string, attachments: Record<string, string>): void
+  /** Stage a single attachment *(mutating)* — sugar over [`Self::set_attachments`]. */
+  setAttachment(name: string, recordPath: string, attachmentName: string, blobHash: string): void
+  /**
+   * The blob-hash map of a record's attachments (`name → hash`, sorted by
+   * name), or `null` when the record has no attachment directory. Read-only.
+   */
+  getAttachments(name: string, recordPath: string): Array<JsAttachmentEntry> | null
+  /** The blob hash of a single named attachment, or `null` if absent. Read-only. */
+  getAttachment(name: string, recordPath: string, attachmentName: string): string | null
+  /**
+   * Remove a single named attachment *(mutating)*. Throws
+   * `NotFoundError(record_not_found)` when it doesn't exist. Marks mutated.
+   */
+  deleteAttachment(name: string, recordPath: string, attachmentName: string): void
+  /**
+   * Remove all attachments for a record *(mutating)*. A no-op when the record
+   * has no attachment directory — in that case the transaction is NOT marked
+   * mutated (so an otherwise-empty transaction still finalizes to no commit).
+   * Returns whether anything was removed.
+   */
+  deleteAttachments(name: string, recordPath: string): boolean
   /**
    * List every record under the sheet's base, decoded through the format
    * codec, in sorted path order. `withBody` is the lazy-body switch for

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, writeBlob, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -324,6 +324,7 @@ module.exports.recordRead = recordRead
 module.exports.recordWrite = recordWrite
 module.exports.recordDelete = recordDelete
 module.exports.recordList = recordList
+module.exports.writeBlob = writeBlob
 module.exports.substrateStats = substrateStats
 module.exports.substrateReset = substrateReset
 module.exports.recordQuery = recordQuery

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/collator-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs test/sheet-markdown.mjs",
+    "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/collator-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs test/sheet-markdown.mjs test/sheet-attachments.mjs",
     "bench": "node bench/query-bench.mjs"
   },
   "devDependencies": {

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -602,6 +602,20 @@ pub fn record_list(
     }
 }
 
+/// Hash raw bytes into the object database as a loose blob, returning its git
+/// blob hash — the core's blob-write primitive (replaces the JS package's direct
+/// `@hologit/holo-tree` `writeBlob`). Used by the CLI/host to hash a binary
+/// attachment before staging it into a record's attachment tree with
+/// `CoreTransaction.setAttachment(s)`. The hash is a pure function of the bytes,
+/// so Node and Python hashing the same content produce the same object.
+#[napi]
+pub fn write_blob(env: Env, git_dir: String, content: Buffer) -> Result<String> {
+    match record::write_blob_at_dir(&git_dir, content.as_ref()) {
+        Ok(hash) => Ok(hash),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
+}
+
 // ── substrate read/write counters (bulk benchmark + hologit#464 finding) ──────
 
 /// A snapshot of holo-tree's process-wide tree/blob counters — read-side
@@ -898,6 +912,12 @@ pub fn diff_records(
         let mut obj = env.create_object()?;
         obj.set_named_property("path", env.create_string(&d.change.path)?)?;
         obj.set_named_property("status", env.create_string(d.change.status.as_str())?)?;
+        // `previousPath` is the rename source (old) path — non-null only for a
+        // 'renamed' change, matching Sheet.diffFrom's rename semantics.
+        match &d.change.previous_path {
+            Some(p) => obj.set_named_property("previousPath", env.create_string(p)?)?,
+            None => obj.set_named_property("previousPath", env.get_null()?)?,
+        }
         match &d.change.src_hash {
             Some(h) => obj.set_named_property("srcHash", env.create_string(h)?)?,
             None => obj.set_named_property("srcHash", env.get_null()?)?,
@@ -1138,6 +1158,14 @@ pub struct JsStageOutcome {
     pub path: String,
 }
 
+/// One attachment entry from `CoreTransaction.getAttachments`: its filename and
+/// blob hash (name → hash).
+#[napi(object)]
+pub struct JsAttachmentEntry {
+    pub name: String,
+    pub hash: String,
+}
+
 /// A live transaction the JS boundary suite drives. Holds a `!Send`
 /// `Transaction` (repo + private tree) and the opened `Sheet`s, so it is
 /// constructed and used on its owning JS thread — the thread-confinement the
@@ -1374,6 +1402,160 @@ impl CoreTransaction {
         }
         tx.mark_mutated();
         Ok(())
+    }
+
+    /// Stage attachments for a record *(mutating)*: place each `name → blobHash`
+    /// at `<recordPath>/<name>` in this transaction's live tree, so the record
+    /// and its attachments commit atomically. Write the blob first with the
+    /// top-level `writeBlob`. Marks the transaction mutated.
+    #[napi]
+    pub fn set_attachments(
+        &mut self,
+        env: Env,
+        name: String,
+        record_path: String,
+        attachments: HashMap<String, String>,
+    ) -> Result<()> {
+        let items: Vec<(String, String)> = attachments.into_iter().collect();
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets.get_mut(&name).ok_or_else(|| {
+                Error::new(Status::InvalidArg, format!("sheet {name:?} not opened"))
+            })?;
+            if let Err(err) = sheet.set_attachments(repo, tree, &record_path, &items) {
+                return Err(raise_core_error(&env, &err));
+            }
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// Stage a single attachment *(mutating)* — sugar over [`Self::set_attachments`].
+    #[napi]
+    pub fn set_attachment(
+        &mut self,
+        env: Env,
+        name: String,
+        record_path: String,
+        attachment_name: String,
+        blob_hash: String,
+    ) -> Result<()> {
+        let mut map = HashMap::new();
+        map.insert(attachment_name, blob_hash);
+        self.set_attachments(env, name, record_path, map)
+    }
+
+    /// The blob-hash map of a record's attachments (`name → hash`, sorted by
+    /// name), or `null` when the record has no attachment directory. Read-only.
+    #[napi]
+    pub fn get_attachments(
+        &mut self,
+        env: Env,
+        name: String,
+        record_path: String,
+    ) -> Result<Option<Vec<JsAttachmentEntry>>> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get(&name)
+            .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
+        match sheet.get_attachments(repo, tree, &record_path) {
+            Ok(Some(entries)) => Ok(Some(
+                entries
+                    .into_iter()
+                    .map(|(name, hash)| JsAttachmentEntry { name, hash })
+                    .collect(),
+            )),
+            Ok(None) => Ok(None),
+            Err(err) => Err(raise_core_error(&env, &err)),
+        }
+    }
+
+    /// The blob hash of a single named attachment, or `null` if absent. Read-only.
+    #[napi]
+    pub fn get_attachment(
+        &mut self,
+        env: Env,
+        name: String,
+        record_path: String,
+        attachment_name: String,
+    ) -> Result<Option<String>> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get(&name)
+            .ok_or_else(|| Error::new(Status::InvalidArg, format!("sheet {name:?} not opened")))?;
+        sheet
+            .get_attachment(repo, tree, &record_path, &attachment_name)
+            .map_err(|err| raise_core_error(&env, &err))
+    }
+
+    /// Remove a single named attachment *(mutating)*. Throws
+    /// `NotFoundError(record_not_found)` when it doesn't exist. Marks mutated.
+    #[napi]
+    pub fn delete_attachment(
+        &mut self,
+        env: Env,
+        name: String,
+        record_path: String,
+        attachment_name: String,
+    ) -> Result<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets.get_mut(&name).ok_or_else(|| {
+                Error::new(Status::InvalidArg, format!("sheet {name:?} not opened"))
+            })?;
+            if let Err(err) = sheet.delete_attachment(repo, tree, &record_path, &attachment_name) {
+                return Err(raise_core_error(&env, &err));
+            }
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// Remove all attachments for a record *(mutating)*. A no-op when the record
+    /// has no attachment directory — in that case the transaction is NOT marked
+    /// mutated (so an otherwise-empty transaction still finalizes to no commit).
+    /// Returns whether anything was removed.
+    #[napi]
+    pub fn delete_attachments(
+        &mut self,
+        env: Env,
+        name: String,
+        record_path: String,
+    ) -> Result<bool> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let removed = {
+            let (repo, tree) = tx.split();
+            let sheet = sheets.get_mut(&name).ok_or_else(|| {
+                Error::new(Status::InvalidArg, format!("sheet {name:?} not opened"))
+            })?;
+            match sheet.delete_attachments(repo, tree, &record_path) {
+                Ok(r) => r,
+                Err(err) => return Err(raise_core_error(&env, &err)),
+            }
+        };
+        if removed {
+            tx.mark_mutated();
+        }
+        Ok(removed)
     }
 
     /// List every record under the sheet's base, decoded through the format

--- a/rust/gitsheets-napi/test/sheet-attachments.mjs
+++ b/rust/gitsheets-napi/test/sheet-attachments.mjs
@@ -1,0 +1,315 @@
+// Attachment + blob-staging + diff-rename boundary suite for gitsheets-napi.
+//
+// Drives the core's attachment surface through the napi `CoreTransaction` and
+// proves parity with specs/behaviors/attachments.md + specs/api/sheet.md:
+//   - the blob-write primitive (`writeBlob` hashes to the expected git blob hash);
+//   - ATOMICITY: a record upsert + its attachment land in ONE commit (the tree
+//     the transaction commits contains both — the crux the cutover needs);
+//   - setAttachment(s) / getAttachment(s) / deleteAttachment(s) semantics
+//     (overwrite, strict single-delete, idempotent bulk-delete no-op);
+//   - diff rename detection: a moved record surfaces as status 'renamed' with
+//     `previousPath`, matching `git diff-tree -M`.
+//
+// Requires the addon to be built first: `npm run build:debug` (or `build`).
+// Run with: `npm test` (node --test).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+let binding;
+try {
+  binding = require('../binding.cjs');
+} catch (err) {
+  throw new Error(
+    `gitsheets-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
+  );
+}
+const { CoreTransaction, writeBlob, diffRecords } = binding;
+
+const CONFIG = "[gitsheet]\npath = '${{ slug }}'\nroot = 'users'\n";
+
+// A repo with `.gitsheets/users.toml` committed on `main`, HEAD symbolic to it.
+function setupRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'gitsheets-attach-'));
+  execFileSync('git', ['init', '-q', '-b', 'main', dir]);
+  execFileSync('git', ['-C', dir, 'config', 'user.name', 'Seed']);
+  execFileSync('git', ['-C', dir, 'config', 'user.email', 'seed@x.org']);
+  mkdirSync(join(dir, '.gitsheets'), { recursive: true });
+  writeFileSync(join(dir, '.gitsheets/users.toml'), CONFIG);
+  execFileSync('git', ['-C', dir, 'add', '.gitsheets/users.toml']);
+  execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'init']);
+  return { dir, gitDir: join(dir, '.git') };
+}
+
+function defaultOpts(message) {
+  return {
+    parent: undefined,
+    branch: undefined,
+    author: { name: 'Jane Doe', email: 'jane@x.org' },
+    committer: undefined,
+    message,
+    trailers: undefined,
+    timeSeconds: 1_700_000_000,
+    offsetMinutes: -300,
+  };
+}
+
+// Independently computed git blob hash: sha1("blob <len>\0<bytes>").
+function gitBlobHash(bytes) {
+  const h = createHash('sha1');
+  h.update(`blob ${bytes.length}\0`);
+  h.update(bytes);
+  return h.digest('hex');
+}
+
+test('writeBlob hashes binary bytes to the git blob hash', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const bytes = Buffer.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0xff, 0x68, 0x69]);
+    const hash = writeBlob(gitDir, bytes);
+    assert.equal(hash, gitBlobHash(bytes));
+    // git agrees too (the object is really in the ODB).
+    const catType = execFileSync('git', ['--git-dir', gitDir, 'cat-file', '-t', hash]).toString().trim();
+    assert.equal(catType, 'blob');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('record + attachment land in ONE commit (atomic staging)', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const bytes = Buffer.from('AVATAR-BYTES');
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('add jane + avatar'));
+    let attachHash;
+    let result;
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', { slug: 'jane' });
+      tx.stageUpsert('users');
+      attachHash = writeBlob(gitDir, bytes);
+      tx.setAttachment('users', 'jane', 'avatar.jpg', attachHash);
+      result = tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+
+    assert.ok(result.commitHash, 'a commit was produced');
+
+    // Exactly ONE new commit (parent count 1) — not a record commit + a separate
+    // attachment commit.
+    const parents = execFileSync('git', ['--git-dir', gitDir, 'rev-list', '--parents', '-n', '1', result.commitHash])
+      .toString().trim().split(/\s+/);
+    assert.equal(parents.length, 2, 'commit has exactly one parent');
+
+    // That single commit's tree contains BOTH the record and the attachment.
+    const tree = execFileSync('git', ['--git-dir', gitDir, 'ls-tree', '-r', result.commitHash])
+      .toString();
+    assert.match(tree, /users\/jane\.toml/, 'record file is in the commit');
+    assert.match(tree, /users\/jane\/avatar\.jpg/, 'attachment is in the SAME commit');
+
+    // And the attachment blob is exactly the bytes we wrote.
+    const blobHashInTree = execFileSync('git', ['--git-dir', gitDir, 'rev-parse', `${result.commitHash}:users/jane/avatar.jpg`])
+      .toString().trim();
+    assert.equal(blobHashInTree, attachHash);
+    assert.equal(blobHashInTree, gitBlobHash(bytes));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('setAttachments / getAttachments / overwrite / getAttachment', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const avatar = writeBlob(gitDir, Buffer.from('AV1'));
+    const cover = writeBlob(gitDir, Buffer.from('COVER'));
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('seed'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', { slug: 'jane' });
+      tx.stageUpsert('users');
+      tx.setAttachments('users', 'jane', { 'avatar.jpg': avatar, 'cover.png': cover });
+
+      // Overwrite avatar within the same tx.
+      const avatar2 = writeBlob(gitDir, Buffer.from('AV2'));
+      tx.setAttachment('users', 'jane', 'avatar.jpg', avatar2);
+
+      const map = tx.getAttachments('users', 'jane');
+      const byName = Object.fromEntries(map.map((e) => [e.name, e.hash]));
+      assert.deepEqual(Object.keys(byName).sort(), ['avatar.jpg', 'cover.png']);
+      assert.equal(byName['avatar.jpg'], avatar2, 'avatar overwritten');
+      assert.equal(byName['cover.png'], cover);
+
+      assert.equal(tx.getAttachment('users', 'jane', 'cover.png'), cover);
+      assert.equal(tx.getAttachment('users', 'jane', 'nope.png'), null);
+      tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('getAttachments returns null when a record has no attachment dir', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    const tx = CoreTransaction.begin(gitDir, defaultOpts('seed'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', { slug: 'jane' });
+      tx.stageUpsert('users');
+      assert.equal(tx.getAttachments('users', 'jane'), null);
+      tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('deleteAttachment is strict; deleteAttachments is an idempotent no-op', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    // Seed jane with two attachments.
+    let tx = CoreTransaction.begin(gitDir, defaultOpts('seed'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', { slug: 'jane' });
+      tx.stageUpsert('users');
+      tx.setAttachment('users', 'jane', 'avatar.jpg', writeBlob(gitDir, Buffer.from('A')));
+      tx.setAttachment('users', 'jane', 'cover.png', writeBlob(gitDir, Buffer.from('C')));
+      tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+
+    // Strict single-delete: missing name throws NotFoundError.
+    tx = CoreTransaction.begin(gitDir, defaultOpts('drop missing'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      // CoreTransaction is the raw addon class — it throws structured errors
+      // (code + gitsheetsClass discriminant), which the JS package maps to the
+      // typed NotFoundError.
+      assert.throws(
+        () => tx.deleteAttachment('users', 'jane', 'nope.png'),
+        (err) => err.code === 'record_not_found' && err.gitsheetsClass === 'NotFoundError',
+      );
+    } finally {
+      tx.discard();
+    }
+
+    // Existing single-delete leaves the sibling.
+    tx = CoreTransaction.begin(gitDir, defaultOpts('drop avatar'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.deleteAttachment('users', 'jane', 'avatar.jpg');
+      const names = tx.getAttachments('users', 'jane').map((e) => e.name);
+      assert.deepEqual(names, ['cover.png']);
+      tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+
+    // deleteAttachments on a record with NO dir → false, and the transaction is
+    // a no-op (no commit) since nothing else mutated.
+    tx = CoreTransaction.begin(gitDir, defaultOpts('add pat only'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', { slug: 'pat' });
+      tx.stageUpsert('users');
+      tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+    tx = CoreTransaction.begin(gitDir, defaultOpts('wipe pat attachments (none)'));
+    let result;
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      const removed = tx.deleteAttachments('users', 'pat');
+      assert.equal(removed, false, 'no dir → nothing removed');
+      result = tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+    assert.ok(!result.commitHash, 'no-op delete produces no commit');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('diffRecords detects a moved record as renamed, matching git diff-tree -M', () => {
+  const { dir, gitDir } = setupRepo();
+  try {
+    // A 4-field record whose slug drives the path; changing only the slug keeps
+    // ~75% of the lines → above git's 50% rename threshold.
+    const person = (slug) => ({
+      bio: 'A reasonably long biography line that stays put.',
+      email: 'jane@example.org',
+      name: 'Jane Q. Doe',
+      slug,
+    });
+
+    // Commit 1: jane.
+    let src;
+    let tx = CoreTransaction.begin(gitDir, defaultOpts('add jane'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', person('jane'));
+      tx.stageUpsert('users');
+      src = tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+
+    // Commit 2: move jane → jane-doe (delete old path via previousPath, write new).
+    let dst;
+    tx = CoreTransaction.begin(gitDir, defaultOpts('rename jane → jane-doe'));
+    try {
+      tx.openSheet('users', '.gitsheets/users.toml', '.', '');
+      tx.prepareUpsert('users', person('jane-doe'), 'jane');
+      tx.stageUpsert('users');
+      dst = tx.finalize();
+    } catch (err) {
+      tx.discard();
+      throw err;
+    }
+
+    const diffs = diffRecords(gitDir, src.commitHash, dst.commitHash, 'users');
+    assert.equal(diffs.length, 1, 'one rename, not add + delete');
+    const change = diffs[0];
+    assert.equal(change.status, 'renamed');
+    assert.equal(change.path, 'jane-doe');
+    assert.equal(change.previousPath, 'jane');
+    assert.ok(change.srcHash && change.dstHash);
+
+    // git diff-tree -M agrees it's a rename.
+    const gitOut = execFileSync('git', [
+      '--git-dir', gitDir, 'diff-tree', '-M', '-r', '--name-status', '--no-commit-id',
+      src.commitHash, dst.commitHash, '--', 'users',
+    ]).toString();
+    assert.ok(
+      gitOut.split('\n').some((l) => l.startsWith('R') && l.includes('users/jane.toml') && l.includes('users/jane-doe.toml')),
+      `git diff-tree -M should report a rename, got: ${JSON.stringify(gitOut)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/rust/gitsheets-py/python/gitsheets/__init__.py
+++ b/rust/gitsheets-py/python/gitsheets/__init__.py
@@ -49,6 +49,7 @@ record_read = _core.record_read
 record_write = _core.record_write
 record_delete = _core.record_delete
 record_list = _core.record_list
+write_blob = _core.write_blob
 substrate_stats = _core.substrate_stats
 substrate_reset = _core.substrate_reset
 create_patch = _core.create_patch
@@ -90,6 +91,7 @@ __all__ = [
     "record_write",
     "record_delete",
     "record_list",
+    "write_blob",
     "substrate_stats",
     "substrate_reset",
     "create_patch",
@@ -163,6 +165,38 @@ class Transaction:
 
     def clear(self, sheet: str) -> None:
         self._inner.clear(sheet)
+
+    def set_attachment(
+        self, sheet: str, record_path: str, name: str, blob_hash: str
+    ) -> None:
+        """Stage a single attachment (`name → blob_hash`) for ``record_path``."""
+        self._inner.set_attachment(sheet, record_path, name, blob_hash)
+
+    def set_attachments(
+        self, sheet: str, record_path: str, attachments: dict[str, str]
+    ) -> None:
+        """Stage attachments (a ``{name: blob_hash}`` dict) for ``record_path``."""
+        self._inner.set_attachments(sheet, record_path, attachments)
+
+    def get_attachments(
+        self, sheet: str, record_path: str
+    ) -> Optional[dict[str, str]]:
+        """The ``{name: hash}`` map of a record's attachments, or ``None``."""
+        return self._inner.get_attachments(sheet, record_path)
+
+    def get_attachment(
+        self, sheet: str, record_path: str, name: str
+    ) -> Optional[str]:
+        """The blob hash of a single named attachment, or ``None``."""
+        return self._inner.get_attachment(sheet, record_path, name)
+
+    def delete_attachment(self, sheet: str, record_path: str, name: str) -> None:
+        """Remove a single named attachment (strict — raises if absent)."""
+        self._inner.delete_attachment(sheet, record_path, name)
+
+    def delete_attachments(self, sheet: str, record_path: str) -> bool:
+        """Remove all attachments for a record (no-op when none). Returns removed?"""
+        return self._inner.delete_attachments(sheet, record_path)
 
     @property
     def parent_commit_hash(self) -> Optional[str]:

--- a/rust/gitsheets-py/src/lib.rs
+++ b/rust/gitsheets-py/src/lib.rs
@@ -607,6 +607,16 @@ fn record_list<'py>(
     }
 }
 
+/// Hash raw bytes (`content`) into the object database as a loose blob, returning
+/// its git blob hash — the core's blob-write primitive. Used to hash a binary
+/// attachment before staging it with `CoreTransaction.set_attachment(s)`. The
+/// hash is a pure function of the bytes, so Python and Node hashing the same
+/// content produce the same object.
+#[pyfunction]
+fn write_blob(py: Python<'_>, git_dir: String, content: Vec<u8>) -> PyResult<String> {
+    record::write_blob_at_dir(&git_dir, &content).map_err(|e| raise_core_error(py, &e))
+}
+
 /// A snapshot of holo-tree's process-wide tree/blob counters.
 #[pyfunction]
 fn substrate_stats(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
@@ -730,6 +740,8 @@ fn diff_records<'py>(
         let obj = PyDict::new(py);
         obj.set_item("path", d.change.path)?;
         obj.set_item("status", d.change.status.as_str())?;
+        // `previous_path` is the rename source (old) path — `None` unless renamed.
+        obj.set_item("previous_path", d.change.previous_path)?;
         obj.set_item("src_hash", d.change.src_hash)?;
         obj.set_item("dst_hash", d.change.dst_hash)?;
         obj.set_item("src", opt_value_to_py(py, d.src)?)?;
@@ -1107,6 +1119,155 @@ impl CoreTransaction {
         Ok(())
     }
 
+    /// Stage attachments for a record *(mutating)*: place each `name → blob_hash`
+    /// (a dict) at `<record_path>/<name>` in this transaction's live tree, so the
+    /// record and its attachments commit atomically. Write the blob first with
+    /// the module-level `write_blob`. Marks the transaction mutated.
+    fn set_attachments(
+        &mut self,
+        py: Python<'_>,
+        name: String,
+        record_path: String,
+        attachments: std::collections::HashMap<String, String>,
+    ) -> PyResult<()> {
+        let items: Vec<(String, String)> = attachments.into_iter().collect();
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets
+                .get_mut(&name)
+                .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+            sheet
+                .set_attachments(repo, tree, &record_path, &items)
+                .map_err(|e| raise_core_error(py, &e))?;
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// Stage a single attachment *(mutating)* — sugar over `set_attachments`.
+    fn set_attachment(
+        &mut self,
+        py: Python<'_>,
+        name: String,
+        record_path: String,
+        attachment_name: String,
+        blob_hash: String,
+    ) -> PyResult<()> {
+        let mut map = std::collections::HashMap::new();
+        map.insert(attachment_name, blob_hash);
+        self.set_attachments(py, name, record_path, map)
+    }
+
+    /// The blob-hash map of a record's attachments (`{name: hash}`), or `None`
+    /// when the record has no attachment directory. Read-only.
+    fn get_attachments<'py>(
+        &mut self,
+        py: Python<'py>,
+        name: String,
+        record_path: String,
+    ) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get(&name)
+            .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+        match sheet
+            .get_attachments(repo, tree, &record_path)
+            .map_err(|e| raise_core_error(py, &e))?
+        {
+            Some(entries) => {
+                let d = PyDict::new(py);
+                for (attachment_name, hash) in entries {
+                    d.set_item(attachment_name, hash)?;
+                }
+                Ok(Some(d))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// The blob hash of a single named attachment, or `None` if absent. Read-only.
+    fn get_attachment(
+        &mut self,
+        py: Python<'_>,
+        name: String,
+        record_path: String,
+        attachment_name: String,
+    ) -> PyResult<Option<String>> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let (repo, tree) = tx.split();
+        let sheet = sheets
+            .get(&name)
+            .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+        sheet
+            .get_attachment(repo, tree, &record_path, &attachment_name)
+            .map_err(|e| raise_core_error(py, &e))
+    }
+
+    /// Remove a single named attachment *(mutating)*. Raises
+    /// `NotFoundError` (`record_not_found`) when it doesn't exist. Marks mutated.
+    fn delete_attachment(
+        &mut self,
+        py: Python<'_>,
+        name: String,
+        record_path: String,
+        attachment_name: String,
+    ) -> PyResult<()> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        {
+            let (repo, tree) = tx.split();
+            let sheet = sheets
+                .get_mut(&name)
+                .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+            sheet
+                .delete_attachment(repo, tree, &record_path, &attachment_name)
+                .map_err(|e| raise_core_error(py, &e))?;
+        }
+        tx.mark_mutated();
+        Ok(())
+    }
+
+    /// Remove all attachments for a record *(mutating)*. A no-op when the record
+    /// has no attachment directory — in that case the transaction is NOT marked
+    /// mutated. Returns whether anything was removed.
+    fn delete_attachments(
+        &mut self,
+        py: Python<'_>,
+        name: String,
+        record_path: String,
+    ) -> PyResult<bool> {
+        let Self { inner, sheets, .. } = self;
+        let tx = inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("transaction is already finalized"))?;
+        let removed = {
+            let (repo, tree) = tx.split();
+            let sheet = sheets
+                .get_mut(&name)
+                .ok_or_else(|| PyValueError::new_err(format!("sheet {name:?} not opened")))?;
+            sheet
+                .delete_attachments(repo, tree, &record_path)
+                .map_err(|e| raise_core_error(py, &e))?
+        };
+        if removed {
+            tx.mark_mutated();
+        }
+        Ok(removed)
+    }
+
     /// The parent commit hash captured at open (`None` on a fresh repo).
     fn parent_commit_hash(&self) -> Option<String> {
         self.inner.as_ref().and_then(|t| t.parent_commit_hash())
@@ -1207,6 +1368,7 @@ fn _gitsheets(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(record_write, m)?)?;
     m.add_function(wrap_pyfunction!(record_delete, m)?)?;
     m.add_function(wrap_pyfunction!(record_list, m)?)?;
+    m.add_function(wrap_pyfunction!(write_blob, m)?)?;
     m.add_function(wrap_pyfunction!(substrate_stats, m)?)?;
     m.add_function(wrap_pyfunction!(substrate_reset, m)?)?;
     m.add_function(wrap_pyfunction!(create_patch, m)?)?;

--- a/rust/gitsheets-py/tests/_node_writer.mjs
+++ b/rust/gitsheets-py/tests/_node_writer.mjs
@@ -64,6 +64,35 @@ if (op === 'record-write') {
     tx.discard();
     throw err;
   }
+} else if (op === 'commit-attachment') {
+  // A record upsert + an attachment staged in the SAME transaction/commit. The
+  // attachment bytes are shared with the Python side (fixed binary content), so
+  // the resulting tree + commit must be byte-identical across bindings.
+  const gitDir = args[0];
+  const attachBytes = Buffer.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0xff, 0x2a]);
+  const opts = {
+    parent: undefined,
+    branch: 'refs/heads/main',
+    author: { name: 'Jane Doe', email: 'jane@x.org' },
+    committer: undefined,
+    message: 'people: add jane + avatar',
+    trailers: [{ key: 'Action', value: 'person.create' }],
+    timeSeconds: 1_700_000_000,
+    offsetMinutes: -300,
+  };
+  const tx = binding.CoreTransaction.begin(gitDir, opts);
+  try {
+    tx.openSheet('people', '.gitsheets/people.toml', '.', '');
+    tx.prepareUpsert('people', { slug: 'jane', email: 'jane@x.org' });
+    tx.stageUpsert('people');
+    const hash = binding.writeBlob(gitDir, attachBytes);
+    tx.setAttachment('people', 'jane', 'avatar.bin', hash);
+    const r = tx.finalize();
+    out({ commitHash: r.commitHash, treeHash: r.treeHash, blobHash: hash });
+  } catch (err) {
+    tx.discard();
+    throw err;
+  }
 } else if (op === 'comparator') {
   const rule = args[0];
   const a = JSON.parse(args[1]);

--- a/rust/gitsheets-py/tests/test_cross_binding.py
+++ b/rust/gitsheets-py/tests/test_cross_binding.py
@@ -149,6 +149,72 @@ def test_commit_bytes_identical_across_bindings():
         shutil.rmtree(seed, ignore_errors=True)
 
 
+def test_attachment_commit_bytes_identical_across_bindings():
+    """A record + an attachment staged in one transaction produces the same
+    commit from both bindings.
+
+    This is the attachment-staging analogue of the commit-parity proof: the
+    record upsert AND the attachment blob are placed into the SAME transaction
+    tree (atomic), and the fixed binary attachment content is shared with the
+    Node side, so the tree + commit bytes must be byte-identical. If they ever
+    diverge, either the blob hashing or the tree placement leaked something
+    binding-specific.
+    """
+    # Fixed binary attachment content — mirrored on the Node side in
+    # _node_writer.mjs (commit-attachment op).
+    attach_bytes = bytes([0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF, 0x2A])
+
+    seed = tempfile.mkdtemp(prefix="gs-seed-")
+    _git(["init", "-q", "-b", "main", seed])
+    _git(["config", "user.name", "Seed"], cwd=seed)
+    _git(["config", "user.email", "seed@x.org"], cwd=seed)
+    os.makedirs(os.path.join(seed, ".gitsheets"))
+    with open(os.path.join(seed, ".gitsheets", "people.toml"), "w") as fh:
+        fh.write("[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n")
+    _git(["add", ".gitsheets/people.toml"], cwd=seed)
+    env = dict(
+        os.environ,
+        GIT_AUTHOR_DATE="2020-01-01T00:00:00Z",
+        GIT_COMMITTER_DATE="2020-01-01T00:00:00Z",
+    )
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "init"], cwd=seed, check=True, capture_output=True, env=env
+    )
+
+    py_dir = tempfile.mkdtemp(prefix="gs-py-") + "/repo"
+    node_dir = tempfile.mkdtemp(prefix="gs-node-") + "/repo"
+    try:
+        shutil.copytree(seed, py_dir)
+        shutil.copytree(seed, node_dir)
+
+        py_git_dir = os.path.join(py_dir, ".git")
+        with gitsheets.transact(
+            py_git_dir,
+            "people: add jane + avatar",
+            1_700_000_000,
+            offset_minutes=-300,
+            author=("Jane Doe", "jane@x.org"),
+            branch="refs/heads/main",
+            trailers=[("Action", "person.create")],
+        ) as tx:
+            tx.open_sheet("people", ".gitsheets/people.toml")
+            tx.upsert("people", {"slug": "jane", "email": "jane@x.org"})
+            py_blob = gitsheets.write_blob(py_git_dir, attach_bytes)
+            tx.set_attachment("people", "jane", "avatar.bin", py_blob)
+        py_result = tx.result
+
+        node = _run_node("commit-attachment", os.path.join(node_dir, ".git"))
+
+        assert py_result["commit_hash"] is not None
+        assert py_blob == node["blobHash"], "attachment blob bytes diverged across bindings"
+        assert py_result["tree_hash"] == node["treeHash"], "tree bytes diverged across bindings"
+        assert py_result["commit_hash"] == node["commitHash"], "commit bytes diverged across bindings"
+    finally:
+        shutil.rmtree(os.path.dirname(py_dir), ignore_errors=True)
+        shutil.rmtree(os.path.dirname(node_dir), ignore_errors=True)
+        shutil.rmtree(seed, ignore_errors=True)
+
+
 def test_embedded_engine_comparator_identical_across_bindings():
     """The same definition-embedded JS snippet yields identical results."""
     rule = "return (a.name > b.name) - (a.name < b.name)"

--- a/rust/gitsheets-py/tests/test_smoke.py
+++ b/rust/gitsheets-py/tests/test_smoke.py
@@ -235,6 +235,104 @@ def test_create_patch_and_merge_patch():
     assert merged == {"slug": "jane"}
 
 
+# ── attachments + blob-write primitive ──────────────────────────────────────────
+
+
+def _git_blob_hash(data: bytes) -> str:
+    import hashlib
+
+    h = hashlib.sha1()
+    h.update(b"blob %d\0" % len(data))
+    h.update(data)
+    return h.hexdigest()
+
+
+def test_write_blob_hashes_to_git_blob_hash(fresh_repo):
+    _, git_dir = fresh_repo
+    data = bytes([0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF])
+    got = gitsheets.write_blob(git_dir, data)
+    assert got == _git_blob_hash(data)
+
+
+def test_record_and_attachment_commit_atomically(seeded_repo):
+    d, git_dir = seeded_repo
+    data = b"AVATAR-BYTES"
+    with gitsheets.transact(
+        git_dir, "add jane + avatar", 1_700_000_000, author=("J", "j@x.org"), branch="refs/heads/main"
+    ) as tx:
+        tx.open_sheet("people", ".gitsheets/people.toml")
+        tx.upsert("people", {"slug": "jane"})
+        blob = gitsheets.write_blob(git_dir, data)
+        tx.set_attachment("people", "jane", "avatar.bin", blob)
+    commit = tx.result["commit_hash"]
+    assert commit is not None
+
+    # ONE commit contains BOTH the record and the attachment.
+    tree = subprocess.run(
+        ["git", "--git-dir", git_dir, "ls-tree", "-r", commit], check=True, capture_output=True
+    ).stdout.decode()
+    assert "people/jane.toml" in tree
+    assert "people/jane/avatar.bin" in tree
+    # The staged attachment blob is exactly the bytes we wrote.
+    in_tree = subprocess.run(
+        ["git", "--git-dir", git_dir, "rev-parse", f"{commit}:people/jane/avatar.bin"],
+        check=True, capture_output=True,
+    ).stdout.decode().strip()
+    assert in_tree == blob == _git_blob_hash(data)
+
+
+def test_attachment_get_delete_surface(seeded_repo):
+    d, git_dir = seeded_repo
+    with gitsheets.transact(
+        git_dir, "seed", 1_700_000_000, author=("J", "j@x.org"), branch="refs/heads/main"
+    ) as tx:
+        tx.open_sheet("people", ".gitsheets/people.toml")
+        tx.upsert("people", {"slug": "jane"})
+        a = gitsheets.write_blob(git_dir, b"A")
+        c = gitsheets.write_blob(git_dir, b"C")
+        tx.set_attachments("people", "jane", {"avatar.jpg": a, "cover.png": c})
+        assert tx.get_attachments("people", "jane") == {"avatar.jpg": a, "cover.png": c}
+        assert tx.get_attachment("people", "jane", "avatar.jpg") == a
+        assert tx.get_attachment("people", "jane", "nope") is None
+        # Strict single-delete of a missing attachment raises.
+        with pytest.raises(gitsheets.NotFoundError):
+            tx.delete_attachment("people", "jane", "nope.png")
+        tx.delete_attachment("people", "jane", "avatar.jpg")
+        assert list(tx.get_attachments("people", "jane").keys()) == ["cover.png"]
+
+
+def test_diff_detects_rename(seeded_repo):
+    d, git_dir = seeded_repo
+
+    def person(slug):
+        return {
+            "bio": "A reasonably long biography line that stays put.",
+            "email": "jane@example.org",
+            "name": "Jane Q. Doe",
+            "slug": slug,
+        }
+
+    with gitsheets.transact(
+        git_dir, "add jane", 1_700_000_000, author=("J", "j@x.org"), branch="refs/heads/main"
+    ) as tx:
+        tx.open_sheet("people", ".gitsheets/people.toml")
+        tx.upsert("people", person("jane"))
+    src = tx.result["commit_hash"]
+
+    with gitsheets.transact(
+        git_dir, "rename", 1_700_000_001, author=("J", "j@x.org"), branch="refs/heads/main"
+    ) as tx:
+        tx.open_sheet("people", ".gitsheets/people.toml")
+        tx.upsert("people", person("jane-doe"), previous_path="jane")
+    dst = tx.result["commit_hash"]
+
+    diffs = gitsheets.diff_records(git_dir, src, dst, "people")
+    assert len(diffs) == 1
+    assert diffs[0]["status"] == "renamed"
+    assert diffs[0]["path"] == "jane-doe"
+    assert diffs[0]["previous_path"] == "jane"
+
+
 # ── typed error mapping ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes the core capability the Node cutover ([`node-binding-thin`](https://github.com/JarvusInnovations/gitsheets/blob/develop/plans/node-binding-thin.md)) exposed as missing, per [`plans/attachment-staging-core.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/plans/attachment-staging-core.md) and part of the holo-tree/Rust-core evolution (#127): **staging arbitrary blobs (attachments) atomically inside a transaction**, plus the blob-write primitive and the `diffFrom` **rename detection** the core diff lacked.

## Atomic attachment staging (the crux)

`CoreTransaction` owns the live `MutableTree` its records write into. The new `Sheet::set_attachments` places each attachment blob at `<base>/<recordPath>/<name>` **in that same live tree, before `finalize`** — so a record upsert and its attachments land in **one commit**, not two. The blob-write primitive `record::write_blob(bytes) -> hash` hashes content into the ODB (content-addressed via holo-tree's `gix::Repository::write_blob`); `set_attachments` then places the already-written blob by hash into the tree. Reads (`get_attachment(s)`), the strict single-delete (`record_not_found`), the idempotent bulk-delete no-op, and the existing cascade-on-record-delete all match `specs/behaviors/attachments.md`. Exposed on **both** napi (`writeBlob` + `CoreTransaction.setAttachment(s)/getAttachment(s)/deleteAttachment(s)`) and pyo3.

## Diff rename detection (git-parity)

`diff_record_changes` now runs gix `diff_tree_to_tree` with an **explicit** `Rewrites::default()` — 50% similarity, renames only, no copies: exactly `git diff-tree -M`'s default, and independent of any repo `diff.renames` config — over the sheet's base subtrees. A moved record surfaces as `RecordStatus::Renamed` with `previous_path` (source) and `path` (destination, matching `Sheet.diffFrom`'s `canonicalPath = dstPath`), restoring the `'renamed'` `DiffStatus`. Parity is asserted against a **live `git diff-tree -M`** oracle in both the Rust core tests and the napi boundary suite; both agree on the rename and on the add+delete (dissimilar) case.

## Cross-binding proof

`test_cross_binding.py::test_attachment_commit_bytes_identical_across_bindings`: a record + a fixed-bytes attachment staged in one transaction via **Python** and via **Node** (through `_node_writer.mjs`) produce a **byte-identical blob hash, tree hash, and commit hash**.

## Validation (all run, all green)

- `cargo test -p gitsheets-core` — 159 pass (incl. atomicity, write_blob→git-hash, rename+git-parity, attachment surface).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- napi `npm test` — 100 pass (incl. the 6-test `sheet-attachments.mjs`).
- py `pytest tests/` — 26 pass (incl. the cross-binding attachment byte-identical proof).

## holo-tree finding (upstream, not worked around)

holo-tree has no place-a-blob-by-hash primitive; `set_attachments` reads the (just-written) blob by hash and re-places it via `write_child_bytes` (content-addressed → byte-identical). A `MutableTree::write_child_hash(path, hash, mode)` would avoid the re-read for large attachments — noted as an upstream hardening opportunity, not blocking.

The Node re-thin that consumes this surface stays in `node-binding-thin`; `packages/gitsheets` is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
