### PR TITLE
feat(axi): bulk upsert + patch, side-channel query exports, config/working-tree hints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1822,6 +1822,7 @@
       "dependencies": {
         "@toon-format/toon": "^2.2.0",
         "axi-sdk-js": "^0.1.6",
+        "csv-stringify": "^6.8.0",
         "gitsheets": "*"
       },
       "bin": {

--- a/packages/gitsheets-axi/package.json
+++ b/packages/gitsheets-axi/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@toon-format/toon": "^2.2.0",
     "axi-sdk-js": "^0.1.6",
+    "csv-stringify": "^6.8.0",
     "gitsheets": "*"
   },
   "devDependencies": {

--- a/packages/gitsheets-axi/src/commands/delete.ts
+++ b/packages/gitsheets-axi/src/commands/delete.ts
@@ -4,6 +4,7 @@ import { NotFoundError, RECORD_PATH_KEY } from 'gitsheets';
 import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
 import { renderObject } from '../output/render.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
 
 export const DELETE_HELP = `usage: gitsheets-axi delete <sheet> <path> [--prefix p] [--message m]
 flags[2]:
@@ -78,15 +79,11 @@ export async function deleteCommand(
   const target = stripExtension(flags.path);
 
   const repo = await ctx.repo();
-  let sheet;
-  try {
-    sheet = await repo.openSheet(
-      flags.sheet,
-      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-    );
-  } catch (error) {
-    throw translateError(error);
-  }
+  const sheet = await openSheetForCommand(
+    repo,
+    flags.sheet,
+    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+  );
 
   // Pre-flight existence check — idempotent on already-missing.
   let exists = false;

--- a/packages/gitsheets-axi/src/commands/patch.ts
+++ b/packages/gitsheets-axi/src/commands/patch.ts
@@ -1,33 +1,46 @@
 import { AxiError } from 'axi-sdk-js';
-import { mergePatch } from 'gitsheets';
+import { mergePatch, Template, type Repository, type Sheet } from 'gitsheets';
 
 import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
-import { renderObject } from '../output/render.js';
+import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
 import { readStdin } from '../util/stdin.js';
 import { openSheetForCommand } from '../util/open-sheet.js';
+import { parseRecordsInput, recordLabel } from '../util/parse-records.js';
+import { MATERIALIZE_HINT } from '../util/hints.js';
 
 export const PATCH_HELP = `usage: gitsheets-axi patch <sheet> <query-json> [--patch <json>] [--prefix p] [--message m]
-flags[3]:
-  --patch <json>       RFC 7396 partial. If omitted, reads stdin.
+       gitsheets-axi patch <sheet> [--data <json>] [--prefix p] [--message m]   # bulk
+flags[4]:
+  --patch <json>       Single mode: RFC 7396 partial. If omitted, reads stdin.
+  --data <json>        Bulk mode: JSON array / NDJSON of combined records.
   --prefix <p>         Tenant sub-tree scope
   --message <m>        Commit message (default: "<sheet> patch <path>")
 examples:
   gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane O. Doe"}'
   echo '{"name":"Jane O. Doe"}' | gitsheets-axi patch users '{"slug":"jane"}'
+  jq -c '.[]' classify.json | gitsheets-axi patch repos      # bulk, one commit
+bulk:
+  With no <query-json>, input is a JSON array or NDJSON of records. In each
+  record the sheet's path-template fields form the query (which record to
+  patch); the remaining fields are the merge patch. Every patch runs in a
+  SINGLE transaction → ONE commit. This is the tool for incremental
+  classification: emit {<path-fields>, <fields-to-set>} per record.
 semantics:
   RFC 7396 JSON Merge Patch. \`null\` deletes a field, arrays replace
   in full, objects merge recursively. Same as gitsheets's library patch.
 idempotency:
-  Reads the existing record, applies the merge, runs the result through
-  willChange. If the canonical bytes are unchanged, exits 0 with
-  result: "no-op" and no commit is produced.
+  Each record is merged and run through willChange. Unchanged records are
+  skipped; a batch where nothing changed exits 0 with result: "no-op" and no
+  commit. In a batch, a record whose query matches nothing aborts the whole
+  transaction — nothing is committed.
 `;
 
 interface PatchFlags {
   sheet: string;
-  queryJson: string;
+  queryJson: string | undefined;
   patchJson: string | undefined;
+  data: string | undefined;
   prefix: string | undefined;
   message: string | undefined;
 }
