### PR TITLE
ci(release): prebuild + trusted-publish machinery for @gitsheets/core-napi

### DIFF
--- a/.github/workflows/core-napi.yml
+++ b/.github/workflows/core-napi.yml
@@ -1,0 +1,168 @@
+# Build + publish the @gitsheets/core-napi napi addon with per-platform prebuilds.
+#
+# This ships the gitsheets-core FFI boundary as prebuilt binaries so a consumer
+# `npm install gitsheets` works with NO Rust toolchain: the main package pulls
+# the matching @gitsheets/core-napi-<platform> package via optionalDependencies.
+#
+# Each target builds NATIVELY on its matching runner where possible:
+#   x86_64-unknown-linux-gnu  → ubuntu-latest
+#   aarch64-unknown-linux-gnu → ubuntu-24.04-arm  (Arm runner)
+#   aarch64-apple-darwin      → macos-latest       (Apple Silicon runner)
+#   x86_64-pc-windows-msvc    → windows-latest
+# and CROSS-builds the two that can't run on any available runner:
+#   x86_64-unknown-linux-musl → ubuntu-latest (zig cc cross-link) — build only
+#   x86_64-apple-darwin       → macos-latest  (cross)             — build only
+#
+# Triggers:
+#   - pull_request touching rust/**            → build + smoke-test the natives (no publish)
+#   - push of a `core-napi-v*` tag             → build, then publish to npm
+#   - workflow_dispatch                        → manual build
+#
+# Publish auth: npm TRUSTED PUBLISHING (OIDC) — no token, matching the repo's
+# publish-npm.yml. Each of the 7 packages (@gitsheets/core-napi + the 6 platform
+# packages) must already exist on npm AND have a trusted publisher configured
+# for this repo + this workflow. One-time bootstrap (a package can't get a
+# trusted publisher until it exists): publish an early version of all 7 manually,
+# then add the trusted publishers. See rust/gitsheets-napi/README.md "Publishing".
+#
+# The release marker is the `core-napi-v*` git tag itself; napi prepublish runs
+# with --skip-gh-release so it does NOT create a bare `v<version>` GitHub release
+# + tag (those collide with the gitsheets JS-package `v*` release namespace that
+# publish-npm.yml owns).
+name: core-napi
+
+on:
+  pull_request:
+    paths:
+      - 'rust/**'
+      - '.github/workflows/core-napi.yml'
+  push:
+    tags:
+      - 'core-napi-v*'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: rust/gitsheets-napi
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Native — build + smoke-test on a matching runner.
+          - target: x86_64-unknown-linux-gnu
+            host: ubuntu-latest
+            test: true
+          - target: aarch64-unknown-linux-gnu
+            host: ubuntu-24.04-arm
+            test: true
+          - target: aarch64-apple-darwin
+            host: macos-latest
+            test: true
+          - target: x86_64-pc-windows-msvc
+            host: windows-latest
+            test: true
+          # Cross — build only; the .node can't run on the host arch/libc, so
+          # the smoke test is skipped (the logic is covered by the native runs).
+          - target: x86_64-unknown-linux-musl
+            host: ubuntu-latest
+            zig: true
+            test: false
+          - target: x86_64-apple-darwin
+            host: macos-latest
+            test: false
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      # zig cc bundles libc/libgcc and links musl cleanly — napi-rs's
+      # recommended cross path. (musl-gcc fails on `libgcc_s.so.1`.)
+      - name: Setup zig (musl cross-link)
+        if: ${{ matrix.zig }}
+        working-directory: ${{ runner.temp }}
+        run: |
+          ZIG=zig-linux-x86_64-0.13.0
+          curl -fsSL "https://ziglang.org/download/0.13.0/${ZIG}.tar.xz" | tar -xJ
+          echo "${{ runner.temp }}/${ZIG}" >> "$GITHUB_PATH"
+
+      - name: Configure git identity (the smoke test commits to scratch repos)
+        if: ${{ matrix.test }}
+        run: |
+          git config --global user.name "gitsheets CI"
+          git config --global user.email "ci@gitsheets.local"
+
+      - run: npm install
+
+      - name: Build (release)
+        run: npm run build -- --target ${{ matrix.target }}${{ matrix.zig && ' --zig' || '' }}
+
+      - name: Smoke test
+        if: ${{ matrix.test }}
+        run: npm test
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bindings-${{ matrix.target }}
+          path: rust/gitsheets-napi/*.node
+          if-no-files-found: error
+
+  publish:
+    name: publish @gitsheets/core-napi
+    if: ${{ startsWith(github.ref, 'refs/tags/core-napi-v') }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # no GitHub release is created (see --skip-gh-release)
+      id-token: write   # npm provenance attestation + OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24' # recent npm for OIDC trusted publishing
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install
+
+      - name: Set version from tag (e.g. core-napi-v0.2.0 → 0.2.0)
+        run: |
+          VERSION="${GITHUB_REF_NAME#core-napi-v}"
+          export VERSION
+          npm version --no-git-tag-version "$VERSION"
+          npx napi version
+          # `napi version` updates the npm/<triple> package versions but NOT the
+          # root optionalDependencies — pin those to the release version too, or
+          # the main package would resolve stale platform packages.
+          node -e "const fs=require('fs'),p=require('./package.json');for(const k in p.optionalDependencies)p.optionalDependencies[k]=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+
+      - name: Collect prebuilt .node artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: rust/gitsheets-napi/artifacts
+          pattern: bindings-*
+          merge-multiple: true
+
+      - name: Distribute artifacts into npm/<triple>/
+        run: npx napi artifacts --dir artifacts
+
+      - name: Publish (platform packages via prepublishOnly hook, then main)
+        # Tokenless: OIDC trusted publishing. Requires all 7 packages to exist
+        # with a trusted publisher configured (see the bootstrap note up top).
+        # prepublishOnly runs `napi prepublish ... --skip-gh-release`, so no
+        # GitHub release/tag is created and no GITHUB_TOKEN is needed.
+        run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1698,7 +1698,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gitsheets/core-napi": "^0.0.0",
+        "@gitsheets/core-napi": "^0.1.0",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "rfc6902": "^5.2.0",
@@ -1742,7 +1742,7 @@
     },
     "rust/gitsheets-napi": {
       "name": "@gitsheets/core-napi",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -1753,6 +1753,14 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@gitsheets/core-napi-darwin-arm64": "0.1.0",
+        "@gitsheets/core-napi-darwin-x64": "0.1.0",
+        "@gitsheets/core-napi-linux-arm64-gnu": "0.1.0",
+        "@gitsheets/core-napi-linux-x64-gnu": "0.1.0",
+        "@gitsheets/core-napi-linux-x64-musl": "0.1.0",
+        "@gitsheets/core-napi-win32-x64-msvc": "0.1.0"
       }
     }
   }

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
-    "@gitsheets/core-napi": "^0.0.0",
+    "@gitsheets/core-napi": "^0.1.0",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "rfc6902": "^5.2.0",

--- a/plans/addon-prebuild-publish.md
+++ b/plans/addon-prebuild-publish.md
@@ -5,6 +5,7 @@ specs:
   - specs/rust-core.md
   - specs/architecture.md
 issues: [127]
+pr: 218
 ---
 
 # Plan: per-platform addon prebuild + npm publish (release track)
@@ -58,8 +59,57 @@ same playbook) and any engine changes.
 
 ## Notes
 
-(Populated at closeout.)
+**Status: machinery scaffolded + build matrix proven in CI; the one-time manual
+bootstrap (first publish + per-package trusted-publisher config) is still pending
+— that's the human's step, so this plan stays `in-progress`.**
+
+**Version scheme.** `@gitsheets/core-napi` carries its own semver in its own
+`core-napi-v*` git-tag namespace, decoupled from the `gitsheets` JS package's
+`v*` tags (mirrors holo-tree's `holo-tree-v*`). Starts at `0.1.0`.
+`packages/gitsheets` depends on it via `^0.1.0` — a caret range so a compatible
+addon release is picked up without a lockstep bump. In-repo, npm workspaces
+resolve the dep to the workspace member (symlink), so dev/CI never touch the
+registry; only external `npm install gitsheets` consumers pull the published
+platform packages.
+
+**What's scaffolded:**
+
+- `rust/gitsheets-napi/package.json` — version `0.1.0` (was `0.0.0`, private
+  removed), six `optionalDependencies` platform packages pinned to `0.1.0`,
+  `prepublishOnly: napi prepublish -t npm --skip-gh-release`, `artifacts` +
+  `version` (`napi version`) scripts. `napi.triples` unchanged (the 6).
+- `rust/gitsheets-napi/npm/<triple>/` — six platform-package manifests generated
+  by `napi create-npm-dir -t .` (correct `os`/`cpu`/`libc`/`main`). Committed;
+  their `.node` payloads are git-ignored and dropped in at publish time.
+- `.github/workflows/core-napi.yml` — 6-triple build matrix (native
+  build+smoke-test on matching runners incl. `ubuntu-24.04-arm`; musl via
+  `--zig`, darwin-x64 cross → build-only), uploads `bindings-*` artifacts. A
+  **tag-gated** `publish` job (`if: startsWith(github.ref,
+  'refs/tags/core-napi-v')`) does `napi version` + pins root
+  `optionalDependencies` + `napi artifacts` + `npm publish --provenance --access
+  public` over **OIDC trusted publishing** (`--skip-gh-release`, no token).
+  Triggers: `pull_request` on `rust/**` + `workflow_dispatch` (build only);
+  publish only on `core-napi-v*` tags. Action tags pinned to resolvable majors
+  (`checkout@v7`, `setup-node@v6`, `upload-artifact@v7`, `download-artifact@v8`,
+  `rust-cache@v2`, `rust-toolchain@stable`).
+- `packages/gitsheets/package.json` — dep bumped `^0.0.0` → `^0.1.0`; root
+  lockfile regenerated (`npm ci` verified green, workspace symlink intact, the
+  not-yet-published optional platform deps are skipped gracefully).
 
 ## Follow-ups
 
-(Populated at closeout.)
+- **[HUMAN] One-time bootstrap** (see `rust/gitsheets-napi/README.md`
+  "Publishing"): (0) ensure the `@gitsheets` npm scope exists and you're a member;
+  (1) run the `core-napi` workflow and download the six `bindings-*` artifacts;
+  (2) `npm login` as a `@gitsheets` member, `npx napi artifacts --dir <dir>`,
+  publish the six `npm/*/` platform packages then the main package
+  (`--ignore-scripts`) at `0.1.0`; (3) enable trusted publishing on npmjs.com for
+  **each** of the seven packages → GitHub Actions, repo
+  `JarvusInnovations/gitsheets`, workflow `core-napi.yml`. After that, releases
+  are `git tag core-napi-v<x> && git push` → CI publishes tokenlessly.
+- Once the addon is published, confirm a clean `npm install gitsheets` on a
+  supported platform resolves the prebuilt addon with NO Rust toolchain and
+  round-trips an upsert→commit (Validation item 2).
+- Consider a build-from-source fallback (`postinstall`) for platforms without a
+  prebuilt binary (optional; unsupported platforms currently get a clear
+  `ConfigError` from the loader).

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -5,6 +5,7 @@
 node_modules/
 
 # Compiled native addons — built per-platform in CI, never committed. The
-# generated index.js / index.d.ts loader+types ARE committed; only the .node
-# binaries are ignored.
+# generated index.js / index.d.ts loader+types ARE committed, and the
+# gitsheets-napi/npm/<triple>/ platform package manifests ARE committed; only
+# the .node binaries that land in them are ignored.
 *.node

--- a/rust/gitsheets-napi/README.md
+++ b/rust/gitsheets-napi/README.md
@@ -1,0 +1,115 @@
+# @gitsheets/core-napi
+
+Node.js native binding for [`gitsheets-core`](../gitsheets-core) — the FFI
+marshalling boundary between the published `gitsheets` npm package (a thin
+TypeScript shell) and the Rust engine that owns the bytes: TOML parse/serialize,
+canonical normalization, path templates, JSON-Schema validation, the embedded
+JS engine, ICU collation, record CRUD / query / index, diff/patch, attachments,
+and the `Sheet`/`Transaction`/`Store` state machine. Tree/blob/commit ops run on
+`holo-tree` (gitoxide) inside the core.
+
+This package exists so that a consumer can `npm install gitsheets` and get a
+working native addon **without a Rust toolchain** — the matching prebuilt binary
+is pulled in as an `optionalDependency` platform package.
+
+## Building (in-repo development)
+
+Requires a Rust toolchain and `@napi-rs/cli` (a devDependency):
+
+```sh
+npm install
+npm run build:debug   # or: npm run build   (release)
+npm test              # node --test against scratch git repos
+```
+
+`napi build` emits `gitsheets-core.<triple>.node`. The generated `index.js`
+loader, `index.d.ts` types, and `binding.cjs` wrapper **are committed**; only the
+`.node` binaries are git-ignored (built per-platform in CI). The `npm/<triple>/`
+platform-package manifests are committed too; their `.node` payloads are dropped
+in at publish time.
+
+In-repo, the JS package resolves this binding through the npm-workspace symlink
+(`node_modules/@gitsheets/core-napi → rust/gitsheets-napi`) and loads the locally
+built `.node` next to `index.js`; the `optionalDependencies` platform packages
+are only used by external consumers.
+
+## Publishing / prebuilds
+
+Published as the scoped package **`@gitsheets/core-napi`** with per-platform
+prebuilt binaries shipped as `optionalDependencies`:
+
+| Platform package | Triple | Built on | Smoke-tested |
+| --- | --- | --- | --- |
+| `@gitsheets/core-napi-linux-x64-gnu` | `x86_64-unknown-linux-gnu` | ubuntu-latest | ✓ native |
+| `@gitsheets/core-napi-linux-arm64-gnu` | `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | ✓ native |
+| `@gitsheets/core-napi-linux-x64-musl` | `x86_64-unknown-linux-musl` | ubuntu-latest (zig cross) | build-only |
+| `@gitsheets/core-napi-darwin-arm64` | `aarch64-apple-darwin` | macos-latest | ✓ native |
+| `@gitsheets/core-napi-darwin-x64` | `x86_64-apple-darwin` | macos-latest (cross) | build-only |
+| `@gitsheets/core-napi-win32-x64-msvc` | `x86_64-pc-windows-msvc` | windows-latest | ✓ native |
+
+Native targets build + smoke-test on a matching runner; cross targets (musl,
+darwin-x64) build only, since their `.node` can't run on the host arch/libc (the
+logic is covered by the native runs). The `.github/workflows/core-napi.yml`
+workflow builds all six on every PR touching `rust/**`, and on a `core-napi-v*`
+tag it builds then publishes.
+
+Auth is **npm trusted publishing (OIDC)** — no tokens, matching the repo's
+`publish-npm.yml`. Trusted publishing is configured *per package*, and a package
+can't get a trusted publisher until it exists — so the seven packages
+(the main package + six platform packages) need a **one-time manual bootstrap**
+before automated releases work.
+
+### Prerequisite: the `@gitsheets` npm scope
+
+The `@gitsheets` org/scope must exist on npmjs.com and the person running the
+bootstrap must be a member with publish rights. (One-time human setup.)
+
+### One-time bootstrap (manual first publish, then configure trusted publishing)
+
+The seven packages all start at an early version (currently `0.1.0`). They must
+exist on npm before trusted publishing can be turned on.
+
+1. **Get the prebuilt binaries.** Run the `core-napi` workflow (open a PR
+   touching `rust/**`, or trigger `workflow_dispatch`) and download its six
+   `bindings-*` artifacts — they hold the `.node` for each platform. A single
+   machine can't build all six natively, so use the CI artifacts.
+
+2. **Publish all seven manually**, logged in as a `@gitsheets` org member
+   (`npm login`):
+
+   ```sh
+   cd rust/gitsheets-napi
+   npm install
+   npx napi artifacts --dir <downloaded-artifacts-dir>   # → npm/<triple>/*.node
+   # platform packages first, then the main package:
+   for d in npm/*/ ; do ( cd "$d" && npm publish --access public ); done
+   npm publish --access public --ignore-scripts          # main; skip the napi
+                                                         # prepublish hook
+   ```
+
+3. **Turn on trusted publishing** on npmjs.com for **each** of the seven packages
+   → package Settings → Trusted Publisher → GitHub Actions, repo
+   `JarvusInnovations/gitsheets`, workflow `core-napi.yml`.
+
+### Releases (after bootstrap — fully automated, tokenless)
+
+```sh
+git tag core-napi-v0.1.1 && git push origin core-napi-v0.1.1
+```
+
+The tag drives the published version; CI builds all six platforms, then publishes
+via OIDC (provenance). No secret needed. The `core-napi-v*` tag is the release
+marker — napi runs with `--skip-gh-release` so it does **not** create a bare
+`v<version>` GitHub release/tag (which would collide with the `gitsheets`
+JS-package `v*` release namespace owned by `publish-npm.yml`).
+
+**Version scheme.** `@gitsheets/core-napi` carries its own semver in its own
+`core-napi-v*` tag namespace, decoupled from the `gitsheets` package's `v*` tags.
+`packages/gitsheets` depends on it via a caret range (`^0.1.0`) so a compatible
+addon release is picked up without a lockstep bump; widen the range deliberately
+when the addon takes a breaking major.
+
+To add or drop a platform later, edit `napi.triples.additional` +
+`optionalDependencies` in `package.json`, run `npx napi create-npm-dir -t .`,
+add the matching matrix entry in the workflow, and (since it's a new package)
+bootstrap + trust that one package too.

--- a/rust/gitsheets-napi/npm/darwin-arm64/README.md
+++ b/rust/gitsheets-napi/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `@gitsheets/core-napi-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `@gitsheets/core-napi`

--- a/rust/gitsheets-napi/npm/darwin-arm64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-arm64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@gitsheets/core-napi-darwin-arm64",
+  "version": "0.1.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "gitsheets-core.darwin-arm64.node",
+  "files": [
+    "gitsheets-core.darwin-arm64.node"
+  ],
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "rust/gitsheets-napi"
+  }
+}

--- a/rust/gitsheets-napi/npm/darwin-x64/README.md
+++ b/rust/gitsheets-napi/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@gitsheets/core-napi-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `@gitsheets/core-napi`

--- a/rust/gitsheets-napi/npm/darwin-x64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-x64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@gitsheets/core-napi-darwin-x64",
+  "version": "0.1.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "gitsheets-core.darwin-x64.node",
+  "files": [
+    "gitsheets-core.darwin-x64.node"
+  ],
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "rust/gitsheets-napi"
+  }
+}

--- a/rust/gitsheets-napi/npm/linux-arm64-gnu/README.md
+++ b/rust/gitsheets-napi/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@gitsheets/core-napi-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@gitsheets/core-napi`

--- a/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@gitsheets/core-napi-linux-arm64-gnu",
+  "version": "0.1.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "gitsheets-core.linux-arm64-gnu.node",
+  "files": [
+    "gitsheets-core.linux-arm64-gnu.node"
+  ],
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "rust/gitsheets-napi"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/rust/gitsheets-napi/npm/linux-x64-gnu/README.md
+++ b/rust/gitsheets-napi/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@gitsheets/core-napi-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `@gitsheets/core-napi`

--- a/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@gitsheets/core-napi-linux-x64-gnu",
+  "version": "0.1.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "gitsheets-core.linux-x64-gnu.node",
+  "files": [
+    "gitsheets-core.linux-x64-gnu.node"
+  ],
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "rust/gitsheets-napi"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/rust/gitsheets-napi/npm/linux-x64-musl/README.md
+++ b/rust/gitsheets-napi/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@gitsheets/core-napi-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@gitsheets/core-napi`

--- a/rust/gitsheets-napi/npm/linux-x64-musl/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-musl/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@gitsheets/core-napi-linux-x64-musl",
+  "version": "0.1.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "gitsheets-core.linux-x64-musl.node",
+  "files": [
+    "gitsheets-core.linux-x64-musl.node"
+  ],
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "rust/gitsheets-napi"
+  },
+  "libc": [
+    "musl"
+  ]
+}

--- a/rust/gitsheets-napi/npm/win32-x64-msvc/README.md
+++ b/rust/gitsheets-napi/npm/win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@gitsheets/core-napi-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** binary for `@gitsheets/core-napi`

--- a/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
+++ b/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@gitsheets/core-napi-win32-x64-msvc",
+  "version": "0.1.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "gitsheets-core.win32-x64-msvc.node",
+  "files": [
+    "gitsheets-core.win32-x64-msvc.node"
+  ],
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/gitsheets.git",
+    "directory": "rust/gitsheets-napi"
+  }
+}

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gitsheets/core-napi",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
   "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
   "main": "binding.cjs",
   "types": "index.d.ts",
@@ -33,11 +32,22 @@
     "index.js",
     "index.d.ts"
   ],
+  "optionalDependencies": {
+    "@gitsheets/core-napi-linux-x64-gnu": "0.1.0",
+    "@gitsheets/core-napi-linux-arm64-gnu": "0.1.0",
+    "@gitsheets/core-napi-linux-x64-musl": "0.1.0",
+    "@gitsheets/core-napi-darwin-arm64": "0.1.0",
+    "@gitsheets/core-napi-darwin-x64": "0.1.0",
+    "@gitsheets/core-napi-win32-x64-msvc": "0.1.0"
+  },
   "scripts": {
+    "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
+    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "node --test test/roundtrip.mjs test/errors.mjs test/canonical.mjs test/path-template.mjs test/validation-parity.mjs test/engine-parity.mjs test/collator-parity.mjs test/record-crud.mjs test/record-query.mjs test/record-index.mjs test/sheet-store.mjs test/sheet-markdown.mjs test/sheet-attachments.mjs",
-    "bench": "node bench/query-bench.mjs"
+    "bench": "node bench/query-bench.mjs",
+    "version": "napi version"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",


### PR DESCRIPTION
## What

Scaffolds the release-engineering track so a consumer can `npm install gitsheets` and get a prebuilt `@gitsheets/core-napi` addon with **no Rust toolchain**, mirroring the proven `@hologit/holo-tree` playbook. Implements `plans/addon-prebuild-publish.md` (stays `in-progress` — the one-time publish bootstrap is the human's step).

**Nothing was published; no npm-registry write was performed.** The publish job is tag-gated and does not run on this PR.

### Scaffolded
- **`rust/gitsheets-napi/package.json`** — version `0.0.0` → `0.1.0`, drop `private`, add the six platform `optionalDependencies` (pinned `0.1.0`), `prepublishOnly: napi prepublish -t npm --skip-gh-release`, plus `artifacts` + `version` (`napi version`) scripts. `napi.triples` unchanged.
- **`rust/gitsheets-napi/npm/<triple>/`** — six platform-package manifests generated by `npx napi create-npm-dir -t .` (correct `os`/`cpu`/`libc`/`main`).
- **`.github/workflows/core-napi.yml`** — 6-triple build matrix (native build+smoke-test on matching runners incl. `ubuntu-24.04-arm`; musl via `--zig`, darwin-x64 cross → build-only), uploads `bindings-*` artifacts. A **tag-gated** `publish` job (`if: refs/tags/core-napi-v*`) does `napi version` + pins root `optionalDependencies` + `napi artifacts` + `npm publish --provenance --access public` over **OIDC trusted publishing** (`--skip-gh-release`, no token). Build triggers on `pull_request` touching `rust/**` + `workflow_dispatch`; publish only on `core-napi-v*` tags.
- **`packages/gitsheets/package.json`** — dep `@gitsheets/core-napi` `^0.0.0` → `^0.1.0`; lockfile regenerated. npm workspaces still resolve to the workspace member in-repo (symlink), so dev/CI never touch the registry.
- **`rust/gitsheets-napi/README.md`** — publishing guide + one-time bootstrap recipe.

### Version scheme
`@gitsheets/core-napi` carries its own semver in its own `core-napi-v*` git-tag namespace, decoupled from the `gitsheets` JS package's `v*` tags (mirrors `holo-tree-v*`). Starts at `0.1.0`; `packages/gitsheets` tracks it via a caret range.

### Local validation
- napi boundary smoke test: **101/101 pass** (release build).
- `gitsheets` vitest suite (the wiring-sensitive one): **288/288 pass**; `npm run type-check` clean; `npm ci` green with the workspace symlink intact and the not-yet-published optional platform deps skipped gracefully.
- The 6-triple matrix result on this PR is in the `core-napi` check below; `ci.yml` + `rust-core.yml` unaffected.

## Manual bootstrap the human must run (handoff)

The publish machinery can't self-start: a package can't get a trusted publisher until it exists on npm. One time only:

0. **Ensure the `@gitsheets` npm scope exists** and you're a member with publish rights.
1. **Get binaries** — run the `core-napi` workflow (this PR, or `workflow_dispatch`) and download its six `bindings-*` artifacts.
2. **First manual publish** — `npm login` as a `@gitsheets` member, then in `rust/gitsheets-napi/`:
   ```sh
   npm install
   npx napi artifacts --dir <downloaded-artifacts-dir>   # → npm/<triple>/*.node
   for d in npm/*/ ; do ( cd "$d" && npm publish --access public ); done
   npm publish --access public --ignore-scripts          # main package (0.1.0)
   ```
3. **Enable trusted publishing** on npmjs.com for **each** of the seven packages → Settings → Trusted Publisher → GitHub Actions, repo `JarvusInnovations/gitsheets`, workflow `core-napi.yml`.

After that, releases are tokenless: `git tag core-napi-v<x> && git push origin core-napi-v<x>` → CI builds all six platforms and publishes via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd