### PR TITLE
chore: consume holo-tree fixes — place attachments by hash + drop CI git-identity workaround (#220, #221)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -31,17 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # The transaction tests commit to throwaway gix repos; gix's update_ref
-      # writes a reflog entry, which needs a committer identity from git config.
-      # CI runners have none configured, so without this the reflog write fails
-      # ("The reflog could not be created or updated"). Mirrors hologit's own
-      # holo-tree-napi.yml. (Upstream follow-up: holo-tree's update_ref should
-      # use the commit's identity for the reflog instead of ambient git config.)
-      - name: Configure git identity (commit-bearing tests write reflogs)
-        run: |
-          git config --global user.name "gitsheets CI"
-          git config --global user.email "ci@gitsheets.local"
-
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -78,13 +67,6 @@ jobs:
         node: ['20', '22']
     steps:
       - uses: actions/checkout@v7
-
-      # Same reflog-identity requirement as the core job (the Sheet/Transaction
-      # boundary tests commit to scratch repos).
-      - name: Configure git identity (commit-bearing tests write reflogs)
-        run: |
-          git config --global user.name "gitsheets CI"
-          git config --global user.email "ci@gitsheets.local"
 
       - uses: actions/setup-node@v6
         with:
@@ -140,14 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-
-      # The Sheet/Transaction commit tests + the cross-binding commit-parity test
-      # commit to scratch repos, whose update_ref writes a reflog needing a
-      # committer identity from git config (same requirement as the other jobs).
-      - name: Configure git identity (commit-bearing tests write reflogs)
-        run: |
-          git config --global user.name "gitsheets CI"
-          git config --global user.email "ci@gitsheets.local"
 
       - uses: actions/setup-python@v6
         with:

--- a/plans/attachment-staging-core.md
+++ b/plans/attachment-staging-core.md
@@ -131,6 +131,7 @@ needed. `gix`'s `blob-diff` feature is already on via its default features
 (`basic`), so **no new dependency** — no `cargo add`. A `Renamed` change carries
 `previous_path` (source) and `path` (destination); its src record is read from
 `previous_path`, and its patch is the src→dst field delta. `RecordStatus::Renamed`
+
 - `RecordChange.previous_path` are surfaced as `status: 'renamed'` / `previousPath`
 on both bindings' `diffRecords`.
 
@@ -151,9 +152,12 @@ correct and byte-identical.
 
 ## Follow-ups
 
-- **holo-tree `write_child_hash` primitive** — place an existing blob by hash at a
-  deep path without reading its bytes back (the efficiency note above). Upstream
-  hologit hardening; not blocking v1.x.
+- **holo-tree `write_child_hash` primitive — DONE (hologit#477 → gitsheets#221).**
+  Place an existing blob by hash at a deep path without reading its bytes back
+  (the efficiency note above). **Fixed upstream** in
+  [hologit#477](https://github.com/JarvusInnovations/hologit/pull/479) (released
+  as `holo-tree-v0.4.0`) and **consumed in gitsheets#221** — `set_attachments`
+  now places by hash via `write_child_hash`, dropping the redundant ODB read.
 - **`node-binding-thin` (the cutover)** rewires `packages/gitsheets` to route
   `Sheet.setAttachment(s)` / `deleteAttachment(s)` / `repo.writeBlob` and
   `Sheet.diffFrom` through this core surface (replacing the direct

--- a/plans/sheet-store-core.md
+++ b/plans/sheet-store-core.md
@@ -177,17 +177,17 @@ embedded-engine parity-gate concern.
 - **Tracked for `python-binding`.** The same `CoreTransaction` surface + the
   two-phase protocol drives the Python binding (Pydantic as the host validator);
   the core orchestration is binding-agnostic.
-- **Upstream holo-tree hardening (Issue).** `holo_repo::update_ref` writes a
-  reflog whose committer it reads from ambient **git config** identity, even when
-  the transaction supplies explicit author/committer for the commit. With no
-  `user.name`/`user.email` configured (a fresh CI runner, or a consumer in an
-  unconfigured/bare context) the ref update fails with *"The reflog could not be
-  created or updated."* Worked around for CI by configuring a git identity in
-  `rust-core.yml` (matching hologit's own CI), but the proper fix is upstream:
-  `update_ref` should derive the reflog identity from the commit's committer (or
-  accept an explicit one / allow suppressing the reflog) so a ref update never
-  depends on ambient git config. Per the holo-tree hardening mandate, file against
-  hologit.
+- **Upstream holo-tree hardening — DONE (hologit#476 → gitsheets#220).**
+  `holo_repo::update_ref` wrote a reflog whose committer it read from ambient
+  **git config** identity, even when the transaction supplied explicit
+  author/committer. With no `user.name`/`user.email` configured (a fresh CI
+  runner, or a consumer in an unconfigured/bare context) the ref update failed
+  with *"The reflog could not be created or updated."* Worked around for CI by
+  configuring a git identity in `rust-core.yml`. **Fixed upstream** in
+  [hologit#476](https://github.com/JarvusInnovations/hologit/pull/478) (released
+  as `holo-tree-v0.4.0`): `update_ref` now derives the reflog identity from the
+  commit's committer. **Consumed in gitsheets#220** — the CI workaround was
+  dropped and a no-ambient-identity regression test added.
 - **`sort = true` locale collation via boa (decide at `node-binding-thin`).**
   Array-field locale sorting (`sort = true`'s `localeCompare`) currently runs
   through the boa engine, which lacks `Intl` — so for non-ASCII / case-sensitive

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1282,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1847,6 +1847,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1867,7 +1870,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "holo-tree"
 version = "0.1.0"
-source = "git+https://github.com/JarvusInnovations/hologit?branch=develop#ba99e706120bf531b6329983933f33460672e634"
+source = "git+https://github.com/JarvusInnovations/hologit?tag=holo-tree-v0.4.0#ba99e706120bf531b6329983933f33460672e634"
 dependencies = [
  "gix",
  "globset",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1282,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1847,9 +1847,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heapless"
@@ -1870,7 +1867,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "holo-tree"
 version = "0.1.0"
-source = "git+https://github.com/JarvusInnovations/hologit?branch=develop#e3750660b373ffa4767de347989fa63f322e9b31"
+source = "git+https://github.com/JarvusInnovations/hologit?branch=develop#ba99e706120bf531b6329983933f33460672e634"
 dependencies = [
  "gix",
  "globset",

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -32,13 +32,13 @@ jsonschema = { version = "0.46.7", default-features = false }
 serde_json = "1"
 
 # ── record-engine-core (the holo-tree substrate seam) ────────────────────────
-# Mutable in-memory git trees (read/write/delete blobs, commit, ref CAS). Not on
-# crates.io, so a git dependency on the hologit repo (the form decided in
-# gitsheets-core-foundation). `branch = "develop"`, NOT `master`: the merged
-# spike fixes this layer relies on — notably `delete_child_deep`'s
-# dirty-propagation (hologit#473) — live on develop and are not yet on master.
-# `Cargo.lock` is committed so the exact commit is pinned and reproducible.
-holo-tree = { git = "https://github.com/JarvusInnovations/hologit", branch = "develop" }
+# Mutable in-memory git trees (read/write/delete blobs, commit, ref CAS). The
+# holo-tree crate isn't on crates.io, so this is a git dependency pinned to an
+# immutable `holo-tree-v*` release tag (cut in lockstep with the `@hologit/
+# holo-tree` npm package). holo-tree-v0.4.0 carries the reflog-identity
+# (hologit#476) and write_child_hash (hologit#477) fixes this crate consumes.
+# Bump the tag to adopt a new release; `Cargo.lock` still pins the exact commit.
+holo-tree = { git = "https://github.com/JarvusInnovations/hologit", tag = "holo-tree-v0.4.0" }
 # The git object layer holo-tree drives. Pinned to the SAME version holo-tree
 # depends on (0.83) so the `gix::Repository` handle this crate opens and passes
 # into holo-tree is one unified type. Default features (matching holo-tree) cover

--- a/rust/gitsheets-core/src/record.rs
+++ b/rust/gitsheets-core/src/record.rs
@@ -213,24 +213,15 @@ pub fn write_blob_at_dir(git_dir: &str, bytes: &[u8]) -> Result<String> {
     write_blob(&repo, bytes)
 }
 
-/// Read a blob's raw bytes by its hex hash, validating it exists in the ODB and
-/// is a blob (not a tree/commit) — the read half of attachment staging. A
-/// missing object is [`Error::RecordNotFound`]; a non-blob is
-/// [`Error::ConfigInvalid`]. Used to place an already-written blob (by hash)
-/// into a tree at a deep path.
-pub(crate) fn read_blob_bytes_by_hash(repo: &gix::Repository, hash: &str) -> Result<Vec<u8>> {
-    let oid = ObjectId::from_hex(hash.as_bytes()).map_err(|e| Error::CommitFailed {
+/// Parse a hex object id, erroring on malformed input. Placing an
+/// already-written blob into a tree by hash goes through holo-tree's
+/// `MutableTree::write_child_hash`, which validates existence + blob-kind from
+/// the object header (no byte read) — so attachment staging no longer reads the
+/// blob back just to re-place it (hologit#477).
+pub(crate) fn parse_oid(hash: &str) -> Result<ObjectId> {
+    ObjectId::from_hex(hash.as_bytes()).map_err(|e| Error::CommitFailed {
         message: format!("invalid blob hash {hash:?}: {e}"),
-    })?;
-    let obj = repo.find_object(oid).map_err(|e| Error::RecordNotFound {
-        message: format!("blob {hash} not found in object database: {e}"),
-    })?;
-    if obj.kind != gix::object::Kind::Blob {
-        return Err(Error::ConfigInvalid {
-            message: format!("object {hash} is not a blob (it is a {:?})", obj.kind),
-        });
-    }
-    Ok(obj.data.to_vec())
+    })
 }
 
 // ── join / path helpers ──────────────────────────────────────────────────────
@@ -955,24 +946,8 @@ mod tests {
         // Independently computed git blob hash: sha1("blob <len>\0<bytes>").
         assert_eq!(hash, git_blob_hash(bytes));
         // And the object is retrievable + byte-identical.
-        let read = read_blob_bytes_by_hash(&repo, &hash).unwrap();
-        assert_eq!(read, bytes);
-    }
-
-    #[test]
-    fn read_blob_bytes_by_hash_rejects_missing_and_non_blob() {
-        let (_dir, repo) = temp_repo();
-        // A well-formed but absent hash → record_not_found.
-        let absent = "0".repeat(40);
-        let err = read_blob_bytes_by_hash(&repo, &absent).err().unwrap();
-        assert_eq!(err.code(), "record_not_found");
-        // A tree hash (the empty tree) is not a blob → config_invalid.
-        let mut t = MutableTree::empty();
-        write_records(&repo, &mut t, "people", &[("jane".into(), rec(&[("slug", s("jane"))]))], TOML_EXTENSION)
-            .unwrap();
-        let tree_hash = t.write(&repo).unwrap().to_string();
-        let err = read_blob_bytes_by_hash(&repo, &tree_hash).err().unwrap();
-        assert_eq!(err.code(), "config_invalid");
+        let obj = repo.find_object(parse_oid(&hash).unwrap()).unwrap();
+        assert_eq!(obj.data, bytes);
     }
 
     // ── rename detection (git diff-tree -M parity) ───────────────────────────

--- a/rust/gitsheets-core/src/sheet.rs
+++ b/rust/gitsheets-core/src/sheet.rs
@@ -477,13 +477,12 @@ impl Sheet {
     ) -> Result<()> {
         for (name, blob_hash) in attachments {
             let full = self.attachment_path(record_path, name);
-            // Re-read the (already-written) blob by hash and place it at `full`.
-            // holo-tree lacks a place-by-hash primitive (upstream hardening
-            // finding — a `MutableTree::write_child_hash(path, hash, mode)` would
-            // avoid this read); `write_child_bytes` re-hashes to the same content-
-            // addressed id, so the placed object is byte-identical.
-            let bytes = record::read_blob_bytes_by_hash(repo, blob_hash)?;
-            tree.write_child_bytes(repo, &full, &bytes)
+            // Place the already-written blob at `full` by hash — holo-tree's
+            // `write_child_hash` validates existence + blob-kind from the object
+            // header (no byte read + re-hash), so a large attachment isn't read
+            // back just to re-place it (hologit#477). 0o100644 = regular file.
+            let oid = record::parse_oid(blob_hash)?;
+            tree.write_child_hash(repo, &full, oid, 0o100644)
                 .map_err(record::map_ht)?;
         }
         self.index_cache = None;
@@ -1285,6 +1284,32 @@ mod tests {
         // The record file is NOT reported as an attachment (it's a sibling).
         let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
         assert_eq!(names, vec!["avatar.jpg", "cover.png"]);
+    }
+
+    #[test]
+    fn set_attachments_rejects_missing_and_non_blob_hashes() {
+        let (_d, repo) = temp_repo();
+        let mut tree = tree_with_config(&repo, config("${{ slug }}", "people"));
+        let mut sheet = open(&repo, &mut tree);
+        stage_record(&mut sheet, &repo, &mut tree, "jane");
+
+        // A well-formed but absent hash is rejected — the placement is validated
+        // (via write_child_hash's header lookup) before any tree mutation.
+        let absent = "0".repeat(40);
+        assert!(sheet
+            .set_attachments(&repo, &mut tree, "jane", &[("x.bin".into(), absent)])
+            .is_err());
+
+        // A tree hash (not a blob) is rejected with a clear message.
+        let tree_hash = tree.write(&repo).unwrap().to_string();
+        let err = sheet
+            .set_attachments(&repo, &mut tree, "jane", &[("x.bin".into(), tree_hash)])
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("not a blob"), "got: {err}");
+
+        // The rejections left no stray attachment behind.
+        assert_eq!(sheet.get_attachments(&repo, &mut tree, "jane").unwrap(), None);
     }
 
     #[test]

--- a/rust/gitsheets-core/src/transaction.rs
+++ b/rust/gitsheets-core/src/transaction.rs
@@ -557,6 +557,52 @@ mod tests {
         (dir, git_dir, commit)
     }
 
+    /// Regression for hologit#476 / gitsheets#220: the commit + ref-update path
+    /// must not depend on ambient git config. We open the repo with `isolated()`
+    /// options — no environment / global / system config, so no `user.name` /
+    /// `user.email` is visible — enable reflogs in LOCAL config (honored under
+    /// isolation, and needed so the reflog-identity path actually runs), then
+    /// drive the same `commit_tree` + `update_ref` that `finalize` uses. The old
+    /// holo-tree read the reflog committer from ambient config and failed here
+    /// with "The reflog could not be created or updated"; the fix derives it from
+    /// the commit's committer, so no machine identity is needed. This is why CI
+    /// no longer configures a git identity.
+    #[test]
+    fn commit_and_ref_update_need_no_ambient_git_identity() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        gix::init(dir.path()).unwrap();
+        let mut cfg = std::fs::OpenOptions::new()
+            .append(true)
+            .open(dir.path().join(".git/config"))
+            .unwrap();
+        writeln!(cfg, "[core]\n\tlogallrefupdates = true").unwrap();
+        drop(cfg);
+
+        // No ambient git identity visible to this handle.
+        let repo = gix::open_opts(dir.path(), gix::open::Options::isolated()).unwrap();
+
+        let mut tree = MutableTree::empty();
+        let tree_hash = tree.write(&repo).unwrap();
+        let sig = build_signature(
+            &Author { name: "Test".into(), email: "test@test".into() },
+            1_600_000_000,
+            0,
+        )
+        .unwrap();
+        let commit =
+            holo_repo::commit_tree(&repo, tree_hash, &[], "init\n", Some(sig.clone()), Some(sig))
+                .unwrap();
+
+        // The assertion: the ref update (which writes a reflog) succeeds despite
+        // no ambient git identity. Panics on the pre-fix holo-tree.
+        holo_repo::update_ref(&repo, "refs/heads/main", commit, None).unwrap();
+        assert_eq!(
+            holo_repo::resolve_ref(&repo, "refs/heads/main").unwrap(),
+            Some(commit),
+        );
+    }
+
     fn default_opts(message: &str) -> TransactionOptions {
         TransactionOptions {
             parent: None,


### PR DESCRIPTION
## What & why

During the Rust-core migration we surfaced two holo-tree ergonomics gaps and papered over them downstream. Both are now fixed upstream and shipped in **holo-tree ≥ ba99e70** (`@hologit/holo-tree@0.4.0`), so this PR consumes the fixes and removes the workarounds.

- **hologit#476** — `update_ref` derived its reflog identity from ambient git config, so a fully-specified commit still failed on an identity-less runner with *"The reflog could not be created or updated."* Now it derives the identity from the commit's committer.
- **hologit#477** — `MutableTree` gained `write_child_hash(path, hash, mode)` to place an already-written blob by hash without reading its bytes.

Closes #220. Closes #221.

## Changes

**Pin holo-tree to a release tag** (`rust/gitsheets-core/Cargo.toml` + `rust/Cargo.lock`) — the git dependency now points at the immutable **`holo-tree-v0.4.0`** tag (commit `ba99e70`, cut in lockstep with `@hologit/holo-tree@0.4.0` on npm) instead of tracking the moving `branch = "develop"`. Same commit, reproducible, and it won't drift on `cargo update`. (The crate isn't on crates.io, so a git dep is still required; the npm artifact is the JS/napi binding and can't be consumed by Cargo.)

**#221 — place attachments by hash (`gitsheets-core`)**

- `Sheet::set_attachments` now calls `MutableTree::write_child_hash(repo, path, oid, 0o100644)` instead of reading the blob back by hash and re-placing it with `write_child_bytes`. `write_child_hash` validates existence + blob-kind from the object *header* (no payload read), so placing a large attachment no longer pays a redundant ODB read + re-hash. Output is still byte-identical.
- Replaced the now-unnecessary `record::read_blob_bytes_by_hash` (its sole job was the read-back workaround) with a lean `record::parse_oid` helper. The missing/non-blob rejection coverage moved to a `set_attachments`-level test (the validation now lives in `write_child_hash`).

**#220 — drop the CI git-identity workaround (`.github/workflows/rust-core.yml`)**

- Removed the three `Configure git identity` steps (core / napi / py jobs). They existed only to satisfy the old `update_ref` reflog write; with #476 the commit-bearing test suite runs identity-free.
- Added a `gitsheets-core` regression test (`commit_and_ref_update_need_no_ambient_git_identity`) that opens a repo with `gix` **isolated** options (no environment / global / system config, so no `user.name` / `user.email`), enables reflogs locally, and drives the same `commit_tree` + `update_ref` `finalize` uses — asserting it succeeds. It panics on the pre-fix holo-tree, and it's what guards against a future dependency downgrade re-introducing the ambient-identity requirement.

## Testing

`cargo test -p gitsheets-core` — 164 pass (incl. the two new tests). Workspace builds (core + napi + py). napi/py boundary + cross-binding attachment suites run in CI — now on runners with no configured git identity, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd>