@@ -35,8 +48,9 @@ interface PatchFlags {
 function parsePatchFlags(args: string[]): PatchFlags {
   const flags: PatchFlags = {
     sheet: '',
-    queryJson: '',
+    queryJson: undefined,
     patchJson: undefined,
+    data: undefined,
     prefix: undefined,
     message: undefined,
   };
@@ -49,6 +63,11 @@ function parsePatchFlags(args: string[]): PatchFlags {
       case '--patch':
         if (!next) throw new AxiError('--patch expects JSON', 'VALIDATION_ERROR');
         flags.patchJson = next;
+        i++;
+        break;
+      case '--data':
+        if (!next) throw new AxiError('--data expects JSON', 'VALIDATION_ERROR');
+        flags.data = next;
         i++;
         break;
       case '--prefix':
@@ -70,13 +89,18 @@ function parsePatchFlags(args: string[]): PatchFlags {
         positional.push(arg);
     }
   }
-  if (positional.length !== 2) {
-    throw new AxiError('patch requires <sheet> <query-json>', 'VALIDATION_ERROR', [
-      "Example: gitsheets-axi patch users '{\"slug\":\"jane\"}' --patch '{...}'",
-    ]);
+  if (positional.length === 0 || positional.length > 2) {
+    throw new AxiError(
+      'patch requires <sheet> [<query-json>]',
+      'VALIDATION_ERROR',
+      [
+        "Single: gitsheets-axi patch users '{\"slug\":\"jane\"}' --patch '{...}'",
+        'Bulk:   gitsheets-axi patch repos --data \'[{...}, ...]\'',
+      ],
+    );
   }
   flags.sheet = positional[0]!;
-  flags.queryJson = positional[1]!;
+  flags.queryJson = positional[1];
   return flags;
 }
 
@@ -89,10 +113,41 @@ export async function patchCommand(
   }
 
   const flags = parsePatchFlags(args);
+  const prefixOpts = flags.prefix !== undefined ? { prefix: flags.prefix } : {};
 
+  const repo = await ctx.repo();
+  const sheet = await openSheetForCommand(repo, flags.sheet, prefixOpts);
+
+  // Single mode is signalled by an explicit <query-json> positional; bulk mode
+  // by its absence (records come from --data / stdin, query embedded per record).
+  if (flags.queryJson !== undefined) {
+    if (flags.data !== undefined) {
+      throw new AxiError(
+        '--data is bulk mode — drop the <query-json> positional to use it',
+        'VALIDATION_ERROR',
+      );
+    }
+    return singlePatch(repo, sheet, flags, prefixOpts);
+  }
+  if (flags.patchJson !== undefined) {
+    throw new AxiError(
+      '--patch is single mode — it needs a <query-json> positional',
+      'VALIDATION_ERROR',
+      ['For bulk, embed the query fields in each record and use --data / stdin'],
+    );
+  }
+  return batchPatch(repo, sheet, flags, prefixOpts);
+}
+
+async function singlePatch(
+  repo: Repository,
+  sheet: Sheet,
+  flags: PatchFlags,
+  prefixOpts: { prefix?: string },
+): Promise<string> {
   let query: Record<string, unknown>;
   try {
-    query = JSON.parse(flags.queryJson) as Record<string, unknown>;
+    query = JSON.parse(flags.queryJson!) as Record<string, unknown>;
   } catch (error) {
     throw new AxiError(
       `Could not parse query JSON: ${error instanceof Error ? error.message : String(error)}`,
@@ -120,74 +175,26 @@ export async function patchCommand(
     throw new AxiError('Patch must be a JSON object', 'VALIDATION_ERROR');
   }
 
-  const repo = await ctx.repo();
-  const sheet = await openSheetForCommand(
-    repo,
-    flags.sheet,
-    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-  );
-
-  let existing;
-  try {
-    existing = await sheet.queryFirst(query);
-  } catch (error) {
-    throw translateError(error);
+  const willResult = await previewPatch(sheet, query, partial as Record<string, unknown>);
+  if (willResult === 'not-found') {
+    throw new AxiError(`${flags.sheet}: no record matches the query`, 'NOT_FOUND');
   }
-  if (!existing) {
-    throw new AxiError(
-      `${flags.sheet}: no record matches the query`,
-      'NOT_FOUND',
-    );
-  }
-
-  // Apply RFC 7396 merge in-axi so we can run willChange against the result.
-  const merged = mergePatch(stripSymbols(existing), partial) as Record<
-    string,
-    unknown
-  >;
-
-  // Preserve the record's path annotation so willChange uses the rename path
-  // logic if any path-template field changed (matches Sheet.patch behavior).
-  const pathSym = (existing as Record<symbol, unknown>)[Symbol.for('gitsheets-path')];
-  if (typeof pathSym === 'string') {
-    (merged as Record<symbol, unknown>)[Symbol.for('gitsheets-path')] = pathSym;
-  }
-
-  // Body-presence on content-typed sheets: patch is body-preserving — the
-  // merged record carries the existing body forward unless the partial
-  // explicitly replaced it. Use allowMissingBody to defer the upsert guard
-  // since the merge produces the canonical record either way.
-  const upsertOpts = { allowMissingBody: true } as const;
-
-  let willResult;
-  try {
-    willResult = await sheet.willChange(merged as never, upsertOpts);
-  } catch (error) {
-    throw translateError(error);
-  }
-
   if (!willResult.changed) {
     return renderObject({
       result: 'no-op',
       sheet: flags.sheet,
       path: willResult.path,
-      hash: willResult.currentBlobHash ?? '',
+      hash: willResult.hash ?? '',
     });
   }
 
   const commitMessage =
     flags.message ?? `${flags.sheet} patch ${willResult.path}`;
   try {
-    const result = await repo.transact(
-      { message: commitMessage },
-      async (tx) => {
-        const txSheet = tx.sheet(
-          flags.sheet,
-          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-        );
-        return txSheet.patch(query, partial);
-      },
-    );
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      return txSheet.patch(query, partial as Record<string, unknown>);
+    });
     return renderObject({
       result: 'committed',
       sheet: flags.sheet,
@@ -198,6 +205,134 @@ export async function patchCommand(
   } catch (error) {
     throw translateError(error);
   }
+}
+
+async function batchPatch(
+  repo: Repository,
+  sheet: Sheet,
+  flags: PatchFlags,
+  prefixOpts: { prefix?: string },
+): Promise<string> {
+  const raw = flags.data ?? (await readStdin());
+  const { records } = parseRecordsInput(raw);
+
+  const config = await sheet.readConfig();
+  const templateFields = new Set(Template.fromString(config.path).getFieldNames());
+
+  // Pre-flight: split each record into (query, partial), confirm the target
+  // exists, and merge+willChange to categorize changed vs unchanged — all
+  // before opening a transaction, so a bad record aborts with nothing
+  // committed and the changed subset commits atomically.
+  const changes: Array<{
+    query: Record<string, unknown>;
+    partial: Record<string, unknown>;
+  }> = [];
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i]!;
+    const query: Record<string, unknown> = {};
+    const partial: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(record)) {
+      if (templateFields.has(k)) query[k] = v;
+      else partial[k] = v;
+    }
+
+    if (Object.keys(query).length === 0) {
+      throw new AxiError(
+        `Record ${i + 1} (${recordLabel(record)}) has none of the path-template fields (${[...templateFields].join(', ')}) — can't tell which record to patch`,
+        'VALIDATION_ERROR',
+        ['Each bulk-patch record must carry the path-template fields as its query'],
+      );
+    }
+    // Query-only record (nothing to set) — a harmless no-op, skip it.
+    if (Object.keys(partial).length === 0) continue;
+
+    let willResult;
+    try {
+      willResult = await previewPatch(sheet, query, partial);
+    } catch (error) {
+      throw attribute(translateError(error), i, record);
+    }
+    if (willResult === 'not-found') {
+      throw new AxiError(
+        `Record ${i + 1} (${recordLabel(record)}): no record matches ${JSON.stringify(query)}`,
+        'NOT_FOUND',
+        ['The whole batch was aborted — nothing committed. Fix or remove the record and re-run.'],
+      );
+    }
+    if (willResult.changed) changes.push({ query, partial });
+  }
+
+  if (changes.length === 0) {
+    return renderObject({
+      result: 'no-op',
+      sheet: flags.sheet,
+      patched: 0,
+      unchanged: records.length,
+    });
+  }
+
+  const commitMessage = flags.message ?? `${flags.sheet} patch (${changes.length})`;
+  try {
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      for (const { query, partial } of changes) {
+        await txSheet.patch(query, partial);
+      }
+      return changes.length;
+    });
+    return joinBlocks(
+      renderObject({
+        result: 'committed',
+        sheet: flags.sheet,
+        patched: changes.length,
+        unchanged: records.length - changes.length,
+        commit: result.commitHash,
+      }),
+      renderHelp([MATERIALIZE_HINT]),
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
+type PatchPreview =
+  | 'not-found'
+  | { changed: boolean; path: string; hash: string | undefined };
+
+/**
+ * Resolve the record matched by `query`, apply the RFC 7396 merge, and run the
+ * result through willChange — the shared pre-flight for both single and bulk
+ * patch. Returns 'not-found' when the query matches no record.
+ */
+async function previewPatch(
+  sheet: Sheet,
+  query: Record<string, unknown>,
+  partial: Record<string, unknown>,
+): Promise<PatchPreview> {
+  const existing = await sheet.queryFirst(query);
+  if (!existing) return 'not-found';
+
+  const merged = mergePatch(stripSymbols(existing), partial) as Record<string, unknown>;
+  // Preserve the record's path annotation so willChange applies rename logic
+  // when a path-template field changed (matches Sheet.patch behavior).
+  const pathSym = (existing as Record<symbol, unknown>)[Symbol.for('gitsheets-path')];
+  if (typeof pathSym === 'string') {
+    (merged as Record<symbol, unknown>)[Symbol.for('gitsheets-path')] = pathSym;
+  }
+
+  // patch is body-preserving; allowMissingBody defers the upsert body guard
+  // since the merge already produced the canonical record.
+  const wc = await sheet.willChange(merged as never, { allowMissingBody: true });
+  return { changed: wc.changed, path: wc.path, hash: wc.currentBlobHash };
+}
+
+function attribute(axi: AxiError, index: number, record: Record<string, unknown>): AxiError {
+  return new AxiError(
+    `Record ${index + 1} (${recordLabel(record)}): ${axi.message}`,
+    axi.code,
+    ['The whole batch was aborted — nothing committed. Fix or remove the record and re-run.'],
+  );
 }
 
 function stripSymbols(record: unknown): unknown {

--- a/packages/gitsheets-axi/src/commands/patch.ts
+++ b/packages/gitsheets-axi/src/commands/patch.ts
@@ -5,6 +5,7 @@ import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
 import { renderObject } from '../output/render.js';
 import { readStdin } from '../util/stdin.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
 
 export const PATCH_HELP = `usage: gitsheets-axi patch <sheet> <query-json> [--patch <json>] [--prefix p] [--message m]
 flags[3]:
@@ -120,15 +121,11 @@ export async function patchCommand(
   }
 
   const repo = await ctx.repo();
-  let sheet;
-  try {
-    sheet = await repo.openSheet(
-      flags.sheet,
-      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-    );
-  } catch (error) {
-    throw translateError(error);
-  }
+  const sheet = await openSheetForCommand(
+    repo,
+    flags.sheet,
+    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+  );
 
   let existing;
   try {

--- a/packages/gitsheets-axi/src/commands/query.ts
+++ b/packages/gitsheets-axi/src/commands/query.ts
@@ -2,28 +2,45 @@ import { AxiError } from 'axi-sdk-js';
 
 import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
-import { renderListResponse } from '../output/render.js';
+import {
+  joinBlocks,
+  renderHelp,
+  renderListResponse,
+  renderObject,
+} from '../output/render.js';
 import { field } from '../output/schema.js';
 import {
   defaultSheetSchema,
   fieldsWithExtras,
 } from '../output/sheet-schema.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
+import { exportRecords, type ExportFormat } from '../util/export-file.js';
 
-export const QUERY_HELP = `usage: gitsheets-axi query <sheet> [--filter k=v ...] [--fields a,b,c] [--limit n]
-flags[4]:
+export const QUERY_HELP = `usage: gitsheets-axi query <sheet> [--filter k=v ...] [--fields a,b,c] [--limit n] [--json-out[=path]] [--ndjson-out[=path]] [--csv-out[=path]]
+flags[7]:
   --filter <k>=<v>     Equality match against record field (repeatable)
   --fields <list>      Extra columns beyond the default schema (comma-separated)
-  --limit <n>          Cap results (default: 100, max: 10000)
+  --limit <n>          Cap the stdout preview (default: 100, max: 10000)
   --prefix <p>         Tenant sub-tree scope (see gitsheets --prefix)
+  --json-out[=path]    Also write the FULL result to a JSON array file
+  --ndjson-out[=path]  Also write the FULL result to an NDJSON file
+  --csv-out[=path]     Also write the FULL result to a CSV file (flat, lossy)
 examples:
   gitsheets-axi query users
   gitsheets-axi query users --filter status=active --limit 50
   gitsheets-axi query posts --fields title,published
+  gitsheets-axi query repos --ndjson-out | tail -1   # export path, pipe elsewhere
 output:
   Default schema is format-aware:
     TOML sheets    — path-template fields + first scalar properties (cap 4)
     Markdown/MDX   — path-template fields + title + body_size (never body content)
   --fields appends additional columns.
+export (--json-out / --ndjson-out / --csv-out):
+  stdout stays the TOON preview; the file carries EVERY matched record (not
+  capped by --limit). JSON/NDJSON are written verbatim so they round-trip
+  straight back into \`gitsheets-axi upsert\`; CSV is flat + lossy (nested
+  values JSON-encoded), for reporting. A bare flag auto-writes a 0600 file
+  under the OS temp dir; \`=path\` persists it. One export flag per invocation.
 `;
 
 interface QueryFlags {
@@ -31,6 +48,8 @@ interface QueryFlags {
   extras: string[];
   limit: number;
   prefix: string | undefined;
+  exportFormat: ExportFormat | undefined;
+  exportPath: string | undefined;
 }
 
 function parseQueryFlags(args: string[]): { sheetName: string; flags: QueryFlags } {
@@ -46,10 +65,50 @@ function parseQueryFlags(args: string[]): { sheetName: string; flags: QueryFlags
     extras: [],
     limit: 100,
     prefix: undefined,
+    exportFormat: undefined,
+    exportPath: undefined,
+  };
+
+  const setExport = (format: ExportFormat, arg: string): void => {
+    if (flags.exportFormat) {
+      throw new AxiError(
+        'Only one export flag is allowed per invocation',
+        'VALIDATION_ERROR',
+        ['Pass either --json-out or --ndjson-out, not both'],
+      );
+    }
+    flags.exportFormat = format;
+    const eq = arg.indexOf('=');
+    if (eq !== -1) {
+      const p = arg.slice(eq + 1);
+      if (!p) {
+        throw new AxiError(
+          `${arg.slice(0, eq)} was given an empty path`,
+          'VALIDATION_ERROR',
+          ['Use the bare flag for an auto-generated temp path, or --…-out=/real/path'],
+        );
+      }
+      flags.exportPath = p;
+    }
   };
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
+    if (arg === undefined) continue;
+
+    if (arg === '--json-out' || arg.startsWith('--json-out=')) {
+      setExport('json', arg);
+      continue;
+    }
+    if (arg === '--ndjson-out' || arg.startsWith('--ndjson-out=')) {
+      setExport('ndjson', arg);
+      continue;
+    }
+    if (arg === '--csv-out' || arg.startsWith('--csv-out=')) {
+      setExport('csv', arg);
+      continue;
+    }
+
     const next = args[i + 1];
     switch (arg) {
       case '--filter': {
@@ -107,15 +166,11 @@ export async function queryCommand(
   const { sheetName, flags } = parseQueryFlags(args);
   const repo = await ctx.repo();
 
-  let sheet;
-  try {
-    sheet = await repo.openSheet(
-      sheetName,
-      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-    );
-  } catch (error) {
-    throw translateError(error);
-  }
+  const sheet = await openSheetForCommand(
+    repo,
+    sheetName,
+    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+  );
 
   const config = await sheet.readConfig();
   const filter: Record<string, unknown> = {};
@@ -159,13 +214,13 @@ export async function queryCommand(
       );
     }
   }
-  if (total > limited.length) {
+  if (total > limited.length && !flags.exportFormat) {
     suggestions.push(
-      `${total - limited.length} records hidden by --limit ${flags.limit}; raise --limit to see more`,
+      `${total - limited.length} records hidden by --limit ${flags.limit}; raise --limit or use --json-out to capture all`,
     );
   }
 
-  return renderListResponse({
+  const listResponse = renderListResponse({
     summary: { count: `${limited.length} of ${total} total` },
     name: 'records',
     items: limited.map((r) => ({
@@ -179,4 +234,28 @@ export async function queryCommand(
     suggestions,
     emptyMessage: `no records in ${sheetName}`,
   });
+
+  if (!flags.exportFormat) return listResponse;
+
+  // Side-channel export: full result set (ignores --limit), written verbatim
+  // so it round-trips back into `upsert`. Additive to the TOON preview above.
+  const exp = exportRecords(
+    records as unknown as Array<Record<string, unknown>>,
+    flags.exportFormat,
+    flags.exportPath,
+    sheetName,
+  );
+  const firstCol = exp.columns[0] ?? '';
+  const hint =
+    flags.exportFormat === 'csv'
+      ? `Run \`column -s, -t ${exp.path} | less -S\` to inspect all ${exp.rows} rows`
+      : flags.exportFormat === 'ndjson'
+        ? `Run \`jq '.${firstCol}' ${exp.path}\` to process all ${exp.rows} rows`
+        : `Run \`jq '.[] | .${firstCol}' ${exp.path}\` to process all ${exp.rows} rows`;
+  return joinBlocks(
+    listResponse,
+    renderObject({ wrote: exp.path, rows: exp.rows, cols: exp.cols }),
+    renderObject({ columns: exp.columns }),
+    renderHelp([hint]),
+  );
 }

--- a/packages/gitsheets-axi/src/commands/upsert.ts
+++ b/packages/gitsheets-axi/src/commands/upsert.ts
@@ -7,6 +7,7 @@ import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
 import { readStdin } from '../util/stdin.js';
 import { openSheetForCommand } from '../util/open-sheet.js';
 import { parseRecordsInput, recordLabel } from '../util/parse-records.js';
+import { MATERIALIZE_HINT } from '../util/hints.js';
 
 export const UPSERT_HELP = `usage: gitsheets-axi upsert <sheet> [--data <json>] [--allow-missing-body] [--prefix p] [--message m]
 flags[4]:
@@ -90,9 +91,6 @@ function parseUpsertFlags(args: string[]): UpsertFlags {
   flags.sheet = positional[0]!;
   return flags;
 }
-
-const MATERIALIZE_HINT =
-  'gitsheets committed to the git ref, not your working tree — run `git checkout HEAD -- .` to materialize the record files on disk';
 
 export async function upsertCommand(
   args: string[],

--- a/packages/gitsheets-axi/src/commands/upsert.ts
+++ b/packages/gitsheets-axi/src/commands/upsert.ts
@@ -1,9 +1,12 @@
 import { AxiError } from 'axi-sdk-js';
+import type { Repository, Sheet } from 'gitsheets';
 
 import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
-import { renderObject } from '../output/render.js';
+import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
 import { readStdin } from '../util/stdin.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
+import { parseRecordsInput, recordLabel } from '../util/parse-records.js';
 
 export const UPSERT_HELP = `usage: gitsheets-axi upsert <sheet> [--data <json>] [--allow-missing-body] [--prefix p] [--message m]
 flags[4]:
@@ -11,13 +14,23 @@ flags[4]:
   --allow-missing-body Content-typed sheets only — permit upsert without body field
   --prefix <p>         Tenant sub-tree scope
   --message <m>        Commit message (default: "<sheet> upsert <path>")
+bulk:
+  Input may be a single JSON object, a JSON array of objects, or NDJSON
+  (one compact object per line) — the shape is autodetected. Many records
+  are upserted in a SINGLE transaction that produces ONE commit.
 examples:
   gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
   echo '{"slug":"jane","email":"jane@x.org"}' | gitsheets-axi upsert users
+  jq -c '.[]' repos.json | gitsheets-axi upsert repos          # NDJSON, one commit
+  cat repos.array.json | gitsheets-axi upsert repos             # JSON array, one commit
 idempotency:
-  Compares the canonical bytes the upsert would write against the
-  existing blob at the rendered path. If identical, exits 0 with
-  result: "no-op" and no commit is produced.
+  Each record's canonical bytes are compared against the existing blob at
+  its rendered path. Unchanged records are skipped; a batch where nothing
+  changed exits 0 with result: "no-op" and no commit. In a batch, a single
+  invalid record aborts the whole transaction — nothing is committed.
+note:
+  gitsheets writes to the git ref, not your working tree. After a commit,
+  run \`git checkout HEAD -- .\` to materialize the record files on disk.
 `;
 
 interface UpsertFlags {
@@ -78,6 +91,9 @@ function parseUpsertFlags(args: string[]): UpsertFlags {
   return flags;
 }
 
+const MATERIALIZE_HINT =
+  'gitsheets committed to the git ref, not your working tree — run `git checkout HEAD -- .` to materialize the record files on disk';
+
 export async function upsertCommand(
   args: string[],
   ctx: GitsheetsContext,
@@ -88,42 +104,29 @@ export async function upsertCommand(
 
   const flags = parseUpsertFlags(args);
   const recordJson = flags.data ?? (await readStdin());
-  if (!recordJson.trim()) {
-    throw new AxiError(
-      'upsert needs a record — pass --data <json> or pipe JSON on stdin',
-      'VALIDATION_ERROR',
-      ['Example: gitsheets-axi upsert users --data \'{"slug":"jane"}\''],
-    );
-  }
+  const { records } = parseRecordsInput(recordJson);
 
-  let record: Record<string, unknown>;
-  try {
-    record = JSON.parse(recordJson) as Record<string, unknown>;
-  } catch (error) {
-    throw new AxiError(
-      `Could not parse record JSON: ${error instanceof Error ? error.message : String(error)}`,
-      'INVALID_JSON',
-      ['Ensure the input is a valid JSON object'],
-    );
-  }
-  if (!record || typeof record !== 'object' || Array.isArray(record)) {
-    throw new AxiError('Record must be a JSON object', 'VALIDATION_ERROR');
-  }
-
-  const repo = await ctx.repo();
-  let sheet;
-  try {
-    sheet = await repo.openSheet(
-      flags.sheet,
-      flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-    );
-  } catch (error) {
-    throw translateError(error);
-  }
-
+  const prefixOpts = flags.prefix !== undefined ? { prefix: flags.prefix } : {};
   const upsertOpts = flags.allowMissingBody ? { allowMissingBody: true } : {};
 
-  // Pre-flight idempotency check.
+  const repo = await ctx.repo();
+  const sheet = await openSheetForCommand(repo, flags.sheet, prefixOpts);
+
+  // Single-record: preserve the detailed per-record output (path/hash/commit).
+  if (records.length === 1) {
+    return singleUpsert(repo, sheet, flags, records[0]!, upsertOpts, prefixOpts);
+  }
+  return batchUpsert(repo, sheet, flags, records, upsertOpts, prefixOpts);
+}
+
+async function singleUpsert(
+  repo: Repository,
+  sheet: Sheet,
+  flags: UpsertFlags,
+  record: Record<string, unknown>,
+  upsertOpts: { allowMissingBody?: boolean },
+  prefixOpts: { prefix?: string },
+): Promise<string> {
   let willResult;
   try {
     willResult = await sheet.willChange(record as never, upsertOpts);
@@ -140,29 +143,92 @@ export async function upsertCommand(
     });
   }
 
-  // Carry through. willChange validated already; this re-validates inside
-  // upsert (cheap, idempotent at the validate layer). Future optimization
-  // could expose a "skip validation" path keyed off willChange's result.
   const commitMessage =
     flags.message ?? `${flags.sheet} upsert ${willResult.path}`;
   try {
     const result = await repo.transact(
       { message: commitMessage },
       async (tx) => {
-        const txSheet = tx.sheet(
-          flags.sheet,
-          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-        );
+        const txSheet = tx.sheet(flags.sheet, prefixOpts);
         return txSheet.upsert(record as never, upsertOpts);
       },
     );
+    return joinBlocks(
+      renderObject({
+        result: 'committed',
+        sheet: flags.sheet,
+        path: result.value.path,
+        hash: result.value.blob.hash,
+        commit: result.commitHash,
+      }),
+      renderHelp([MATERIALIZE_HINT]),
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
+async function batchUpsert(
+  repo: Repository,
+  sheet: Sheet,
+  flags: UpsertFlags,
+  records: Array<Record<string, unknown>>,
+  upsertOpts: { allowMissingBody?: boolean },
+  prefixOpts: { prefix?: string },
+): Promise<string> {
+  // Pre-flight every record: validates (via willChange) and categorizes
+  // changed vs unchanged BEFORE opening a transaction. A single bad record
+  // aborts the whole batch here, so we never produce a partial commit.
+  const changed: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i]!;
+    try {
+      const wc = await sheet.willChange(record as never, upsertOpts);
+      if (wc.changed) changed.push(record);
+    } catch (error) {
+      const axi = translateError(error);
+      throw new AxiError(
+        `Record ${i + 1} (${recordLabel(record)}): ${axi.message}`,
+        axi.code,
+        [
+          'The whole batch was aborted — nothing committed. Fix or remove the offending record and re-run.',
+        ],
+      );
+    }
+  }
+
+  if (changed.length === 0) {
     return renderObject({
-      result: 'committed',
+      result: 'no-op',
       sheet: flags.sheet,
-      path: result.value.path,
-      hash: result.value.blob.hash,
-      commit: result.commitHash,
+      upserted: 0,
+      unchanged: records.length,
     });
+  }
+
+  const commitMessage =
+    flags.message ?? `${flags.sheet} upsert (${changed.length})`;
+  try {
+    const result = await repo.transact(
+      { message: commitMessage },
+      async (tx) => {
+        const txSheet = tx.sheet(flags.sheet, prefixOpts);
+        for (const record of changed) {
+          await txSheet.upsert(record as never, upsertOpts);
+        }
+        return changed.length;
+      },
+    );
+    return joinBlocks(
+      renderObject({
+        result: 'committed',
+        sheet: flags.sheet,
+        upserted: changed.length,
+        unchanged: records.length - changed.length,
+        commit: result.commitHash,
+      }),
+      renderHelp([MATERIALIZE_HINT]),
+    );
   } catch (error) {
     throw translateError(error);
   }

--- a/packages/gitsheets-axi/src/util/export-file.ts
+++ b/packages/gitsheets-axi/src/util/export-file.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { stringify as csvStringify } from 'csv-stringify/sync';
+
+export type ExportFormat = 'json' | 'ndjson' | 'csv';
+
+export interface ExportResult {
+  path: string;
+  rows: number;
+  cols: number;
+  columns: string[];
+}
+
+/**
+ * Write the full record set to a side-channel file — the metabase-axi export
+ * pattern (see kunchenguid/axi#32). This is purely additive: stdout keeps the
+ * agent-optimized TOON preview; the file carries the complete payload only when
+ * an export flag is passed. A bare flag auto-generates an owner-only (0600)
+ * file under the OS temp dir (which the OS prunes); an explicit `=path`
+ * persists wherever the caller points it.
+ *
+ * The JSON/NDJSON files are written verbatim (no injected fields), so they
+ * round-trip straight back into `gitsheets-axi upsert` — JSON array for `json`,
+ * one object per line for `ndjson`. CSV is flat: nested values are JSON-encoded
+ * into their cell, so it's a lossy view for reporting, not a round-trip format.
+ */
+export function exportRecords(
+  records: Array<Record<string, unknown>>,
+  format: ExportFormat,
+  explicitPath: string | undefined,
+  sheetName: string,
+): ExportResult {
+  const path = explicitPath ?? autoPath(sheetName, format);
+  mkdirSync(dirname(path), { recursive: true });
+
+  const columns = unionColumns(records);
+  const body = serialize(records, format, columns);
+  writeFileSync(path, body, { mode: 0o600 });
+
+  return { path, rows: records.length, cols: columns.length, columns };
+}
+
+function serialize(
+  records: Array<Record<string, unknown>>,
+  format: ExportFormat,
+  columns: string[],
+): string {
+  if (format === 'ndjson') {
+    return (
+      records.map((r) => JSON.stringify(r)).join('\n') +
+      (records.length > 0 ? '\n' : '')
+    );
+  }
+  if (format === 'csv') {
+    // Flat CSV: a stable header (union of keys) + one row per record. Nested
+    // values (arrays / tables) are JSON-encoded so cells never read as
+    // "[object Object]"; this makes CSV a lossy reporting view, not lossless.
+    return csvStringify(records, {
+      header: true,
+      columns,
+      cast: {
+        object: (v) => JSON.stringify(v),
+        boolean: (v) => (v ? 'true' : 'false'),
+      },
+    });
+  }
+  return JSON.stringify(records);
+}
+
+function autoPath(sheetName: string, format: ExportFormat): string {
+  const dir = join(tmpdir(), 'gitsheets-axi');
+  const ext = format;
+  const safe = sheetName.replace(/[^A-Za-z0-9_.-]/g, '_') || 'sheet';
+  const stamp = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return join(dir, `${safe}-${stamp}.${ext}`);
+}
+
+/** Keys across all records, first-seen order — the exported file's columns. */
+function unionColumns(records: Array<Record<string, unknown>>): string[] {
+  const seen = new Set<string>();
+  const cols: string[] = [];
+  for (const record of records) {
+    for (const key of Object.keys(record)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        cols.push(key);
+      }
+    }
+  }
+  return cols;
+}

--- a/packages/gitsheets-axi/src/util/hints.ts
+++ b/packages/gitsheets-axi/src/util/hints.ts
@@ -1,0 +1,8 @@
+/**
+ * Shown after any commit-producing mutation. gitsheets commits records to the
+ * git ref via plumbing and never touches the working tree, so a fresh commit
+ * leaves the record files "deleted" on disk until they're checked out. This
+ * surprises first-time users — it isn't data loss.
+ */
+export const MATERIALIZE_HINT =
+  'gitsheets committed to the git ref, not your working tree — run `git checkout HEAD -- .` to materialize the record files on disk';

--- a/packages/gitsheets-axi/src/util/open-sheet.ts
+++ b/packages/gitsheets-axi/src/util/open-sheet.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { AxiError } from 'axi-sdk-js';
+import { ConfigError, type Repository, type Sheet } from 'gitsheets';
+
+import { translateError } from '../errors.js';
+
+/**
+ * Open a sheet, translating failures to AxiError. When the sheet config is
+ * missing from the committed tree but `.gitsheets/<name>.toml` exists in the
+ * working tree, emit a targeted hint: gitsheets reads sheet configs from the
+ * committed git tree, not the working tree, so a freshly-authored config must
+ * be committed before any record command can see it. This is a common first-run
+ * trap — author the config, run upsert, get an opaque "not found".
+ */
+export async function openSheetForCommand(
+  repo: Repository,
+  name: string,
+  opts: { prefix?: string } = {},
+): Promise<Sheet> {
+  try {
+    return await repo.openSheet(name, opts);
+  } catch (error) {
+    if (error instanceof ConfigError && error.code === 'config_missing') {
+      const configPath = join('.gitsheets', `${name}.toml`);
+      const workDir = dirname(repo.gitDir);
+      if (existsSync(join(workDir, configPath))) {
+        throw new AxiError(
+          `Sheet '${name}' isn't in the committed tree, but ${configPath} exists in your working tree.`,
+          'CONFIG_INVALID',
+          [
+            `Commit the config first — gitsheets reads sheet configs from the committed git tree, not the working tree: git add ${configPath} && git commit -m "add ${name} sheet"`,
+          ],
+        );
+      }
+    }
+    throw translateError(error);
+  }
+}

--- a/packages/gitsheets-axi/src/util/parse-records.ts
+++ b/packages/gitsheets-axi/src/util/parse-records.ts
@@ -1,0 +1,97 @@
+import { AxiError } from 'axi-sdk-js';
+
+export type RecordInputShape = 'single' | 'array' | 'ndjson';
+
+export interface ParsedRecords {
+  records: Array<Record<string, unknown>>;
+  /** How the input was interpreted — for messaging only. */
+  shape: RecordInputShape;
+}
+
+/**
+ * Parse upsert input into a list of records, autodetecting the shape:
+ *   - a single JSON object (pretty or compact) → one record
+ *   - a JSON array of objects                   → batch
+ *   - NDJSON (one compact object per line)       → batch
+ *
+ * Detection is unambiguous and needs no flag. We first try to parse the whole
+ * input as one JSON value: an array or object settles it (this covers both
+ * pretty-printed and compact forms). Only when whole-input parsing fails do we
+ * fall back to NDJSON line-splitting — valid NDJSON is one compact object per
+ * line, so a pretty-printed multi-line object never reaches that path.
+ */
+export function parseRecordsInput(raw: string): ParsedRecords {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new AxiError(
+      'upsert needs a record — pass --data <json> or pipe JSON on stdin',
+      'VALIDATION_ERROR',
+      [
+        'Accepts a JSON object, a JSON array of objects, or NDJSON (one object per line)',
+      ],
+    );
+  }
+
+  // Whole-input parse first: catches single object + array, pretty or compact.
+  let whole: unknown;
+  let wholeOk = true;
+  try {
+    whole = JSON.parse(trimmed);
+  } catch {
+    wholeOk = false;
+  }
+
+  if (wholeOk) {
+    if (Array.isArray(whole)) {
+      return { records: whole.map((r, i) => asObject(r, i)), shape: 'array' };
+    }
+    return { records: [asObject(whole, 0)], shape: 'single' };
+  }
+
+  // NDJSON fallback: one JSON object per non-blank line.
+  const lines = trimmed
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const records = lines.map((line, i) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new AxiError(
+        `Could not parse input as JSON, a JSON array, or NDJSON — line ${i + 1} is not valid JSON`,
+        'INVALID_JSON',
+        [
+          'Provide a JSON object, a JSON array of objects, or NDJSON (one compact object per line)',
+        ],
+      );
+    }
+    return asObject(parsed, i);
+  });
+  return { records, shape: 'ndjson' };
+}
+
+function asObject(value: unknown, index: number): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AxiError(
+      `Record at position ${index + 1} is not a JSON object`,
+      'VALIDATION_ERROR',
+      ["Each record must be a JSON object with the sheet's fields"],
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Pick a short human/agent-readable label for a record, used to name the
+ * offending record when a batch upsert aborts on a bad row. Falls back to the
+ * position when no obvious identifier field is present.
+ */
+export function recordLabel(record: Record<string, unknown>): string {
+  for (const key of ['id', 'slug', 'name', 'key', 'path']) {
+    const v = record[key];
+    if (typeof v === 'string' && v.length > 0) return `${key}=${v}`;
+    if (typeof v === 'number') return `${key}=${v}`;
+  }
+  return 'no id field';
+}

--- a/packages/gitsheets-axi/test/bulk-patch.test.ts
+++ b/packages/gitsheets-axi/test/bulk-patch.test.ts
@@ -1,0 +1,179 @@
+// Bulk patch (JSON array / NDJSON of combined records → one commit). Each
+// record's path-template fields form the query; the rest is the RFC 7396 merge.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+
+[gitsheet.schema.properties.team]
+type = 'string'
+
+[gitsheet.schema.properties.role]
+type = 'string'
+`;
+
+const SEED = JSON.stringify([
+  { slug: 'jane', email: 'jane@x.org', team: 'eng' },
+  { slug: 'bob', email: 'bob@x.org', team: 'eng' },
+  { slug: 'mia', email: 'mia@x.org', team: 'ops' },
+]);
+
+async function seeded(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users sheet');
+  await runCli(['upsert', 'users', '--data', SEED], fixture.path);
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('bulk patch', () => {
+  it('patches many records in a single commit, merging (not replacing)', async () => {
+    const fixture = await seeded();
+    const before = await commitCount(fixture);
+    const patches = JSON.stringify([
+      { slug: 'jane', role: 'lead' },
+      { slug: 'bob', role: 'ic' },
+    ]);
+    const { stdout, exitCode } = await runCli(['patch', 'users', '--data', patches], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('patched: 2');
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    // Merge semantics: role added, email/team preserved.
+    const { stdout: jane } = await runCli(['read', 'users', 'jane'], fixture.path);
+    expect(jane).toContain('role: lead');
+    expect(jane).toContain('jane@x.org');
+    expect(jane).toContain('team: eng');
+  });
+
+  it('autodetects NDJSON', async () => {
+    const fixture = await seeded();
+    const ndjson = ['{"slug":"jane","role":"lead"}', '{"slug":"mia","role":"ops-lead"}'].join('\n');
+    const { stdout } = await runCli(['patch', 'users', '--data', ndjson], fixture.path);
+    expect(stdout).toContain('patched: 2');
+  });
+
+  it('is idempotent — re-patching the same values is a no-op', async () => {
+    const fixture = await seeded();
+    const patches = JSON.stringify([{ slug: 'jane', role: 'lead' }]);
+    await runCli(['patch', 'users', '--data', patches], fixture.path);
+    const after1 = await commitCount(fixture);
+    const { stdout } = await runCli(['patch', 'users', '--data', patches], fixture.path);
+    expect(stdout).toContain('result: no-op');
+    expect(stdout).toContain('unchanged: 1');
+    expect(await commitCount(fixture)).toBe(after1);
+  });
+
+  it('null deletes a field (RFC 7396)', async () => {
+    const fixture = await seeded();
+    await runCli(['patch', 'users', '--data', JSON.stringify([{ slug: 'jane', team: null }])], fixture.path);
+    const { stdout } = await runCli(['read', 'users', 'jane'], fixture.path);
+    expect(stdout).not.toContain('team:');
+  });
+
+  it('aborts the whole batch when a record matches nothing', async () => {
+    const fixture = await seeded();
+    const before = await commitCount(fixture);
+    const patches = JSON.stringify([
+      { slug: 'jane', role: 'lead' },
+      { slug: 'ghost', role: 'nope' }, // no such record
+    ]);
+    const { stdout, exitCode } = await runCli(['patch', 'users', '--data', patches], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/Record 2 \(slug=ghost\)/);
+    expect(stdout).toMatch(/no record matches/);
+    expect(await commitCount(fixture)).toBe(before); // nothing committed
+  });
+
+  it('errors when a record carries none of the path-template fields', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '--data', JSON.stringify([{ role: 'lead' }])],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/path-template fields/);
+  });
+
+  it('commits only the changed subset', async () => {
+    const fixture = await seeded();
+    await runCli(['patch', 'users', '--data', JSON.stringify([{ slug: 'jane', role: 'lead' }])], fixture.path);
+    const after1 = await commitCount(fixture);
+    const mixed = JSON.stringify([
+      { slug: 'jane', role: 'lead' }, // unchanged
+      { slug: 'bob', role: 'ic' }, // changed
+    ]);
+    const { stdout } = await runCli(['patch', 'users', '--data', mixed], fixture.path);
+    expect(stdout).toContain('patched: 1');
+    expect(stdout).toContain('unchanged: 1');
+    expect(await commitCount(fixture)).toBe(after1 + 1);
+  });
+});
+
+describe('single patch still works', () => {
+  it('patches one record via explicit query + --patch', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '{"slug":"jane"}', '--patch', '{"role":"lead"}'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('path: jane');
+  });
+
+  it('rejects --data alongside a query positional', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '{"slug":"jane"}', '--data', '[{"slug":"jane","role":"x"}]'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/bulk mode/);
+  });
+
+  it('rejects --patch without a query positional', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '--patch', '{"role":"x"}'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/single mode/);
+  });
+});

--- a/packages/gitsheets-axi/test/bulk-upsert.test.ts
+++ b/packages/gitsheets-axi/test/bulk-upsert.test.ts
@@ -1,0 +1,221 @@
+// Bulk upsert (JSON array / NDJSON autodetect → one commit) and the
+// side-channel query exports (--json-out / --ndjson-out / --csv-out).
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.email]
+type = 'string'
+
+[gitsheet.schema.properties.team]
+type = 'string'
+`;
+
+async function seedRepo({ withConfig = true }: { withConfig?: boolean } = {}): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  if (withConfig) {
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+    await fixture.git('add', '.gitsheets/');
+    await fixture.git('commit', '-m', 'add users sheet');
+  }
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+const THREE = JSON.stringify([
+  { slug: 'jane', email: 'jane@x.org', team: 'eng' },
+  { slug: 'bob', email: 'bob@x.org', team: 'eng' },
+  { slug: 'mia', email: 'mia@x.org', team: 'ops' },
+]);
+
+describe('bulk upsert', () => {
+  it('imports a JSON array in a single commit', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+    const { stdout, exitCode } = await runCli(['upsert', 'users', '--data', THREE], fixture.path);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('upserted: 3');
+    expect(stdout).toContain('unchanged: 0');
+    // Exactly one new commit for all three records.
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    const { stdout: q } = await runCli(['query', 'users'], fixture.path);
+    expect(q).toContain('count: 3 of 3 total');
+  });
+
+  it('surfaces the working-tree materialize hint', async () => {
+    const fixture = await seedRepo();
+    const { stdout } = await runCli(['upsert', 'users', '--data', THREE], fixture.path);
+    expect(stdout).toMatch(/git checkout HEAD -- \./);
+  });
+
+  it('autodetects NDJSON (one object per line)', async () => {
+    const fixture = await seedRepo();
+    const ndjson = [
+      '{"slug":"jane","email":"jane@x.org"}',
+      '{"slug":"bob","email":"bob@x.org"}',
+    ].join('\n');
+    const { stdout, exitCode } = await runCli(['upsert', 'users', '--data', ndjson], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('upserted: 2');
+  });
+
+  it('is idempotent — re-importing the same batch is a no-op', async () => {
+    const fixture = await seedRepo();
+    await runCli(['upsert', 'users', '--data', THREE], fixture.path);
+    const after1 = await commitCount(fixture);
+
+    const { stdout, exitCode } = await runCli(['upsert', 'users', '--data', THREE], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: no-op');
+    expect(stdout).toContain('unchanged: 3');
+    // No second commit.
+    expect(await commitCount(fixture)).toBe(after1);
+  });
+
+  it('commits only the changed subset on a partial re-import', async () => {
+    const fixture = await seedRepo();
+    await runCli(['upsert', 'users', '--data', THREE], fixture.path);
+    const after1 = await commitCount(fixture);
+
+    const mixed = JSON.stringify([
+      { slug: 'jane', email: 'jane@x.org', team: 'eng' }, // unchanged
+      { slug: 'bob', email: 'bob@NEW.org', team: 'eng' }, // changed
+    ]);
+    const { stdout } = await runCli(['upsert', 'users', '--data', mixed], fixture.path);
+    expect(stdout).toContain('upserted: 1');
+    expect(stdout).toContain('unchanged: 1');
+    expect(await commitCount(fixture)).toBe(after1 + 1);
+  });
+
+  it('aborts the whole batch when any record is invalid — nothing committed', async () => {
+    const fixture = await seedRepo();
+    const before = await commitCount(fixture);
+    const bad = JSON.stringify([
+      { slug: 'jane', email: 'jane@x.org' },
+      { slug: 'bob' }, // missing required email
+    ]);
+    const { stdout, exitCode } = await runCli(['upsert', 'users', '--data', bad], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toMatch(/Record 2 \(slug=bob\)/);
+    // No partial commit.
+    expect(await commitCount(fixture)).toBe(before);
+  });
+});
+
+describe('config not committed', () => {
+  it('hints to commit the config when it exists only in the working tree', async () => {
+    const fixture = await seedRepo({ withConfig: false });
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+    // Deliberately NOT committed.
+    const { stdout, exitCode } = await runCli(
+      ['upsert', 'users', '--data', '{"slug":"jane","email":"j@x.org"}'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('isn\'t in the committed tree');
+    expect(stdout).toMatch(/git add \.gitsheets\/users\.toml/);
+  });
+});
+
+describe('query exports', () => {
+  async function seeded(): Promise<TestRepoHandle> {
+    const fixture = await seedRepo();
+    await runCli(['upsert', 'users', '--data', THREE], fixture.path);
+    return fixture;
+  }
+
+  function writtenPath(stdout: string): string {
+    const m = stdout.match(/wrote: (\S+)/);
+    if (!m) throw new Error(`no "wrote:" line in output:\n${stdout}`);
+    return m[1]!;
+  }
+
+  it('--json-out writes the full set and round-trips back into upsert', async () => {
+    const fixture = await seeded();
+    // Preview capped at 1, but the file must carry all 3.
+    const { stdout } = await runCli(
+      ['query', 'users', '--limit', '1', '--json-out'],
+      fixture.path,
+    );
+    expect(stdout).toContain('count: 1 of 3 total');
+    expect(stdout).toContain('rows: 3');
+
+    const file = writtenPath(stdout);
+    const parsed = JSON.parse(await readFile(file, 'utf-8')) as unknown[];
+    expect(parsed).toHaveLength(3);
+
+    // Round-trip: feeding the exported file straight back is a pure no-op.
+    const { stdout: back } = await runCli(
+      ['upsert', 'users', '--data', await readFile(file, 'utf-8')],
+      fixture.path,
+    );
+    expect(back).toContain('result: no-op');
+    expect(back).toContain('unchanged: 3');
+  });
+
+  it('--ndjson-out writes one object per line', async () => {
+    const fixture = await seeded();
+    const { stdout } = await runCli(['query', 'users', '--ndjson-out'], fixture.path);
+    const file = writtenPath(stdout);
+    const body = await readFile(file, 'utf-8');
+    const lines = body.trim().split('\n');
+    expect(lines).toHaveLength(3);
+    for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
+  });
+
+  it('--csv-out writes a header + one row per record', async () => {
+    const fixture = await seeded();
+    const { stdout } = await runCli(['query', 'users', '--csv-out'], fixture.path);
+    const file = writtenPath(stdout);
+    const body = await readFile(file, 'utf-8');
+    const lines = body.trim().split('\n');
+    expect(lines).toHaveLength(4); // header + 3
+    expect(lines[0]).toContain('slug');
+    expect(lines[0]).toContain('email');
+  });
+
+  it('rejects two export flags at once', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(
+      ['query', 'users', '--json-out', '--csv-out'],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/one export flag/i);
+  });
+});

--- a/skills/gitsheets/SKILL.md
+++ b/skills/gitsheets/SKILL.md
@@ -24,6 +24,8 @@ If unsure or the question spans multiple surfaces, read all four. They're sized 
 
 If the user is working *inside an agent session* and wants to read/mutate gitsheets data via shell, prefer `gitsheets-axi` (`references/axi.md`). If they're writing application code, prefer the library API. If they're authoring configs or asking conceptual questions, sheet-config or api references are right.
 
+**Bootstrapping the CLI.** `gitsheets-axi` may not be on `PATH` in a fresh environment where only this skill is installed — that's fine. Run it with no install via `npx -y gitsheets-axi <args>` (e.g. `npx -y gitsheets-axi query users`), or `npm install -g gitsheets-axi` once for a persistent command. Check with `command -v gitsheets-axi`. The human `gitsheets` CLI bootstraps the same way (`npx -y gitsheets …`). So "just install the skill" is a complete starting point — the tools are one `npx` away.
+
 ## Always-true facts
 
 These don't change between releases and are worth keeping in mind regardless of the user's question:
@@ -66,7 +68,7 @@ If the user is heading toward one of these, gently steer them back:
 
 If you're going to edit gitsheets record files (`.toml` or `.md`) directly on disk rather than through the API, install a post-edit hook that runs `gitsheets-axi check <sheet> $FILE --fix` after each edit. This re-canonicalizes the file (deep-sorted keys, normalized markdown body) and validates against the sheet's schema, catching mistakes immediately rather than at the next git commit. Hook examples in `references/axi.md`.
 
-`gitsheets-axi` is preferred for hook use because its output is TOON on stdout with stable error codes (`VALIDATION_FAILED`, `CONFIG_INVALID`, `NOT_CANONICAL`, etc.) — an agent reading the hook's stdout can switch on the outcome. The human `gitsheets check` works too and is documented in `references/cli.md`; pick it when `gitsheets-axi` isn't installed in the environment.
+`gitsheets-axi` is preferred for hook use because its output is TOON on stdout with stable error codes (`VALIDATION_FAILED`, `CONFIG_INVALID`, `NOT_CANONICAL`, etc.) — an agent reading the hook's stdout can switch on the outcome. If it isn't installed, install it (`npm install -g gitsheets-axi`) — a `npx -y` prefix isn't a good fit inside a per-edit hook that fires constantly, so a real install is worth it here. The human `gitsheets check` (`references/cli.md`) is an equivalent fallback when a global install isn't possible.
 
 For CI / pre-commit verification, drop the `--fix`: `gitsheets-axi check <sheet> $FILE` exits non-zero if the file isn't already canonical, without touching it.
 

--- a/skills/gitsheets/SKILL.md
+++ b/skills/gitsheets/SKILL.md
@@ -61,7 +61,8 @@ If the user is heading toward one of these, gently steer them back:
 - **Indexing on body content.** Indexes always build with body-less reads on markdown sheets — `keyFn(record).body` is `undefined`. Index on frontmatter fields.
 - **Calling `pull` then `push`** to sync. The library has no pull. The single-writer model is non-negotiable; "pull elsewhere, restart consumer" is the canonical reconciliation path.
 - **Using `Sheet.upsert(partial)` to update a single field.** `upsert` is a full-record replace. To mutate fields without overwriting the rest, use `sheet.patch(query, partial)` (RFC 7396 — `null` deletes a field, arrays replace).
-- **Looping `upsert` once per record for a bulk load.** That produces one commit per record (hundreds of junk commits). `upsert` autodetects a JSON array or NDJSON and imports the whole batch in a single commit — pass the stream, don't loop.
+- **Updating existing records with `upsert` in bulk.** `upsert` replaces the whole record, so a bulk update must re-send every field or silently drop the rest. For updating fields across many records (classifying, tagging, backfilling), use **bulk `gitsheets-axi patch`** (array / NDJSON of combined records → one commit, merge semantics) — emit only the fields you're setting.
+- **Looping `upsert` (or `patch`) once per record for a bulk job.** That produces one commit per record (hundreds of junk commits). Both `upsert` and `patch` autodetect a JSON array or NDJSON and process the whole batch in a single commit — pass the stream, don't loop.
 - **Hand-serializing TOML to write records.** Never build TOML strings (or reach for a TOML library) to produce records. gitsheets owns serialization, key-sorting, canonical form, and validation. Produce JSON and let `upsert` write the bytes.
 
 ## Editing record files directly (post-edit hook)

--- a/skills/gitsheets/SKILL.md
+++ b/skills/gitsheets/SKILL.md
@@ -34,6 +34,8 @@ These don't change between releases and are worth keeping in mind regardless of 
 - **Validation is on writes only.** Reads return whatever's on disk. If a schema was tightened after some records were written, those reads can return records that wouldn't pass current validation.
 - **Canonical normalization is deterministic.** Object keys are deep-sorted on write; array fields can declare a `sort` rule. Logically-equal records produce byte-identical TOML, so git diffs are meaningful.
 - **Mutations go through transactions.** `repo.transact(opts, async tx => …)` is the explicit path. Outside a transaction, standalone Sheet methods (`upsert`, `delete`, `patch`) auto-open one — unless the consumer called `repo.requireExplicitTransactions()`, in which case they throw.
+- **Writes land in the git ref, not the working tree.** gitsheets commits records via git plumbing directly to the branch ref; it does **not** update your checked-out files. Right after a write, `git status` shows the new records as *deleted* on disk — the ref has them, the working tree doesn't. `git checkout HEAD -- .` materializes them. This is expected, not data loss.
+- **Sheet configs are read from the committed tree.** A freshly-authored `.gitsheets/<name>.toml` is invisible to record commands until it's committed. Commit the config first, then upsert/query.
 - **Push is push-only.** The optional push daemon (`repo.startPushDaemon`) pushes new commits to a remote with retry/backoff. It never pulls — the consumer process is the single writer.
 - **All gitsheets errors extend `GitsheetsError`** and carry a stable `code` field. Consumers switch on `instanceof` or `err.code`, never on `err.message`. The error classes are: `ConfigError`, `ValidationError`, `TransactionError`, `IndexError`, `RefError`, `PathTemplateError`, `NotFoundError`.
 
@@ -46,6 +48,7 @@ When the user is building something, these idioms are usually the right shape:
 - **Bulk reads + lazy bodies**: on content-typed (markdown) sheets, pass `{ withBody: false }` to `query` for listing/filtering, then `await sheet.loadBody(record)` when the body is actually needed.
 - **Secondary indices**: `sheet.defineIndex('byEmail', { unique: true }, r => r.email.toLowerCase())`. Built lazily on first `findByIndex` call; rebuilt when the underlying tree hash changes. For markdown sheets, index builds always use body-less reads — don't index on body content (returns `undefined` → record excluded).
 - **CSV import**: `gitsheets upsert <sheet> records.csv --format=csv` — first row is the header, each subsequent row becomes one record. Cell values stay strings; type coercion belongs in the schema.
+- **Bulk ingest a databank**: build a JSON array or NDJSON stream with `jq` (never hand-serialize TOML), then pipe it into **one** `upsert` — `jq -c '.[]' raw.json | gitsheets-axi upsert repos`. The whole batch commits once. To reshape existing data, `gitsheets-axi query <sheet> --ndjson-out`, transform the file, and pipe it back in (exports round-trip verbatim). See `references/axi.md` → "Bulk data engineering".
 
 ## Anti-patterns to redirect
 
@@ -56,6 +59,8 @@ If the user is heading toward one of these, gently steer them back:
 - **Indexing on body content.** Indexes always build with body-less reads on markdown sheets — `keyFn(record).body` is `undefined`. Index on frontmatter fields.
 - **Calling `pull` then `push`** to sync. The library has no pull. The single-writer model is non-negotiable; "pull elsewhere, restart consumer" is the canonical reconciliation path.
 - **Using `Sheet.upsert(partial)` to update a single field.** `upsert` is a full-record replace. To mutate fields without overwriting the rest, use `sheet.patch(query, partial)` (RFC 7396 — `null` deletes a field, arrays replace).
+- **Looping `upsert` once per record for a bulk load.** That produces one commit per record (hundreds of junk commits). `upsert` autodetects a JSON array or NDJSON and imports the whole batch in a single commit — pass the stream, don't loop.
+- **Hand-serializing TOML to write records.** Never build TOML strings (or reach for a TOML library) to produce records. gitsheets owns serialization, key-sorting, canonical form, and validation. Produce JSON and let `upsert` write the bytes.
 
 ## Editing record files directly (post-edit hook)
 

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -62,11 +62,14 @@ Single-sheet detail: config summary (root, format, path template), schema proper
 List records.
 
 | Flag | Notes |
-|---|---|
+| --- | --- |
 | `--filter <k>=<v>` | Equality match; repeatable |
 | `--fields <list>` | Extra columns beyond the default schema |
-| `--limit <n>` | Default 100, max 10000 |
+| `--limit <n>` | Caps the **stdout preview**. Default 100, max 10000 |
 | `--prefix <p>` | Tenant sub-tree scope (matches the library's `prefix` option) |
+| `--json-out[=path]` | Also write the **full** result set to a JSON array file |
+| `--ndjson-out[=path]` | Also write the full result set to an NDJSON file |
+| `--csv-out[=path]` | Also write the full result set to a CSV file (flat, lossy) |
 
 **Default schema is format-aware:**
 
@@ -75,24 +78,49 @@ List records.
 
 The summary line `count: N of M total` is always present so agents know when results are paginated.
 
+**Bulk export — the round-trip out of gitsheets.** The `--*-out` flags are a side-channel: stdout stays the token-cheap TOON preview, and the file carries **every matched record** (ignoring `--limit`). A bare flag auto-writes an owner-only (`0600`) file under `$TMPDIR/gitsheets-axi/`; `=path` persists it wherever you point it. At most one export flag per invocation. On write, stdout gains `wrote:` / `columns:` / a `jq` hint so you can compose the follow-up without opening the file:
+
+```
+wrote: /tmp/gitsheets-axi/repos-….ndjson
+rows: 463
+cols: 12
+columns[12]: name,visibility,archived,...
+help[1]: Run `jq '.name' /tmp/gitsheets-axi/repos-….ndjson` to process all 463 rows
+```
+
+`--json-out` and `--ndjson-out` are written **verbatim** (record fields only, no injected keys), so they pipe straight back into `gitsheets-axi upsert` — export → transform → re-import is a clean loop. `--csv-out` is flat (nested values JSON-encoded into their cell): a lossy reporting view, not a round-trip format.
+
 ### `gitsheets-axi read <sheet> <path> [--full]`
 
 Single-record detail. For markdown/mdx sheets, the body field is truncated to ~500 chars with `(truncated, N chars total)` and a `--full` hint. Surfaces `_path` and `_sheet` as plain fields (the `RECORD_PATH_KEY` / `RECORD_SHEET_KEY` Symbol annotations).
 
 ### `gitsheets-axi upsert <sheet> [--data <json>] [flags]`
 
-Create or replace a record.
+Create or replace one **or many** records.
 
 | Flag | Notes |
-|---|---|
+| --- | --- |
 | `--data <json>` | Record JSON inline. If omitted, reads stdin. |
 | `--allow-missing-body` | Content-typed sheets only — opt in to upserting without body field |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message (default: `<sheet> upsert <path>`) |
 
-**Idempotent:** if the canonical bytes match the existing record, exits 0 with `result: "no-op"` and no commit.
+**Bulk import — this is the path for loading a databank.** The input shape is autodetected, no flag needed:
 
-Output on commit:
+- a single JSON object → one record
+- a **JSON array** of objects → batch
+- **NDJSON** (one compact object per line) → batch
+
+A batch upserts every record in **one transaction that produces ONE commit** — not one commit per record. Feed it a file or a pipe:
+
+```bash
+cat repos.array.json | gitsheets-axi upsert repos          # JSON array → one commit
+jq -c '.[]' repos.json | gitsheets-axi upsert repos        # NDJSON → one commit
+```
+
+**Idempotent, per record.** Each record's canonical bytes are compared against what's on disk; unchanged records are skipped. A batch where nothing changed exits 0 with `result: "no-op"` and no commit. In a batch, a **single invalid record aborts the whole transaction** (nothing committed) and the error names the offending row.
+
+Single-record output on commit:
 
 ```
 result: committed
@@ -100,23 +128,30 @@ sheet: users
 path: jane
 hash: 4d3f...
 commit: a1b2c3...
+help[1]: gitsheets committed to the git ref, not your working tree — run `git checkout HEAD -- .` to materialize the record files on disk
 ```
 
-Output on no-op:
+Batch output:
 
 ```
-result: no-op
-sheet: users
-path: jane
-hash: 4d3f...
+result: committed
+sheet: repos
+upserted: 5
+unchanged: 458
+commit: a1b2c3...
+help[1]: gitsheets committed to the git ref, not your working tree — run `git checkout HEAD -- .` to materialize the record files on disk
 ```
+
+Output on no-op mirrors the shape with `result: no-op` and no `commit`.
+
+> **Working-tree gotcha.** gitsheets writes to the git **ref** via plumbing; it does **not** touch your working tree. Right after a commit, `git status` shows the new records as *deleted* on disk (the ref has them, the working tree doesn't). Run `git checkout HEAD -- .` to materialize them. This surprises every first-time user — it's not data loss.
 
 ### `gitsheets-axi patch <sheet> <query-json> [--patch <json>] [flags]`
 
 RFC 7396 JSON Merge Patch against the record matched by `<query-json>`. `null` deletes a field, arrays replace, objects merge recursively.
 
 | Flag | Notes |
-|---|---|
+| --- | --- |
 | `--patch <json>` | Partial JSON. If omitted, reads stdin. |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message |
@@ -130,7 +165,7 @@ Throws `NOT_FOUND` if the query matches no record.
 Delete the record at `<path>`.
 
 | Flag | Notes |
-|---|---|
+| --- | --- |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message |
 
@@ -141,7 +176,7 @@ Delete the record at `<path>`.
 Verify a record file in the working tree is parseable, valid against the sheet's schema, and in canonical form. Reads from the working tree (not git). **Never commits.**
 
 | Flag | Notes |
-|---|---|
+| --- | --- |
 | `--fix` | Rewrite the file in canonical form if not already canonical |
 | `--prefix <p>` | Tenant scope |
 
@@ -211,7 +246,7 @@ Translates a pre-v1.0 `[gitsheet.fields]` block into the modern `[gitsheet.schem
 Manage binary blobs colocated with records. Subcommands:
 
 | Subcommand | Flags / Notes |
-|---|---|
+| --- | --- |
 | `list <sheet> <path>` | Table of attachment names + mime types + blob hashes |
 | `get <sheet> <path> <name>` | Base64-encoded content + metadata; truncated at ~64 KB unless `--full` |
 | `set <sheet> <path> <name> [--file f / --data t / stdin]` | Idempotent on byte-match |
@@ -232,10 +267,28 @@ This is **not** a daemon lifecycle command — for retry-with-backoff semantics 
 
 Explicit, opt-in installer for the agent `SessionStart` hooks (see [Hook installation](#hook-installation)). Installs into Claude Code, Codex, and OpenCode. Idempotent and self-repairing — re-running repairs a stale executable path. `--help` prints usage; any action other than `hooks` exits non-zero with a `VALIDATION_ERROR`. Restart the agent session afterward to pick up the ambient context.
 
+## Bulk data engineering (loading a databank)
+
+Populating a sheet from an external source (a GitHub API dump, a CSV, another system) is the canonical gitsheets job. The path that works:
+
+1. **Author the sheet config, then commit it.** `gitsheets-axi init <sheet>` scaffolds `.gitsheets/<sheet>.toml`; edit the schema, then `git add .gitsheets/<sheet>.toml && git commit`. **You must commit before any record command sees the sheet** — configs are read from the committed tree, not the working tree. (If you skip this, upsert/query return a targeted "commit the config first" error.)
+2. **Build a JSON array or NDJSON stream of records** with `jq` — do **not** hand-serialize TOML. gitsheets owns TOML serialization, key-sorting, canonical form, and validation; your job is to produce JSON.
+3. **Pipe it into one `upsert`** → one commit for the whole batch:
+
+   ```bash
+   jq -c '.[] | {name, visibility, description}' raw.json \
+     | gitsheets-axi upsert repos --message "seed repos from GitHub"
+   ```
+
+4. **Materialize the working tree** if you want the files on disk: `git checkout HEAD -- .` (gitsheets committed to the ref, not the working tree — see the gotcha under `upsert`).
+5. **Round-trip to reshape:** `gitsheets-axi query <sheet> --ndjson-out` → transform the file with `jq` → pipe back into `upsert`. Exported JSON/NDJSON is verbatim, so re-import is clean and idempotent.
+
+Do **not** loop `upsert --data` once per record — that produces one commit per record (hundreds of junk commits). Pass the whole array/stream to a single `upsert`.
+
 ## When to use `gitsheets-axi` vs `gitsheets`
 
 | Scenario | Use |
-|---|---|
+| --- | --- |
 | Agent is reading/writing records via shell | `gitsheets-axi` |
 | Writing TypeScript that imports `gitsheets` | `gitsheets` library |
 | Authoring `.gitsheets/<name>.toml` configs | Either (the configs are the same) |

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -151,19 +151,35 @@ Output on no-op mirrors the shape with `result: no-op` and no `commit`.
 
 > **Working-tree gotcha.** gitsheets writes to the git **ref** via plumbing; it does **not** touch your working tree. Right after a commit, `git status` shows the new records as *deleted* on disk (the ref has them, the working tree doesn't). Run `git checkout HEAD -- .` to materialize them. This surprises every first-time user — it's not data loss.
 
-### `gitsheets-axi patch <sheet> <query-json> [--patch <json>] [flags]`
+### `gitsheets-axi patch <sheet> [<query-json>] [flags]`
 
-RFC 7396 JSON Merge Patch against the record matched by `<query-json>`. `null` deletes a field, arrays replace, objects merge recursively.
+RFC 7396 JSON Merge Patch — update fields without replacing the whole record. `null` deletes a field, arrays replace, objects merge recursively. Two modes:
 
 | Flag | Notes |
 | --- | --- |
-| `--patch <json>` | Partial JSON. If omitted, reads stdin. |
+| `--patch <json>` | **Single mode**: partial JSON for the record matched by `<query-json>`. If omitted, reads stdin. |
+| `--data <json>` | **Bulk mode**: a JSON array / NDJSON of combined records. If omitted, reads stdin. |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message |
 
-**Idempotent.** Same no-op semantics as upsert.
+**Single** — explicit query + partial:
 
-Throws `NOT_FOUND` if the query matches no record.
+```bash
+gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane O. Doe"}'
+```
+
+**Bulk — this is the classification primitive.** Drop the `<query-json>` positional and pass an array / NDJSON of **combined** records. In each record the sheet's **path-template fields** form the query (which record to patch); the **remaining fields** are the merge patch. Every patch runs in **one transaction → one commit**:
+
+```bash
+# classify many repos at once — one commit, merge-not-replace
+jq -c '.[] | {name, target_team, status}' decisions.json | gitsheets-axi patch repos
+```
+
+Prefer bulk `patch` over bulk `upsert` for updates: `upsert` is a full-record *replace* (you must carry every existing field or lose it), while `patch` merges — you emit only the fields you're setting, and untouched fields are safe.
+
+**Idempotent.** Unchanged records are skipped; a batch where nothing changed is a `no-op` with no commit. In a batch, a record whose query matches nothing **aborts the whole transaction** (nothing committed) and names the offending row. Output mirrors bulk `upsert` (`patched:` / `unchanged:` / the materialize hint).
+
+Single mode throws `NOT_FOUND` if the query matches no record.
 
 ### `gitsheets-axi delete <sheet> <path> [flags]`
 
@@ -288,7 +304,20 @@ Populating a sheet from an external source (a GitHub API dump, a CSV, another sy
 4. **Materialize the working tree** if you want the files on disk: `git checkout HEAD -- .` (gitsheets committed to the ref, not the working tree — see the gotcha under `upsert`).
 5. **Round-trip to reshape:** `gitsheets-axi query <sheet> --ndjson-out` → transform the file with `jq` → pipe back into `upsert`. Exported JSON/NDJSON is verbatim, so re-import is clean and idempotent.
 
-Do **not** loop `upsert --data` once per record — that produces one commit per record (hundreds of junk commits). Pass the whole array/stream to a single `upsert`.
+**Incrementally classifying / updating records** (adding `target_team`, `status`, etc. to records that already exist) is a **bulk `patch`** job, not upsert:
+
+```bash
+# pull the worklist, decide, patch the whole pass in one commit
+gitsheets-axi query repos --filter status=unclassified --ndjson-out
+# → transform into {name, target_team, status} decisions with jq/logic, then:
+jq -c '.[]' decisions.json | gitsheets-axi patch repos --message "classify batch 1"
+gitsheets-axi diff repos HEAD~1        # review what changed
+gitsheets-axi query repos --filter status=unclassified   # what's left
+```
+
+`patch` merges, so you emit only the fields you're setting and the rest of each record is safe — whereas `upsert` would replace the whole record and drop anything you didn't re-send. Idempotency makes each pass re-runnable (already-classified records no-op), and `diff` per batch is your review surface.
+
+Do **not** loop `upsert --data` (or `patch`) once per record — that produces one commit per record (hundreds of junk commits). Pass the whole array/stream to a single `upsert` / `patch`.
 
 ## When to use `gitsheets-axi` vs `gitsheets`
 

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -4,10 +4,15 @@
 
 **Use `gitsheets-axi` when an agent is reading or mutating gitsheets data via shell execution.** Use the `gitsheets` library (TypeScript imports) when authoring code that runs inside an application.
 
+**Getting the tool.** If `gitsheets-axi` isn't already on `PATH`, don't stop — you don't need to install anything to start:
+
 ```bash
-npm install -g gitsheets-axi    # one-time global install
-gitsheets-axi                   # session-aware home view
+gitsheets-axi query users            # if it's already installed
+npx -y gitsheets-axi query users     # zero-install: runs the published package on demand
+npm install -g gitsheets-axi         # optional: install once for a persistent global command
 ```
+
+`npx -y gitsheets-axi <args>` runs the latest published package with no install step, so a fresh environment that has **only this skill** can use every command below by prefixing `npx -y`. For repeated use in a session, `npm install -g gitsheets-axi` once (then drop the prefix). To check availability: `command -v gitsheets-axi`. Every example in this reference writes the bare `gitsheets-axi` — prefix `npx -y` when it isn't installed.
 
 `gitsheets-axi` shares the gitsheets minor version (1.3.x ↔ 1.3.x). Major and minor stay in lockstep; patch versions are independent. Run `gitsheets-axi setup hooks` once to install opt-in `SessionStart` hooks for Claude Code, Codex, and OpenCode — once installed, every new agent session sees a TOON home view of the current repo's sheets.
 

--- a/skills/gitsheets/references/cli.md
+++ b/skills/gitsheets/references/cli.md
@@ -20,7 +20,7 @@
 ## Global flags
 
 | Flag | Default | Env |
-|---|---|---|
+| --- | --- | --- |
 | `--git-dir <path>` | discovered from cwd | `GIT_DIR` |
 | `--root <path>` | `/` | `GITSHEETS_ROOT` |
 | `--prefix <path>` | none | `GITSHEETS_PREFIX` |
@@ -33,6 +33,8 @@
 `--prefix` scopes records to a sub-tree under each sheet's configured root — useful for multi-tenant deployments. With `--prefix tenant-a`, a sheet with `root = 'users'` reads/writes records at `users/tenant-a/<path>.toml`. The sheet's config file is unaffected.
 
 A `--working` flag (read/write the working tree's state) is documented but deferred — see issue #165.
+
+> **Working-tree gotcha.** Every mutating command commits to the git **ref** via plumbing and does **not** update your checked-out files. After a write (especially a bulk `upsert`), `git status` shows the new records as *deleted* on disk — the ref has them, the working tree doesn't. Run `git checkout HEAD -- .` to materialize them. This is expected, not data loss, and is what #165's `--working` mode will eventually smooth over.
 
 ## upsert
 
@@ -206,7 +208,7 @@ Migration mapping: `type` → `[gitsheet.schema.properties.<name>].type`, `enum`
 ## Exit codes
 
 | Code | Meaning |
-|---|---|
+| --- | --- |
 | 0 | Success |
 | 1 | Generic / unknown error (or `check` reporting not-canonical) |
 | 2 | Argument-parsing error |


### PR DESCRIPTION
## What & why

Dogfooding a real workload (ingesting 463 GitHub repos into a gitsheets databank, then classifying them) surfaced a cluster of ergonomic gaps in `gitsheets-axi` around **data engineering at scale**. The agent-facing tool had no bulk path, so the natural approach produced one commit per record (hundreds of junk commits), and several first-run traps had no guidance. This batch closes them. No public-API breakage; all additions.

## New capabilities

### Bulk `upsert` — one commit per batch

- Input shape is autodetected (no flag): single object, **JSON array**, or **NDJSON** (one compact object per line).
- A batch upserts every record in **one transaction → one commit** (was one commit per call).
- Per-record idempotent: unchanged records skipped, all-unchanged = `no-op` with no commit. A single invalid record **aborts the whole batch** (nothing committed) and names the offending row.

### Bulk `patch` — the classification primitive

- `patch <sheet>` with no `<query-json>` positional reads an array / NDJSON of **combined** records: the sheet's path-template fields form the query, the rest is the RFC 7396 merge. One transaction → one commit. Mirrors the human CLI's `upsert --patch`.
- **Merge, not replace** — emit only the fields you're setting; untouched fields are safe. This is the correct primitive for incrementally classifying / tagging / backfilling records (bulk `upsert` would replace and silently drop fields).
- Idempotent; a record whose query matches nothing aborts the batch. Single mode (`patch <sheet> '{query}' --patch '{partial}'`) is unchanged.

### `query` side-channel exports (`--json-out` / `--ndjson-out` / `--csv-out`)

- Purely additive: stdout stays the token-cheap TOON preview; the file carries **every** matched record (ignores `--limit`).
- JSON/NDJSON are written **verbatim** so they round-trip straight back into `upsert` (export → transform with `jq` → re-import). CSV is flat + lossy, for reporting.
- Bare flag auto-writes a `0600` file under `$TMPDIR/gitsheets-axi/`; `=path` persists it. On write, stdout gains `wrote:` / `columns:` / a `jq` hint so a follow-up can be composed without opening the file. One export flag per invocation. (Follows the metabase-axi side-channel pattern from kunchenguid/axi#32, rather than `--json`-to-stdout.)

### Sharper errors / hints

- **Config not committed:** `upsert`/`query`/`patch`/`delete` now detect a `.gitsheets/<sheet>.toml` that exists in the working tree but not the committed tree and say exactly that (configs are read from the committed tree).
- **Working-tree materialize hint** on every commit: gitsheets writes to the git ref via plumbing and doesn't touch the working tree, so a fresh commit shows records as "deleted" on disk until `git checkout HEAD -- .`. This surprised every first-time user; now it's surfaced in output and docs.

## Skill docs (`skills/gitsheets/`)

- `references/axi.md`: bulk `upsert`/`patch`, the exports, a step-by-step "Bulk data engineering" recipe, an "incrementally classifying records" loop, and both gotchas.
- `SKILL.md`: always-true facts (writes land in the ref not the tree; configs read from the committed tree), a bulk-ingest pattern, and anti-patterns (don't loop single upserts; don't bulk-update via upsert; don't hand-serialize TOML).
- **Self-bootstrapping:** `npx -y gitsheets-axi <args>` runs the published package with zero install, so a skill-only environment can use every command by prefixing `npx -y`. Documented in both files.

## Dependency

Adds `csv-stringify` to `gitsheets-axi` (for `--csv-out`), committed separately.

## Testing

- 21 new tests (`bulk-upsert.test.ts` ×11, `bulk-patch.test.ts` ×10) covering one-commit batching, NDJSON autodetect, idempotency/no-op, partial-change subsets, batch-abort-on-bad-record, merge semantics (incl. `null` deletes a field), config-missing hint, export round-trip, and the mode guards.
- Full suite **380 passing**, type-check clean, clippy N/A. Verified end-to-end against the real built CLI for both the ingest and classification flows.

## Not in this PR

The upstream holo-tree hardening these surfaced (hologit#476 reflog identity, hologit#477 `write_child_hash`) is tracked separately, as are the gitsheets cleanups gated on it (#220, #221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd>
