### PR TITLE
feat(axi): read-side analytics, filter operators, write robustness, rename + bulk delete (#223)

### DIFF
--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -12,6 +12,7 @@ import { distinctCommand, DISTINCT_HELP } from './commands/distinct.js';
 import { readCommand, READ_HELP } from './commands/read.js';
 import { upsertCommand, UPSERT_HELP } from './commands/upsert.js';
 import { patchCommand, PATCH_HELP } from './commands/patch.js';
+import { renameCommand, RENAME_HELP } from './commands/rename.js';
 import { deleteCommand, DELETE_HELP } from './commands/delete.js';
 import { checkCommand, CHECK_HELP } from './commands/check.js';
 import { diffCommand, DIFF_HELP } from './commands/diff.js';
@@ -30,10 +31,10 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[18]:
+commands[19]:
   (none)=home, sheets, query, count,
-  distinct, read, upsert, patch, delete,
-  check, diff, normalize,
+  distinct, read, upsert, patch, rename,
+  delete, check, diff, normalize,
   init, infer, migrate-config,
   attachment, push, setup
 flags[2]:
@@ -60,6 +61,7 @@ const COMMAND_HELP: Record<string, string> = {
   read: READ_HELP,
   upsert: UPSERT_HELP,
   patch: PATCH_HELP,
+  rename: RENAME_HELP,
   delete: DELETE_HELP,
   check: CHECK_HELP,
   diff: DIFF_HELP,
@@ -82,6 +84,7 @@ const COMMANDS: Record<string, CommandFn> = {
   read: readCommand,
   upsert: upsertCommand,
   patch: patchCommand,
+  rename: renameCommand,
   delete: deleteCommand,
   check: checkCommand,
   diff: diffCommand,

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -7,6 +7,8 @@ import { createContext, type GitsheetsContext } from './context.js';
 import { homeCommand } from './commands/home.js';
 import { sheetsCommand, SHEETS_HELP } from './commands/sheets.js';
 import { queryCommand, QUERY_HELP } from './commands/query.js';
+import { countCommand, COUNT_HELP } from './commands/count.js';
+import { distinctCommand, DISTINCT_HELP } from './commands/distinct.js';
 import { readCommand, READ_HELP } from './commands/read.js';
 import { upsertCommand, UPSERT_HELP } from './commands/upsert.js';
 import { patchCommand, PATCH_HELP } from './commands/patch.js';
@@ -28,9 +30,9 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[16]:
-  (none)=home, sheets, query, read,
-  upsert, patch, delete,
+commands[18]:
+  (none)=home, sheets, query, count,
+  distinct, read, upsert, patch, delete,
   check, diff, normalize,
   init, infer, migrate-config,
   attachment, push, setup
@@ -38,22 +40,23 @@ flags[2]:
   --help, -v/-V/--version
 examples:
   gitsheets-axi
-  gitsheets-axi query users --filter status=active
+  gitsheets-axi query repos --filter status=unclassified --sort pushed_at
+  gitsheets-axi count repos --filter archived=true
+  gitsheets-axi query repos --group-by target_team
+  gitsheets-axi distinct repos disposition
   gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
   gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane"}'
   gitsheets-axi check users users/jane.toml --fix
   gitsheets-axi diff posts HEAD~10
-  gitsheets-axi normalize users
-  gitsheets-axi init users
-  gitsheets-axi infer users
   gitsheets-axi attachment list users jane
-  gitsheets-axi push
   gitsheets-axi setup hooks
 `;
 
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
   query: QUERY_HELP,
+  count: COUNT_HELP,
+  distinct: DISTINCT_HELP,
   read: READ_HELP,
   upsert: UPSERT_HELP,
   patch: PATCH_HELP,
@@ -74,6 +77,8 @@ type CommandFn = (args: string[], ctx: GitsheetsContext) => Promise<string | Rec
 const COMMANDS: Record<string, CommandFn> = {
   sheets: sheetsCommand,
   query: queryCommand,
+  count: countCommand,
+  distinct: distinctCommand,
   read: readCommand,
   upsert: upsertCommand,
   patch: patchCommand,

--- a/packages/gitsheets-axi/src/commands/count.ts
+++ b/packages/gitsheets-axi/src/commands/count.ts
@@ -1,0 +1,99 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
+import { buildPredicate } from '../util/filter.js';
+
+export const COUNT_HELP = `usage: gitsheets-axi count <sheet> [--filter k=v ...] [--prefix p]
+flags[2]:
+  --filter <expr>      Filter clause (repeatable). k=v · k!=v · k<v · k>v ·
+                       k<=v · k>=v · k~regex · "k in (a,b)" · k:present · k:empty
+  --prefix <p>         Tenant sub-tree scope
+examples:
+  gitsheets-axi count repos
+  gitsheets-axi count repos --filter status=unclassified
+  gitsheets-axi count repos --filter 'pushed_at<2022-01-01' --filter archived=false
+note:
+  With no --filter, counts candidate record paths without parsing (cheap).
+  A filter scans body-less records and counts matches.
+`;
+
+interface CountFlags {
+  sheet: string;
+  filters: string[];
+  prefix: string | undefined;
+}
+
+function parseCountFlags(args: string[]): CountFlags {
+  const sheet = args[0];
+  if (!sheet || sheet.startsWith('-')) {
+    throw new AxiError('count requires a sheet name', 'VALIDATION_ERROR', [
+      'Run `gitsheets-axi count <sheet>`',
+    ]);
+  }
+  const flags: CountFlags = { sheet, filters: [], prefix: undefined };
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+    switch (arg) {
+      case '--filter':
+        if (!next) throw new AxiError('--filter expects an expression', 'VALIDATION_ERROR');
+        flags.filters.push(next);
+        i++;
+        break;
+      case '--prefix':
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        flags.prefix = next;
+        i++;
+        break;
+      default:
+        throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+          'Run `gitsheets-axi count --help`',
+        ]);
+    }
+  }
+  return flags;
+}
+
+export async function countCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return COUNT_HELP;
+  }
+
+  const flags = parseCountFlags(args);
+  const repo = await ctx.repo();
+  const sheet = await openSheetForCommand(
+    repo,
+    flags.sheet,
+    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+  );
+
+  // No filter → the cheap candidate-path count.
+  if (flags.filters.length === 0) {
+    try {
+      return renderObject({ sheet: flags.sheet, count: await sheet.count() });
+    } catch (error) {
+      throw translateError(error);
+    }
+  }
+
+  // Filtered → scan body-less and count matches, reporting the total too.
+  const predicate = buildPredicate(flags.filters);
+  let matched = 0;
+  let total = 0;
+  try {
+    const records = await sheet.queryAll({}, { withBody: false });
+    total = records.length;
+    for (const r of records) {
+      if (predicate(r as Record<string, unknown>)) matched++;
+    }
+  } catch (error) {
+    throw translateError(error);
+  }
+  return renderObject({ sheet: flags.sheet, count: matched, of: total });
+}

--- a/packages/gitsheets-axi/src/commands/delete.ts
+++ b/packages/gitsheets-axi/src/commands/delete.ts
@@ -1,27 +1,39 @@
 import { AxiError } from 'axi-sdk-js';
-import { NotFoundError, RECORD_PATH_KEY } from 'gitsheets';
+import { NotFoundError, RECORD_PATH_KEY, type Repository, type Sheet } from 'gitsheets';
 
 import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
-import { renderObject } from '../output/render.js';
+import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
 import { openSheetForCommand } from '../util/open-sheet.js';
+import { buildPredicate } from '../util/filter.js';
+import { readStdin } from '../util/stdin.js';
+import { MATERIALIZE_HINT } from '../util/hints.js';
 
 export const DELETE_HELP = `usage: gitsheets-axi delete <sheet> <path> [--prefix p] [--message m]
-flags[2]:
+       gitsheets-axi delete <sheet> --filter expr ... [--dry-run]   # bulk by query
+       gitsheets-axi delete <sheet> --stdin [--dry-run]             # bulk by id/path list
+flags[5]:
+  --filter <expr>      Bulk: delete every record matching the filter DSL (repeatable)
+  --stdin              Bulk: delete records named one-per-line on stdin
+  --dry-run            Bulk: report how many would be deleted — no commit
   --prefix <p>         Tenant sub-tree scope
   --message <m>        Commit message (default: "<sheet> delete <path>")
 examples:
   gitsheets-axi delete users jane
-  gitsheets-axi delete posts hello --message "remove deprecated post"
+  gitsheets-axi delete repos --filter disposition=delete-candidate --dry-run
+  gitsheets-axi delete repos --filter disposition=delete-candidate
+  cat paths.txt | gitsheets-axi delete repos --stdin
 idempotency:
-  Already-missing records exit 0 with result: "no-op" — no commit, no
-  error. Pattern: an agent re-running a workflow can safely call delete
-  without checking existence first.
+  Already-missing records exit 0 with result: "no-op" — no commit, no error.
+  Bulk delete removes every matching record in ONE commit.
 `;
 
 interface DeleteFlags {
   sheet: string;
-  path: string;
+  path: string | undefined;
+  filters: string[];
+  stdin: boolean;
+  dryRun: boolean;
   prefix: string | undefined;
   message: string | undefined;
 }
@@ -29,7 +41,10 @@ interface DeleteFlags {
 function parseDeleteFlags(args: string[]): DeleteFlags {
   const flags: DeleteFlags = {
     sheet: '',
-    path: '',
+    path: undefined,
+    filters: [],
+    stdin: false,
+    dryRun: false,
     prefix: undefined,
     message: undefined,
   };
@@ -38,32 +53,57 @@ function parseDeleteFlags(args: string[]): DeleteFlags {
     const arg = args[i];
     if (arg === undefined) continue;
     const next = args[i + 1];
-    if (arg === '--prefix') {
-      if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
-      flags.prefix = next;
-      i++;
-      continue;
+    switch (arg) {
+      case '--filter':
+        if (!next) throw new AxiError('--filter expects an expression', 'VALIDATION_ERROR');
+        flags.filters.push(next);
+        i++;
+        break;
+      case '--stdin':
+        flags.stdin = true;
+        break;
+      case '--dry-run':
+        flags.dryRun = true;
+        break;
+      case '--prefix':
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        flags.prefix = next;
+        i++;
+        break;
+      case '--message':
+        if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+        flags.message = next;
+        i++;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+            'Run `gitsheets-axi delete --help`',
+          ]);
+        }
+        positional.push(arg);
     }
-    if (arg === '--message') {
-      if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
-      flags.message = next;
-      i++;
-      continue;
-    }
-    if (arg.startsWith('-')) {
-      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
-        'Run `gitsheets-axi delete --help`',
-      ]);
-    }
-    positional.push(arg);
   }
-  if (positional.length !== 2) {
-    throw new AxiError('delete requires <sheet> <path>', 'VALIDATION_ERROR', [
+  flags.sheet = positional[0] ?? '';
+  flags.path = positional[1];
+
+  const bulk = flags.filters.length > 0 || flags.stdin;
+  if (!flags.sheet) {
+    throw new AxiError('delete requires <sheet>', 'VALIDATION_ERROR', [
       'Example: gitsheets-axi delete users jane',
     ]);
   }
-  flags.sheet = positional[0]!;
-  flags.path = positional[1]!;
+  if (flags.filters.length > 0 && flags.stdin) {
+    throw new AxiError('Use either --filter or --stdin, not both', 'VALIDATION_ERROR');
+  }
+  if (bulk && flags.path !== undefined) {
+    throw new AxiError('Drop the <path> positional in bulk mode (--filter / --stdin)', 'VALIDATION_ERROR');
+  }
+  if (!bulk && flags.path === undefined) {
+    throw new AxiError('delete requires <sheet> <path> (or --filter / --stdin for bulk)', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi delete users jane',
+    ]);
+  }
   return flags;
 }
 
@@ -76,16 +116,25 @@ export async function deleteCommand(
   }
 
   const flags = parseDeleteFlags(args);
-  const target = stripExtension(flags.path);
+  const prefixOpts = flags.prefix !== undefined ? { prefix: flags.prefix } : {};
 
   const repo = await ctx.repo();
-  const sheet = await openSheetForCommand(
-    repo,
-    flags.sheet,
-    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-  );
+  const sheet = await openSheetForCommand(repo, flags.sheet, prefixOpts);
 
-  // Pre-flight existence check — idempotent on already-missing.
+  if (flags.filters.length > 0 || flags.stdin) {
+    return bulkDelete(repo, sheet, flags, prefixOpts);
+  }
+  return singleDelete(repo, sheet, flags, prefixOpts);
+}
+
+async function singleDelete(
+  repo: Repository,
+  sheet: Sheet,
+  flags: DeleteFlags,
+  prefixOpts: { prefix?: string },
+): Promise<string> {
+  const target = stripExtension(flags.path!);
+
   let exists = false;
   try {
     for await (const record of sheet.query()) {
@@ -110,16 +159,10 @@ export async function deleteCommand(
 
   const commitMessage = flags.message ?? `${flags.sheet} delete ${target}`;
   try {
-    const result = await repo.transact(
-      { message: commitMessage },
-      async (tx) => {
-        const txSheet = tx.sheet(
-          flags.sheet,
-          flags.prefix !== undefined ? { prefix: flags.prefix } : {},
-        );
-        await txSheet.delete(target);
-      },
-    );
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      await txSheet.delete(target);
+    });
     return renderObject({
       result: 'committed',
       sheet: flags.sheet,
@@ -127,8 +170,6 @@ export async function deleteCommand(
       commit: result.commitHash,
     });
   } catch (error) {
-    // Edge: race where the record vanished between the existence check
-    // and the delete. Treat as no-op rather than failing.
     if (error instanceof NotFoundError) {
       return renderObject({
         result: 'no-op',
@@ -141,9 +182,72 @@ export async function deleteCommand(
   }
 }
 
+async function bulkDelete(
+  repo: Repository,
+  sheet: Sheet,
+  flags: DeleteFlags,
+  prefixOpts: { prefix?: string },
+): Promise<string> {
+  // Resolve the delete set against records that actually exist, so the result
+  // is idempotent (absent ids are skipped, not errors).
+  const existing = await sheet.queryAll({}, { withBody: false });
+  const existingPaths = new Set<string>();
+  for (const r of existing) {
+    const p = (r as Record<symbol, unknown>)[RECORD_PATH_KEY];
+    if (typeof p === 'string') existingPaths.add(p);
+  }
+
+  let targets: string[];
+  if (flags.stdin) {
+    const raw = await readStdin();
+    const requested = raw
+      .split('\n')
+      .map((s) => stripExtension(s.trim()))
+      .filter((s) => s.length > 0);
+    targets = requested.filter((p) => existingPaths.has(p));
+  } else {
+    const predicate = buildPredicate(flags.filters);
+    targets = (existing as Array<Record<string, unknown>>)
+      .filter(predicate)
+      .map((r) => (r as Record<symbol, unknown>)[RECORD_PATH_KEY])
+      .filter((p): p is string => typeof p === 'string');
+  }
+
+  if (flags.dryRun) {
+    return renderObject({
+      result: 'dry-run',
+      sheet: flags.sheet,
+      willDelete: targets.length,
+      of: existingPaths.size,
+    });
+  }
+
+  if (targets.length === 0) {
+    return renderObject({ result: 'no-op', sheet: flags.sheet, deleted: 0 });
+  }
+
+  const commitMessage = flags.message ?? `${flags.sheet} delete (${targets.length})`;
+  try {
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      for (const path of targets) await txSheet.delete(path);
+    });
+    return joinBlocks(
+      renderObject({
+        result: 'committed',
+        sheet: flags.sheet,
+        deleted: targets.length,
+        commit: result.commitHash,
+      }),
+      renderHelp([MATERIALIZE_HINT]),
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
 function stripExtension(path: string): string {
   if (path.endsWith('.toml')) return path.slice(0, -5);
   if (path.endsWith('.md')) return path.slice(0, -3);
-  if (path.endsWith('.mdx')) return path.slice(0, -4);
   return path;
 }

--- a/packages/gitsheets-axi/src/commands/distinct.ts
+++ b/packages/gitsheets-axi/src/commands/distinct.ts
@@ -1,0 +1,102 @@
+import { AxiError } from 'axi-sdk-js';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderListResponse } from '../output/render.js';
+import { field } from '../output/schema.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
+import { buildPredicate } from '../util/filter.js';
+import { facetCounts } from '../util/aggregate.js';
+
+export const DISTINCT_HELP = `usage: gitsheets-axi distinct <sheet> <field> [--filter expr ...] [--prefix p]
+flags[2]:
+  --filter <expr>      Filter clause (repeatable), same DSL as query
+  --prefix <p>         Tenant sub-tree scope
+examples:
+  gitsheets-axi distinct repos target_team
+  gitsheets-axi distinct repos disposition --filter status=classified
+note:
+  Lists each unique value of <field> (with its count), sorted alphabetically.
+  Use \`query --group-by <field>\` for the same facets ordered by count.
+`;
+
+interface DistinctFlags {
+  sheet: string;
+  field: string;
+  filters: string[];
+  prefix: string | undefined;
+}
+
+function parseDistinctFlags(args: string[]): DistinctFlags {
+  const positional: string[] = [];
+  const flags: DistinctFlags = { sheet: '', field: '', filters: [], prefix: undefined };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+    switch (arg) {
+      case '--filter':
+        if (!next) throw new AxiError('--filter expects an expression', 'VALIDATION_ERROR');
+        flags.filters.push(next);
+        i++;
+        break;
+      case '--prefix':
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        flags.prefix = next;
+        i++;
+        break;
+      default:
+        if (arg!.startsWith('-')) {
+          throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+            'Run `gitsheets-axi distinct --help`',
+          ]);
+        }
+        positional.push(arg!);
+    }
+  }
+  if (positional.length !== 2) {
+    throw new AxiError('distinct requires <sheet> <field>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi distinct repos target_team',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  flags.field = positional[1]!;
+  return flags;
+}
+
+export async function distinctCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return DISTINCT_HELP;
+  }
+
+  const flags = parseDistinctFlags(args);
+  const repo = await ctx.repo();
+  const sheet = await openSheetForCommand(
+    repo,
+    flags.sheet,
+    flags.prefix !== undefined ? { prefix: flags.prefix } : {},
+  );
+
+  let records;
+  try {
+    records = await sheet.queryAll({}, { withBody: false });
+  } catch (error) {
+    throw translateError(error);
+  }
+
+  const predicate = buildPredicate(flags.filters);
+  const matched = (records as Array<Record<string, unknown>>).filter(predicate);
+  const facets = facetCounts(matched, flags.field).sort((a, b) =>
+    a.value < b.value ? -1 : a.value > b.value ? 1 : 0,
+  );
+
+  return renderListResponse({
+    summary: { distinct: `${facets.length} values of ${flags.field}` },
+    name: 'values',
+    items: facets as unknown as Array<Record<string, unknown>>,
+    schema: [field('value'), field('count')],
+    emptyMessage: `no records in ${flags.sheet}`,
+  });
+}

--- a/packages/gitsheets-axi/src/commands/patch.ts
+++ b/packages/gitsheets-axi/src/commands/patch.ts
@@ -8,18 +8,29 @@ import { readStdin } from '../util/stdin.js';
 import { openSheetForCommand } from '../util/open-sheet.js';
 import { parseRecordsInput, recordLabel } from '../util/parse-records.js';
 import { MATERIALIZE_HINT } from '../util/hints.js';
+import { renderDryRun, type InvalidRow } from './upsert.js';
+
+const PATH_KEY = Symbol.for('gitsheets-path');
+type OnMissing = 'abort' | 'skip' | 'insert';
 
 export const PATCH_HELP = `usage: gitsheets-axi patch <sheet> <query-json> [--patch <json>] [--prefix p] [--message m]
-       gitsheets-axi patch <sheet> [--data <json>] [--prefix p] [--message m]   # bulk
-flags[4]:
+       gitsheets-axi patch <sheet> [--data <json>] [--on-missing m] [--delete-missing] [--dry-run]   # bulk
+flags[7]:
   --patch <json>       Single mode: RFC 7396 partial. If omitted, reads stdin.
   --data <json>        Bulk mode: JSON array / NDJSON of combined records.
+  --on-missing <m>     Bulk: what to do when a record's query matches nothing —
+                       abort (default) | skip | insert (upsert it as new).
+  --delete-missing     Bulk: delete existing records NOT targeted by the batch
+                       (exact re-sync). One commit.
+  --dry-run            Bulk: preview {will-change, no-op, missing, invalid,
+                       delete} — no commit.
   --prefix <p>         Tenant sub-tree scope
   --message <m>        Commit message (default: "<sheet> patch <path>")
 examples:
   gitsheets-axi patch users '{"slug":"jane"}' --patch '{"name":"Jane O. Doe"}'
-  echo '{"name":"Jane O. Doe"}' | gitsheets-axi patch users '{"slug":"jane"}'
-  jq -c '.[]' classify.json | gitsheets-axi patch repos      # bulk, one commit
+  jq -c '.[]' classify.json | gitsheets-axi patch repos                   # bulk, one commit
+  jq -c '.[]' classify.json | gitsheets-axi patch repos --on-missing skip # tolerate stale rows
+  gitsheets-axi patch repos --data "$(cat sync.json)" --on-missing insert --delete-missing
 bulk:
   With no <query-json>, input is a JSON array or NDJSON of records. In each
   record the sheet's path-template fields form the query (which record to
@@ -30,10 +41,10 @@ semantics:
   RFC 7396 JSON Merge Patch. \`null\` deletes a field, arrays replace
   in full, objects merge recursively. Same as gitsheets's library patch.
 idempotency:
-  Each record is merged and run through willChange. Unchanged records are
-  skipped; a batch where nothing changed exits 0 with result: "no-op" and no
-  commit. In a batch, a record whose query matches nothing aborts the whole
-  transaction — nothing is committed.
+  Unchanged records are skipped; a batch where nothing changed exits 0 with
+  result: "no-op" and no commit. With --on-missing abort (default), a record
+  matching nothing aborts the batch (nothing committed); --dry-run reports all
+  missing/invalid rows at once.
 `;
 
 interface PatchFlags {
@@ -43,6 +54,9 @@ interface PatchFlags {
   data: string | undefined;
   prefix: string | undefined;
   message: string | undefined;
+  onMissing: OnMissing;
+  deleteMissing: boolean;
+  dryRun: boolean;
 }
 
 function parsePatchFlags(args: string[]): PatchFlags {
@@ -53,6 +67,9 @@ function parsePatchFlags(args: string[]): PatchFlags {
     data: undefined,
     prefix: undefined,
     message: undefined,
+    onMissing: 'abort',
+    deleteMissing: false,
+    dryRun: false,
   };
   const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -69,6 +86,19 @@ function parsePatchFlags(args: string[]): PatchFlags {
         if (!next) throw new AxiError('--data expects JSON', 'VALIDATION_ERROR');
         flags.data = next;
         i++;
+        break;
+      case '--on-missing':
+        if (next !== 'abort' && next !== 'skip' && next !== 'insert') {
+          throw new AxiError('--on-missing expects abort | skip | insert', 'VALIDATION_ERROR');
+        }
+        flags.onMissing = next;
+        i++;
+        break;
+      case '--delete-missing':
+        flags.deleteMissing = true;
+        break;
+      case '--dry-run':
+        flags.dryRun = true;
         break;
       case '--prefix':
         if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
@@ -124,6 +154,12 @@ export async function patchCommand(
     if (flags.data !== undefined) {
       throw new AxiError(
         '--data is bulk mode — drop the <query-json> positional to use it',
+        'VALIDATION_ERROR',
+      );
+    }
+    if (flags.onMissing !== 'abort' || flags.deleteMissing || flags.dryRun) {
+      throw new AxiError(
+        '--on-missing / --delete-missing / --dry-run are bulk-only — drop the <query-json> positional',
         'VALIDATION_ERROR',
       );
     }
@@ -217,16 +253,19 @@ async function batchPatch(
   const { records } = parseRecordsInput(raw);
 
   const config = await sheet.readConfig();
-  const templateFields = new Set(Template.fromString(config.path).getFieldNames());
+  const template = Template.fromString(config.path);
+  const templateFields = new Set(template.getFieldNames());
 
-  // Pre-flight: split each record into (query, partial), confirm the target
-  // exists, and merge+willChange to categorize changed vs unchanged — all
-  // before opening a transaction, so a bad record aborts with nothing
-  // committed and the changed subset commits atomically.
-  const changes: Array<{
-    query: Record<string, unknown>;
-    partial: Record<string, unknown>;
-  }> = [];
+  // Pre-flight: split each record into (query, partial) and categorize —
+  // changed / unchanged / missing (query matched nothing) / invalid — before
+  // opening a transaction. We never throw mid-loop so --dry-run can report the
+  // full picture; the commit path aborts explicitly afterward.
+  const changes: Array<{ query: Record<string, unknown>; partial: Record<string, unknown> }> = [];
+  const inserts: Array<Record<string, unknown>> = [];
+  const batchPaths = new Set<string>();
+  const invalid: InvalidRow[] = [];
+  const missing: Array<{ row: number; id: string }> = [];
+  let unchanged = 0;
 
   for (let i = 0; i < records.length; i++) {
     const record = records[i]!;
@@ -238,47 +277,100 @@ async function batchPatch(
     }
 
     if (Object.keys(query).length === 0) {
-      throw new AxiError(
-        `Record ${i + 1} (${recordLabel(record)}) has none of the path-template fields (${[...templateFields].join(', ')}) — can't tell which record to patch`,
-        'VALIDATION_ERROR',
-        ['Each bulk-patch record must carry the path-template fields as its query'],
-      );
+      invalid.push({
+        row: i + 1,
+        id: recordLabel(record),
+        reason: `has none of the path-template fields (${[...templateFields].join(', ')})`,
+        code: 'VALIDATION_ERROR',
+      });
+      continue;
     }
-    // Query-only record (nothing to set) — a harmless no-op, skip it.
-    if (Object.keys(partial).length === 0) continue;
 
-    let willResult;
+    let preview;
     try {
-      willResult = await previewPatch(sheet, query, partial);
+      preview = await previewPatch(sheet, query, partial);
     } catch (error) {
-      throw attribute(translateError(error), i, record);
+      const axi = translateError(error);
+      invalid.push({ row: i + 1, id: recordLabel(record), reason: axi.message, code: axi.code });
+      continue;
     }
-    if (willResult === 'not-found') {
-      throw new AxiError(
-        `Record ${i + 1} (${recordLabel(record)}): no record matches ${JSON.stringify(query)}`,
-        'NOT_FOUND',
-        ['The whole batch was aborted — nothing committed. Fix or remove the record and re-run.'],
-      );
+
+    if (preview === 'not-found') {
+      if (flags.onMissing === 'skip') {
+        missing.push({ row: i + 1, id: recordLabel(record) });
+      } else if (flags.onMissing === 'insert') {
+        inserts.push(record);
+        try {
+          batchPaths.add(template.render(record));
+        } catch {
+          /* un-renderable insert surfaces at commit; ignore for path set */
+        }
+      } else {
+        missing.push({ row: i + 1, id: recordLabel(record) }); // abort mode: collected, thrown below
+      }
+      continue;
     }
-    if (willResult.changed) changes.push({ query, partial });
+
+    batchPaths.add(preview.path);
+    if (preview.changed) changes.push({ query, partial });
+    else unchanged++;
   }
 
-  if (changes.length === 0) {
+  // --delete-missing: existing records not targeted by the batch.
+  const deletions: string[] = [];
+  if (flags.deleteMissing) {
+    const existing = await sheet.queryAll({}, { withBody: false });
+    for (const r of existing) {
+      const p = (r as Record<symbol, unknown>)[PATH_KEY];
+      if (typeof p === 'string' && !batchPaths.has(p)) deletions.push(p);
+    }
+  }
+
+  if (flags.dryRun) {
+    return renderDryRun(
+      flags.sheet,
+      {
+        willChange: changes.length,
+        insert: inserts.length,
+        noOp: unchanged,
+        missing: missing.length,
+        invalid: invalid.length,
+        ...(flags.deleteMissing ? { willDelete: deletions.length } : {}),
+      },
+      invalid,
+    );
+  }
+
+  if (invalid.length > 0) {
+    const first = invalid[0]!;
+    throw new AxiError(`Record ${first.row} (${first.id}): ${first.reason}`, first.code, [
+      `${invalid.length} record(s) invalid — the whole batch was aborted, nothing committed. Run --dry-run to see all.`,
+    ]);
+  }
+  if (flags.onMissing === 'abort' && missing.length > 0) {
+    const first = missing[0]!;
+    throw new AxiError(`Record ${first.row} (${first.id}): no record matches its query`, 'NOT_FOUND', [
+      `${missing.length} record(s) matched nothing — batch aborted. Use --on-missing skip|insert, or --dry-run to see all.`,
+    ]);
+  }
+
+  if (changes.length === 0 && inserts.length === 0 && deletions.length === 0) {
     return renderObject({
       result: 'no-op',
       sheet: flags.sheet,
       patched: 0,
-      unchanged: records.length,
+      unchanged: records.length - invalid.length - missing.length,
+      ...(missing.length > 0 ? { skipped: missing.length } : {}),
     });
   }
 
-  const commitMessage = flags.message ?? `${flags.sheet} patch (${changes.length})`;
+  const commitMessage = flags.message ?? `${flags.sheet} patch (${changes.length + inserts.length})`;
   try {
     const result = await repo.transact({ message: commitMessage }, async (tx) => {
       const txSheet = tx.sheet(flags.sheet, prefixOpts);
-      for (const { query, partial } of changes) {
-        await txSheet.patch(query, partial);
-      }
+      for (const { query, partial } of changes) await txSheet.patch(query, partial);
+      for (const record of inserts) await txSheet.upsert(record as never);
+      for (const path of deletions) await txSheet.delete(path);
       return changes.length;
     });
     return joinBlocks(
@@ -286,7 +378,10 @@ async function batchPatch(
         result: 'committed',
         sheet: flags.sheet,
         patched: changes.length,
-        unchanged: records.length - changes.length,
+        ...(inserts.length > 0 ? { inserted: inserts.length } : {}),
+        unchanged,
+        ...(missing.length > 0 ? { skipped: missing.length } : {}),
+        ...(flags.deleteMissing ? { deleted: deletions.length } : {}),
         commit: result.commitHash,
       }),
       renderHelp([MATERIALIZE_HINT]),
@@ -325,14 +420,6 @@ async function previewPatch(
   // since the merge already produced the canonical record.
   const wc = await sheet.willChange(merged as never, { allowMissingBody: true });
   return { changed: wc.changed, path: wc.path, hash: wc.currentBlobHash };
-}
-
-function attribute(axi: AxiError, index: number, record: Record<string, unknown>): AxiError {
-  return new AxiError(
-    `Record ${index + 1} (${recordLabel(record)}): ${axi.message}`,
-    axi.code,
-    ['The whole batch was aborted — nothing committed. Fix or remove the record and re-run.'],
-  );
 }
 
 function stripSymbols(record: unknown): unknown {

--- a/packages/gitsheets-axi/src/commands/query.ts
+++ b/packages/gitsheets-axi/src/commands/query.ts
@@ -15,39 +15,44 @@ import {
 } from '../output/sheet-schema.js';
 import { openSheetForCommand } from '../util/open-sheet.js';
 import { exportRecords, type ExportFormat } from '../util/export-file.js';
+import { buildPredicate } from '../util/filter.js';
+import { facetCounts, sortRecords } from '../util/aggregate.js';
 
-export const QUERY_HELP = `usage: gitsheets-axi query <sheet> [--filter k=v ...] [--fields a,b,c] [--limit n] [--json-out[=path]] [--ndjson-out[=path]] [--csv-out[=path]]
-flags[7]:
-  --filter <k>=<v>     Equality match against record field (repeatable)
+export const QUERY_HELP = `usage: gitsheets-axi query <sheet> [--filter expr ...] [--fields a,b] [--sort f [--desc]] [--limit n] [--group-by f] [--json-out[=path]] [--ndjson-out[=path]] [--csv-out[=path]]
+flags[9]:
+  --filter <expr>      Filter clause (repeatable): k=v · k!=v · k<v · k>v ·
+                       k<=v · k>=v · k~regex · "k in (a,b)" · k:present · k:empty
   --fields <list>      Extra columns beyond the default schema (comma-separated)
+  --sort <field>       Sort records by a field (missing values sort last)
+  --desc               Sort descending (with --sort)
   --limit <n>          Cap the stdout preview (default: 100, max: 10000)
-  --prefix <p>         Tenant sub-tree scope (see gitsheets --prefix)
-  --json-out[=path]    Also write the FULL result to a JSON array file
-  --ndjson-out[=path]  Also write the FULL result to an NDJSON file
-  --csv-out[=path]     Also write the FULL result to a CSV file (flat, lossy)
+  --group-by <field>   Faceted counts by a field instead of a record list
+  --prefix <p>         Tenant sub-tree scope
+  --json-out[=path]    Also write the FULL matched result to a JSON array file
+  --ndjson-out[=path]  Also write the FULL matched result to an NDJSON file
+  --csv-out[=path]     Also write the FULL matched result to a CSV file (flat)
 examples:
-  gitsheets-axi query users
-  gitsheets-axi query users --filter status=active --limit 50
-  gitsheets-axi query posts --fields title,published
-  gitsheets-axi query repos --ndjson-out | tail -1   # export path, pipe elsewhere
+  gitsheets-axi query repos --filter status=unclassified
+  gitsheets-axi query repos --filter 'pushed_at<2022-01-01' --sort pushed_at
+  gitsheets-axi query repos --group-by target_team
+  gitsheets-axi query repos --filter 'target_team in (archive,sencha)' --ndjson-out
 output:
-  Default schema is format-aware:
-    TOML sheets    — path-template fields + first scalar properties (cap 4)
-    Markdown/MDX   — path-template fields + title + body_size (never body content)
-  --fields appends additional columns.
+  Default schema is format-aware (TOML: path fields + first scalars, cap 4;
+  Markdown: path fields + title + body_size). --fields appends columns.
+  --group-by emits {value,count} facets (biggest first) over the filtered set.
 export (--json-out / --ndjson-out / --csv-out):
-  stdout stays the TOON preview; the file carries EVERY matched record (not
-  capped by --limit). JSON/NDJSON are written verbatim so they round-trip
-  straight back into \`gitsheets-axi upsert\`; CSV is flat + lossy (nested
-  values JSON-encoded), for reporting. A bare flag auto-writes a 0600 file
-  under the OS temp dir; \`=path\` persists it. One export flag per invocation.
+  stdout stays the TOON preview; the file carries EVERY matched record (ignores
+  --limit). JSON/NDJSON verbatim (round-trip into upsert); CSV flat + lossy.
 `;
 
 interface QueryFlags {
-  filters: Array<[string, string]>;
+  filters: string[];
   extras: string[];
   limit: number;
   prefix: string | undefined;
+  sort: string | undefined;
+  desc: boolean;
+  groupBy: string | undefined;
   exportFormat: ExportFormat | undefined;
   exportPath: string | undefined;
 }
@@ -65,28 +70,27 @@ function parseQueryFlags(args: string[]): { sheetName: string; flags: QueryFlags
     extras: [],
     limit: 100,
     prefix: undefined,
+    sort: undefined,
+    desc: false,
+    groupBy: undefined,
     exportFormat: undefined,
     exportPath: undefined,
   };
 
   const setExport = (format: ExportFormat, arg: string): void => {
     if (flags.exportFormat) {
-      throw new AxiError(
-        'Only one export flag is allowed per invocation',
-        'VALIDATION_ERROR',
-        ['Pass either --json-out or --ndjson-out, not both'],
-      );
+      throw new AxiError('Only one export flag is allowed per invocation', 'VALIDATION_ERROR', [
+        'Pass one of --json-out / --ndjson-out / --csv-out',
+      ]);
     }
     flags.exportFormat = format;
     const eq = arg.indexOf('=');
     if (eq !== -1) {
       const p = arg.slice(eq + 1);
       if (!p) {
-        throw new AxiError(
-          `${arg.slice(0, eq)} was given an empty path`,
-          'VALIDATION_ERROR',
-          ['Use the bare flag for an auto-generated temp path, or --…-out=/real/path'],
-        );
+        throw new AxiError(`${arg.slice(0, eq)} was given an empty path`, 'VALIDATION_ERROR', [
+          'Use the bare flag for an auto temp path, or --…-out=/real/path',
+        ]);
       }
       flags.exportPath = p;
     }
@@ -111,37 +115,36 @@ function parseQueryFlags(args: string[]): { sheetName: string; flags: QueryFlags
 
     const next = args[i + 1];
     switch (arg) {
-      case '--filter': {
-        if (!next || !next.includes('=')) {
-          throw new AxiError(
-            '--filter expects key=value',
-            'VALIDATION_ERROR',
-            ['Example: --filter status=active'],
-          );
-        }
-        const eq = next.indexOf('=');
-        flags.filters.push([next.slice(0, eq), next.slice(eq + 1)]);
+      case '--filter':
+        if (!next) throw new AxiError('--filter expects an expression', 'VALIDATION_ERROR');
+        flags.filters.push(next);
         i++;
         break;
-      }
       case '--fields':
-        if (!next) {
-          throw new AxiError('--fields expects a comma-separated list', 'VALIDATION_ERROR');
-        }
+        if (!next) throw new AxiError('--fields expects a comma-separated list', 'VALIDATION_ERROR');
         flags.extras = next.split(',').map((s) => s.trim()).filter(Boolean);
         i++;
         break;
+      case '--sort':
+        if (!next) throw new AxiError('--sort expects a field name', 'VALIDATION_ERROR');
+        flags.sort = next;
+        i++;
+        break;
+      case '--desc':
+        flags.desc = true;
+        break;
+      case '--group-by':
+        if (!next) throw new AxiError('--group-by expects a field name', 'VALIDATION_ERROR');
+        flags.groupBy = next;
+        i++;
+        break;
       case '--limit':
-        if (!next) {
-          throw new AxiError('--limit expects an integer', 'VALIDATION_ERROR');
-        }
+        if (!next) throw new AxiError('--limit expects an integer', 'VALIDATION_ERROR');
         flags.limit = Math.min(10_000, Math.max(1, parseInt(next, 10) || 100));
         i++;
         break;
       case '--prefix':
-        if (!next) {
-          throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
-        }
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
         flags.prefix = next;
         i++;
         break;
@@ -165,7 +168,6 @@ export async function queryCommand(
 
   const { sheetName, flags } = parseQueryFlags(args);
   const repo = await ctx.repo();
-
   const sheet = await openSheetForCommand(
     repo,
     sheetName,
@@ -173,26 +175,33 @@ export async function queryCommand(
   );
 
   const config = await sheet.readConfig();
-  const filter: Record<string, unknown> = {};
-  for (const [k, v] of flags.filters) {
-    filter[k] = v;
-  }
-
-  // Load bodies for content-typed sheets so the body_size column renders
-  // correctly. We never put body content itself into the default schema —
-  // per AXI's "long-form content belongs in detail views, not lists" — but
-  // the size is the cheap, agent-actionable summary.
   const withBody = config.format.body !== undefined;
 
-  let records;
+  let all;
   try {
-    records = await sheet.queryAll(filter, { withBody });
+    all = await sheet.queryAll({}, { withBody });
   } catch (error) {
     throw translateError(error);
   }
 
-  const total = records.length;
-  const limited = records.slice(0, flags.limit);
+  const predicate = buildPredicate(flags.filters);
+  const matched = (all as Array<Record<string, unknown>>).filter(predicate);
+
+  // --group-by: faceted counts over the filtered set (not capped by --limit).
+  if (flags.groupBy) {
+    const facets = facetCounts(matched, flags.groupBy);
+    const groupBlock = renderListResponse({
+      summary: { groups: `${facets.length} distinct ${flags.groupBy}`, matched: matched.length },
+      name: 'groups',
+      items: facets as unknown as Array<Record<string, unknown>>,
+      schema: [field('value'), field('count')],
+      emptyMessage: `no records match in ${sheetName}`,
+    });
+    return maybeExport(groupBlock, matched, flags, sheetName);
+  }
+
+  const ordered = flags.sort ? sortRecords(matched, flags.sort, flags.desc) : matched;
+  const limited = ordered.slice(0, flags.limit);
 
   const baseSchema = defaultSheetSchema(config);
   const schema = fieldsWithExtras(baseSchema, flags.extras);
@@ -200,34 +209,23 @@ export async function queryCommand(
   const suggestions: string[] = [];
   if (limited.length === 0 && flags.filters.length > 0) {
     suggestions.push(
-      'No records match the filter — try `gitsheets-axi query ' +
-        sheetName +
-        '` without filters',
+      `No records match the filter — try \`gitsheets-axi query ${sheetName}\` without filters`,
     );
   } else if (limited.length > 0) {
-    suggestions.push(
-      `Run \`gitsheets-axi read ${sheetName} <path>\` to view a single record`,
-    );
-    if (config.format.body) {
-      suggestions.push(
-        `Add \`--full\` on \`read\` to see untruncated body content`,
-      );
-    }
+    suggestions.push(`Run \`gitsheets-axi read ${sheetName} <path>\` to view a single record`);
+    if (config.format.body) suggestions.push('Add `--full` on `read` to see untruncated body content');
   }
-  if (total > limited.length && !flags.exportFormat) {
+  if (matched.length > limited.length && !flags.exportFormat) {
     suggestions.push(
-      `${total - limited.length} records hidden by --limit ${flags.limit}; raise --limit or use --json-out to capture all`,
+      `${matched.length - limited.length} records hidden by --limit ${flags.limit}; raise --limit or use --json-out to capture all`,
     );
   }
 
   const listResponse = renderListResponse({
-    summary: { count: `${limited.length} of ${total} total` },
+    summary: { count: `${limited.length} of ${matched.length} total` },
     name: 'records',
     items: limited.map((r) => ({
       ...r,
-      // Surface the record's source path as a top-level "path" so default
-      // schemas that include it work without callers needing to know the
-      // RECORD_PATH_KEY symbol.
       path: (r as Record<symbol, unknown>)[Symbol.for('gitsheets-path')] ?? '',
     })) as Array<Record<string, unknown>>,
     schema: [...schema, field('path')],
@@ -235,16 +233,21 @@ export async function queryCommand(
     emptyMessage: `no records in ${sheetName}`,
   });
 
-  if (!flags.exportFormat) return listResponse;
+  return maybeExport(listResponse, ordered, flags, sheetName);
+}
 
-  // Side-channel export: full result set (ignores --limit), written verbatim
-  // so it round-trips back into `upsert`. Additive to the TOON preview above.
-  const exp = exportRecords(
-    records as unknown as Array<Record<string, unknown>>,
-    flags.exportFormat,
-    flags.exportPath,
-    sheetName,
-  );
+/**
+ * Append the side-channel export block when an export flag was passed. The file
+ * carries the full matched (and, for the record path, sorted) set, verbatim.
+ */
+function maybeExport(
+  stdoutBlock: string,
+  records: Array<Record<string, unknown>>,
+  flags: QueryFlags,
+  sheetName: string,
+): string {
+  if (!flags.exportFormat) return stdoutBlock;
+  const exp = exportRecords(records, flags.exportFormat, flags.exportPath, sheetName);
   const firstCol = exp.columns[0] ?? '';
   const hint =
     flags.exportFormat === 'csv'
@@ -253,7 +256,7 @@ export async function queryCommand(
         ? `Run \`jq '.${firstCol}' ${exp.path}\` to process all ${exp.rows} rows`
         : `Run \`jq '.[] | .${firstCol}' ${exp.path}\` to process all ${exp.rows} rows`;
   return joinBlocks(
-    listResponse,
+    stdoutBlock,
     renderObject({ wrote: exp.path, rows: exp.rows, cols: exp.cols }),
     renderObject({ columns: exp.columns }),
     renderHelp([hint]),

--- a/packages/gitsheets-axi/src/commands/rename.ts
+++ b/packages/gitsheets-axi/src/commands/rename.ts
@@ -1,0 +1,155 @@
+import { AxiError } from 'axi-sdk-js';
+import { Template } from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
+import { MATERIALIZE_HINT } from '../util/hints.js';
+
+export const RENAME_HELP = `usage: gitsheets-axi rename <sheet> <old-path> <new-path> [--prefix p] [--message m]
+flags[2]:
+  --prefix <p>         Tenant sub-tree scope
+  --message <m>        Commit message (default: "<sheet> rename <old> -> <new>")
+examples:
+  gitsheets-axi rename teams kevin-clough kingofthepark
+  gitsheets-axi rename repos old-name new-name --message "slug rename"
+note:
+  Reads the record at <old-path>, re-keys it to <new-path>, and deletes the old
+  one — atomically in ONE commit. Supported for a bare single-field path
+  template; for decorated or multi-field templates, use \`patch\` to change the
+  path fields, or \`upsert --delete-missing\`.
+`;
+
+interface RenameFlags {
+  sheet: string;
+  oldPath: string;
+  newPath: string;
+  prefix: string | undefined;
+  message: string | undefined;
+}
+
+function parseRenameFlags(args: string[]): RenameFlags {
+  const flags: RenameFlags = { sheet: '', oldPath: '', newPath: '', prefix: undefined, message: undefined };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    const next = args[i + 1];
+    switch (arg) {
+      case '--prefix':
+        if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
+        flags.prefix = next;
+        i++;
+        break;
+      case '--message':
+        if (!next) throw new AxiError('--message expects a string', 'VALIDATION_ERROR');
+        flags.message = next;
+        i++;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+            'Run `gitsheets-axi rename --help`',
+          ]);
+        }
+        positional.push(arg);
+    }
+  }
+  if (positional.length !== 3) {
+    throw new AxiError('rename requires <sheet> <old-path> <new-path>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi rename teams kevin-clough kingofthepark',
+    ]);
+  }
+  flags.sheet = positional[0]!;
+  flags.oldPath = stripExtension(positional[1]!);
+  flags.newPath = stripExtension(positional[2]!);
+  return flags;
+}
+
+// A bare single-field template: the whole path is one field reference
+// (`${{ field }}` or `${ field }`) with no literal decoration, so <new-path>
+// maps directly onto the field's value.
+const BARE_TEMPLATE = /^\$\{\{?\s*[A-Za-z_$][\w$]*\s*\}?\}$/;
+
+export async function renameCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+    return RENAME_HELP;
+  }
+
+  const flags = parseRenameFlags(args);
+  const prefixOpts = flags.prefix !== undefined ? { prefix: flags.prefix } : {};
+
+  const repo = await ctx.repo();
+  const sheet = await openSheetForCommand(repo, flags.sheet, prefixOpts);
+  const config = await sheet.readConfig();
+  const template = Template.fromString(config.path);
+  const fields = template.getFieldNames();
+
+  if (fields.length !== 1 || template.componentCount !== 1 || !BARE_TEMPLATE.test(config.path.trim())) {
+    throw new AxiError(
+      `rename supports a bare single-field path template; '${config.path}' is not one`,
+      'VALIDATION_ERROR',
+      ['Use `patch` to change the path fields, or `upsert --delete-missing` to re-key.'],
+    );
+  }
+  const field = fields[0]!;
+
+  let existing;
+  try {
+    existing = await sheet.queryFirst({ [field]: flags.oldPath });
+  } catch (error) {
+    throw translateError(error);
+  }
+  if (!existing) {
+    throw new AxiError(`${flags.sheet}: no record at ${flags.oldPath}`, 'NOT_FOUND');
+  }
+
+  const collision = await sheet.queryFirst({ [field]: flags.newPath });
+  if (collision) {
+    throw new AxiError(`${flags.sheet}: ${flags.newPath} already exists — refusing to overwrite`, 'VALIDATION_ERROR', [
+      `Delete or rename the existing ${flags.newPath} first`,
+    ]);
+  }
+
+  const renamed = { ...stripSymbols(existing), [field]: flags.newPath };
+  const commitMessage = flags.message ?? `${flags.sheet} rename ${flags.oldPath} -> ${flags.newPath}`;
+  try {
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      await txSheet.upsert(renamed as never);
+      await txSheet.delete(flags.oldPath);
+    });
+    return joinBlocks(
+      renderObject({
+        result: 'renamed',
+        sheet: flags.sheet,
+        from: flags.oldPath,
+        to: flags.newPath,
+        commit: result.commitHash,
+      }),
+      renderHelp([MATERIALIZE_HINT]),
+    );
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
+function stripSymbols(record: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (record && typeof record === 'object') {
+    for (const key of Object.keys(record as Record<string, unknown>)) {
+      out[key] = (record as Record<string, unknown>)[key];
+    }
+  }
+  return out;
+}
+
+function stripExtension(path: string): string {
+  if (path.endsWith('.toml')) return path.slice(0, -5);
+  if (path.endsWith('.md')) return path.slice(0, -3);
+  return path;
+}

--- a/packages/gitsheets-axi/src/commands/sheets.ts
+++ b/packages/gitsheets-axi/src/commands/sheets.ts
@@ -130,7 +130,10 @@ async function sheetsView(
   }
 
   if (schemaProps.length > 0) {
-    output['schema'] = renderSchemaProperties(schemaProps);
+    const schemaObj = (config as { schema?: Record<string, unknown> }).schema;
+    const requiredList = schemaObj?.['required'];
+    const required = new Set<string>(Array.isArray(requiredList) ? (requiredList as string[]) : []);
+    output['schema'] = renderSchemaProperties(schemaProps, required);
   }
 
   output['help'] = [
@@ -153,13 +156,20 @@ function schemaPropertyList(
 
 function renderSchemaProperties(
   props: Array<[string, Record<string, unknown>]>,
+  required: Set<string>,
 ): Record<string, string> {
-  // Flat name → "type [required]" map for token-efficient display.
+  // Flat name → "type [required] enum: a|b|c" map for token-efficient display.
+  // Surfacing the enum options lets an agent see allowed values before it
+  // writes, instead of learning them from a rejected upsert.
   const out: Record<string, string> = {};
   for (const [name, schema] of props) {
     const type = String(schema['type'] ?? 'any');
     const format = schema['format'] ? ` (${String(schema['format'])})` : '';
-    out[name] = `${type}${format}`;
+    const req = required.has(name) ? ' [required]' : '';
+    const enumVals = Array.isArray(schema['enum'])
+      ? ` enum: ${(schema['enum'] as unknown[]).map(String).join('|')}`
+      : '';
+    out[name] = `${type}${format}${req}${enumVals}`;
   }
   return out;
 }

--- a/packages/gitsheets-axi/src/commands/upsert.ts
+++ b/packages/gitsheets-axi/src/commands/upsert.ts
@@ -3,35 +3,39 @@ import type { Repository, Sheet } from 'gitsheets';
 
 import type { GitsheetsContext } from '../context.js';
 import { translateError } from '../errors.js';
-import { joinBlocks, renderHelp, renderObject } from '../output/render.js';
+import { joinBlocks, renderHelp, renderList, renderObject } from '../output/render.js';
+import { field } from '../output/schema.js';
 import { readStdin } from '../util/stdin.js';
 import { openSheetForCommand } from '../util/open-sheet.js';
 import { parseRecordsInput, recordLabel } from '../util/parse-records.js';
 import { MATERIALIZE_HINT } from '../util/hints.js';
 
-export const UPSERT_HELP = `usage: gitsheets-axi upsert <sheet> [--data <json>] [--allow-missing-body] [--prefix p] [--message m]
-flags[4]:
+const PATH_KEY = Symbol.for('gitsheets-path');
+
+export const UPSERT_HELP = `usage: gitsheets-axi upsert <sheet> [--data <json>] [--delete-missing] [--dry-run] [--allow-missing-body] [--prefix p] [--message m]
+flags[6]:
   --data <json>        Record JSON inline. If omitted, reads stdin.
+  --delete-missing     After upserting, delete existing records NOT in the input
+                       set (make the sheet exactly match the batch). One commit.
+  --dry-run            Preview {will-change, no-op, invalid, delete} — no commit.
   --allow-missing-body Content-typed sheets only — permit upsert without body field
   --prefix <p>         Tenant sub-tree scope
   --message <m>        Commit message (default: "<sheet> upsert <path>")
 bulk:
-  Input may be a single JSON object, a JSON array of objects, or NDJSON
-  (one compact object per line) — the shape is autodetected. Many records
-  are upserted in a SINGLE transaction that produces ONE commit.
+  Input may be a single JSON object, a JSON array of objects, or NDJSON (one
+  compact object per line) — autodetected. A batch upserts in ONE commit.
 examples:
-  gitsheets-axi upsert users --data '{"slug":"jane","email":"jane@x.org"}'
   echo '{"slug":"jane","email":"jane@x.org"}' | gitsheets-axi upsert users
-  jq -c '.[]' repos.json | gitsheets-axi upsert repos          # NDJSON, one commit
-  cat repos.array.json | gitsheets-axi upsert repos             # JSON array, one commit
+  jq -c '.[]' repos.json | gitsheets-axi upsert repos                  # NDJSON, one commit
+  gitsheets-axi upsert repos --data "$(cat repos.json)" --delete-missing   # exact re-sync
+  gitsheets-axi upsert repos --data "$(cat repos.json)" --dry-run           # preview
 idempotency:
-  Each record's canonical bytes are compared against the existing blob at
-  its rendered path. Unchanged records are skipped; a batch where nothing
-  changed exits 0 with result: "no-op" and no commit. In a batch, a single
-  invalid record aborts the whole transaction — nothing is committed.
+  Unchanged records are skipped; a batch where nothing changed is a no-op with
+  no commit. A single invalid record aborts the batch (nothing committed) and
+  names the row — run --dry-run to see all invalid rows at once.
 note:
-  gitsheets writes to the git ref, not your working tree. After a commit,
-  run \`git checkout HEAD -- .\` to materialize the record files on disk.
+  gitsheets writes to the git ref, not your working tree. After a commit run
+  \`git checkout HEAD -- .\` to materialize the record files on disk.
 `;
 
 interface UpsertFlags {
@@ -40,6 +44,8 @@ interface UpsertFlags {
   allowMissingBody: boolean;
   prefix: string | undefined;
   message: string | undefined;
+  deleteMissing: boolean;
+  dryRun: boolean;
 }
 
 function parseUpsertFlags(args: string[]): UpsertFlags {
@@ -49,6 +55,8 @@ function parseUpsertFlags(args: string[]): UpsertFlags {
     allowMissingBody: false,
     prefix: undefined,
     message: undefined,
+    deleteMissing: false,
+    dryRun: false,
   };
   const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -63,6 +71,12 @@ function parseUpsertFlags(args: string[]): UpsertFlags {
         break;
       case '--allow-missing-body':
         flags.allowMissingBody = true;
+        break;
+      case '--delete-missing':
+        flags.deleteMissing = true;
+        break;
+      case '--dry-run':
+        flags.dryRun = true;
         break;
       case '--prefix':
         if (!next) throw new AxiError('--prefix expects a path', 'VALIDATION_ERROR');
@@ -110,8 +124,8 @@ export async function upsertCommand(
   const repo = await ctx.repo();
   const sheet = await openSheetForCommand(repo, flags.sheet, prefixOpts);
 
-  // Single-record: preserve the detailed per-record output (path/hash/commit).
-  if (records.length === 1) {
+  // Fast single-record path only when no set-level flag is in play.
+  if (records.length === 1 && !flags.deleteMissing && !flags.dryRun) {
     return singleUpsert(repo, sheet, flags, records[0]!, upsertOpts, prefixOpts);
   }
   return batchUpsert(repo, sheet, flags, records, upsertOpts, prefixOpts);
@@ -141,16 +155,12 @@ async function singleUpsert(
     });
   }
 
-  const commitMessage =
-    flags.message ?? `${flags.sheet} upsert ${willResult.path}`;
+  const commitMessage = flags.message ?? `${flags.sheet} upsert ${willResult.path}`;
   try {
-    const result = await repo.transact(
-      { message: commitMessage },
-      async (tx) => {
-        const txSheet = tx.sheet(flags.sheet, prefixOpts);
-        return txSheet.upsert(record as never, upsertOpts);
-      },
-    );
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      return txSheet.upsert(record as never, upsertOpts);
+    });
     return joinBlocks(
       renderObject({
         result: 'committed',
@@ -166,6 +176,13 @@ async function singleUpsert(
   }
 }
 
+export interface InvalidRow {
+  row: number;
+  id: string;
+  reason: string;
+  code: string;
+}
+
 async function batchUpsert(
   repo: Repository,
   sheet: Sheet,
@@ -174,55 +191,82 @@ async function batchUpsert(
   upsertOpts: { allowMissingBody?: boolean },
   prefixOpts: { prefix?: string },
 ): Promise<string> {
-  // Pre-flight every record: validates (via willChange) and categorizes
-  // changed vs unchanged BEFORE opening a transaction. A single bad record
-  // aborts the whole batch here, so we never produce a partial commit.
+  // Pre-flight: categorize into changed / unchanged / invalid. Unlike the
+  // commit path, we never throw here — dry-run needs every invalid row, and the
+  // normal path aborts explicitly after collecting.
   const changed: Array<Record<string, unknown>> = [];
+  const batchPaths = new Set<string>();
+  const invalid: InvalidRow[] = [];
+  let unchanged = 0;
+
   for (let i = 0; i < records.length; i++) {
     const record = records[i]!;
     try {
       const wc = await sheet.willChange(record as never, upsertOpts);
+      batchPaths.add(wc.path);
       if (wc.changed) changed.push(record);
+      else unchanged++;
     } catch (error) {
       const axi = translateError(error);
-      throw new AxiError(
-        `Record ${i + 1} (${recordLabel(record)}): ${axi.message}`,
-        axi.code,
-        [
-          'The whole batch was aborted — nothing committed. Fix or remove the offending record and re-run.',
-        ],
-      );
+      invalid.push({ row: i + 1, id: recordLabel(record), reason: axi.message, code: axi.code });
     }
   }
 
-  if (changed.length === 0) {
+  // --delete-missing: existing records whose path isn't in the input set.
+  const deletions: string[] = [];
+  if (flags.deleteMissing) {
+    const existing = await sheet.queryAll({}, { withBody: false });
+    for (const r of existing) {
+      const p = (r as Record<symbol, unknown>)[PATH_KEY];
+      if (typeof p === 'string' && !batchPaths.has(p)) deletions.push(p);
+    }
+  }
+
+  if (flags.dryRun) {
+    return renderDryRun(
+      flags.sheet,
+      {
+        willChange: changed.length,
+        noOp: unchanged,
+        invalid: invalid.length,
+        ...(flags.deleteMissing ? { willDelete: deletions.length } : {}),
+      },
+      invalid,
+    );
+  }
+
+  if (invalid.length > 0) {
+    const first = invalid[0]!;
+    throw new AxiError(`Record ${first.row} (${first.id}): ${first.reason}`, first.code, [
+      `${invalid.length} record(s) invalid — the whole batch was aborted, nothing committed. Run --dry-run to see all.`,
+    ]);
+  }
+
+  if (changed.length === 0 && deletions.length === 0) {
     return renderObject({
       result: 'no-op',
       sheet: flags.sheet,
       upserted: 0,
       unchanged: records.length,
+      ...(flags.deleteMissing ? { deleted: 0 } : {}),
     });
   }
 
-  const commitMessage =
-    flags.message ?? `${flags.sheet} upsert (${changed.length})`;
+  const commitMessage = flags.message ?? `${flags.sheet} upsert (${changed.length})`;
   try {
-    const result = await repo.transact(
-      { message: commitMessage },
-      async (tx) => {
-        const txSheet = tx.sheet(flags.sheet, prefixOpts);
-        for (const record of changed) {
-          await txSheet.upsert(record as never, upsertOpts);
-        }
-        return changed.length;
-      },
-    );
+    const result = await repo.transact({ message: commitMessage }, async (tx) => {
+      const txSheet = tx.sheet(flags.sheet, prefixOpts);
+      for (const record of changed) await txSheet.upsert(record as never, upsertOpts);
+      for (const path of deletions) await txSheet.delete(path);
+      return changed.length;
+    });
     return joinBlocks(
       renderObject({
         result: 'committed',
         sheet: flags.sheet,
         upserted: changed.length,
         unchanged: records.length - changed.length,
+        ...(flags.deleteMissing ? { deleted: deletions.length } : {}),
         commit: result.commitHash,
       }),
       renderHelp([MATERIALIZE_HINT]),
@@ -230,4 +274,23 @@ async function batchUpsert(
   } catch (error) {
     throw translateError(error);
   }
+}
+
+/** Shared dry-run renderer: a `dry-run` summary of counts + an invalid-rows table. */
+export function renderDryRun(
+  sheet: string,
+  counts: Record<string, number>,
+  invalid: InvalidRow[],
+): string {
+  const blocks = [renderObject({ result: 'dry-run', sheet, ...counts })];
+  if (invalid.length > 0) {
+    blocks.push(
+      renderList('invalid', invalid as unknown as Array<Record<string, unknown>>, [
+        field('row'),
+        field('id'),
+        field('reason'),
+      ]),
+    );
+  }
+  return joinBlocks(...blocks);
 }

--- a/packages/gitsheets-axi/src/util/aggregate.ts
+++ b/packages/gitsheets-axi/src/util/aggregate.ts
@@ -1,0 +1,54 @@
+import { scalarString } from './filter.js';
+
+export interface Facet {
+  value: string;
+  count: number;
+}
+
+/**
+ * Faceted counts of a field across records — the `--group-by` / `distinct`
+ * primitive. Sorted by count descending, then value ascending, so the biggest
+ * buckets read first. A missing field counts under the empty-string key.
+ */
+export function facetCounts(
+  records: Array<Record<string, unknown>>,
+  field: string,
+): Facet[] {
+  const counts = new Map<string, number>();
+  for (const r of records) {
+    const key = scalarString(r[field]);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || compareStrings(a.value, b.value));
+}
+
+/** Sort records by a field. Undefined/null sort last regardless of direction. */
+export function sortRecords(
+  records: Array<Record<string, unknown>>,
+  field: string,
+  desc: boolean,
+): Array<Record<string, unknown>> {
+  const dir = desc ? -1 : 1;
+  return [...records].sort((a, b) => {
+    const av = a[field];
+    const bv = b[field];
+    const am = av === undefined || av === null;
+    const bm = bv === undefined || bv === null;
+    if (am && bm) return 0;
+    if (am) return 1; // missing always last
+    if (bm) return -1;
+    return dir * compareScalars(av, bv);
+  });
+}
+
+function compareScalars(a: unknown, b: unknown): number {
+  if (typeof a === 'number' && typeof b === 'number') return Math.sign(a - b);
+  if (a instanceof Date && b instanceof Date) return Math.sign(a.getTime() - b.getTime());
+  return compareStrings(scalarString(a), scalarString(b));
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/packages/gitsheets-axi/src/util/filter.ts
+++ b/packages/gitsheets-axi/src/util/filter.ts
@@ -1,0 +1,151 @@
+import { AxiError } from 'axi-sdk-js';
+
+/**
+ * A parsed `--filter` clause: the field it targets and a predicate over that
+ * field's value (with the whole record available for completeness).
+ */
+export interface FilterClause {
+  field: string;
+  op: string;
+  test: (value: unknown, record: Record<string, unknown>) => boolean;
+}
+
+/**
+ * Parse the axi `--filter` mini-DSL. One clause per `--filter` arg; multiple
+ * clauses AND together. Supported forms (checked in this order):
+ *
+ *   field:present            field exists and is non-empty
+ *   field:empty              field is absent / null / '' / []
+ *   field in (a,b,c)         value is one of the listed strings
+ *   field!=value             not equal
+ *   field>=value  field<=value  field>value  field<value   comparison
+ *   field~regex              String(value) matches the JS regex
+ *   field=value              equality (the original behavior)
+ *
+ * Comparison is numeric when the field holds a number, time-based for Date
+ * fields, else lexical (ISO-8601 date strings sort correctly).
+ */
+export function parseFilter(expr: string): FilterClause {
+  const trimmed = expr.trim();
+
+  // Suffix existence operators.
+  let m = /^([\w.]+):(present|empty)$/.exec(trimmed);
+  if (m) {
+    const field = m[1]!;
+    const kind = m[2]!;
+    return {
+      field,
+      op: `:${kind}`,
+      test: (v) => (kind === 'present' ? isPresent(v) : !isPresent(v)),
+    };
+  }
+
+  // Set membership: field in (a, b, c)
+  m = /^([\w.]+)\s+in\s+\((.*)\)$/i.exec(trimmed);
+  if (m) {
+    const field = m[1]!;
+    const set = new Set(
+      m[2]!
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0),
+    );
+    return { field, op: 'in', test: (v) => set.has(scalarString(v)) };
+  }
+
+  // Binary operators, longest token first so `!=`/`>=`/`<=` beat `=`/`>`/`<`.
+  for (const op of ['!=', '>=', '<=', '~', '>', '<', '=']) {
+    const idx = trimmed.indexOf(op);
+    if (idx <= 0) continue;
+    const field = trimmed.slice(0, idx).trim();
+    const rhs = trimmed.slice(idx + op.length).trim();
+    if (!/^[\w.]+$/.test(field)) break; // not a clean field → malformed
+    return { field, op, test: binaryTest(op, rhs, expr) };
+  }
+
+  throw new AxiError(
+    `Could not parse --filter "${expr}"`,
+    'VALIDATION_ERROR',
+    [
+      'Forms: k=v · k!=v · k<v · k>v · k<=v · k>=v · k~regex · "k in (a,b)" · k:present · k:empty',
+    ],
+  );
+}
+
+/** Compose many `--filter` clauses into one AND predicate over a record. */
+export function buildPredicate(
+  exprs: string[],
+): (record: Record<string, unknown>) => boolean {
+  if (exprs.length === 0) return () => true;
+  const clauses = exprs.map(parseFilter);
+  return (record) => clauses.every((c) => c.test(record[c.field], record));
+}
+
+function binaryTest(
+  op: string,
+  rhs: string,
+  expr: string,
+): (value: unknown) => boolean {
+  if (op === '~') {
+    let re: RegExp;
+    try {
+      re = new RegExp(rhs);
+    } catch (error) {
+      throw new AxiError(
+        `Invalid regex in --filter "${expr}": ${error instanceof Error ? error.message : String(error)}`,
+        'VALIDATION_ERROR',
+      );
+    }
+    return (v) => v !== undefined && v !== null && re.test(String(v));
+  }
+  if (op === '=') return (v) => valueEquals(v, rhs);
+  if (op === '!=') return (v) => !valueEquals(v, rhs);
+  // Ordered comparisons.
+  return (v) => {
+    const c = compareValue(v, rhs);
+    if (c === undefined) return false;
+    if (op === '>') return c > 0;
+    if (op === '<') return c < 0;
+    if (op === '>=') return c >= 0;
+    return c <= 0; // '<='
+  };
+}
+
+function valueEquals(value: unknown, rhs: string): boolean {
+  if (typeof value === 'number') return value === Number(rhs);
+  if (typeof value === 'boolean') return String(value) === rhs;
+  if (value instanceof Date) return value.toISOString() === rhs || String(value) === rhs;
+  if (value === undefined || value === null) return rhs === '';
+  return String(value) === rhs;
+}
+
+/** -1 / 0 / 1 comparing `value` to the RHS string, or undefined if incomparable. */
+function compareValue(value: unknown, rhs: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'number') {
+    const n = Number(rhs);
+    if (Number.isNaN(n)) return undefined;
+    return Math.sign(value - n);
+  }
+  if (value instanceof Date) {
+    const t = Date.parse(rhs);
+    if (Number.isNaN(t)) return undefined;
+    return Math.sign(value.getTime() - t);
+  }
+  const a = String(value);
+  return a < rhs ? -1 : a > rhs ? 1 : 0;
+}
+
+function isPresent(v: unknown): boolean {
+  if (v === undefined || v === null) return false;
+  if (v === '') return false;
+  if (Array.isArray(v) && v.length === 0) return false;
+  return true;
+}
+
+/** Stable string form for set membership / grouping keys. */
+export function scalarString(v: unknown): string {
+  if (v === undefined || v === null) return '';
+  if (v instanceof Date) return v.toISOString();
+  return String(v);
+}

--- a/packages/gitsheets-axi/test/read-analytics.test.ts
+++ b/packages/gitsheets-axi/test/read-analytics.test.ts
@@ -1,0 +1,140 @@
+// Read-side analytics: count, rich --filter operators, query --group-by,
+// --sort/--desc, and distinct. (#223 High tier.)
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const REPOS_TOML = `[gitsheet]
+root = 'repos'
+path = '\${{ name }}'
+`;
+
+const REPOS = JSON.stringify([
+  { name: 'a', visibility: 'public', status: 'classified', target_team: 'slate', pushed_at: '2023-05-01', archived: false },
+  { name: 'b', visibility: 'private', status: 'unclassified', pushed_at: '2021-01-01', archived: false },
+  { name: 'c', visibility: 'public', status: 'unclassified', pushed_at: '2020-06-01', archived: true },
+  { name: 'd', visibility: 'public', status: 'classified', target_team: 'sencha', pushed_at: '2024-01-01', archived: false },
+  { name: 'e', visibility: 'private', status: 'classified', target_team: 'slate', pushed_at: '2019-01-01', archived: true },
+]);
+
+async function seeded(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'repos.toml'), REPOS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add repos sheet');
+  await runCli(['upsert', 'repos', '--data', REPOS], fixture.path);
+  return fixture;
+}
+
+describe('count', () => {
+  it('counts all records with no filter', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(['count', 'repos'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/count: 5\b/);
+  });
+
+  it('counts a filtered subset', async () => {
+    const fixture = await seeded();
+    const { stdout } = await runCli(['count', 'repos', '--filter', 'status=unclassified'], fixture.path);
+    expect(stdout).toMatch(/count: 2\b/);
+    expect(stdout).toMatch(/of: 5\b/);
+  });
+
+  it('honors a comparison filter', async () => {
+    const fixture = await seeded();
+    const { stdout } = await runCli(['count', 'repos', '--filter', 'pushed_at<2022-01-01'], fixture.path);
+    expect(stdout).toMatch(/count: 3\b/); // 2021, 2020, 2019
+  });
+});
+
+describe('query filter operators', () => {
+  const cases: Array<[string, string[], number]> = [
+    ['!=', ['status!=classified'], 2],
+    ['in()', ['target_team in (slate,sencha)'], 3],
+    ['regex ~', ['visibility~^pub'], 3],
+    ['comparison >', ['pushed_at>2022-01-01'], 2],
+    [':present', ['target_team:present'], 3],
+    [':empty', ['target_team:empty'], 2],
+    ['AND of two clauses', ['visibility=public', 'archived=false'], 2],
+  ];
+  for (const [label, filters, expected] of cases) {
+    it(`filters with ${label}`, async () => {
+      const fixture = await seeded();
+      const args = ['query', 'repos'];
+      for (const f of filters) args.push('--filter', f);
+      const { stdout, exitCode } = await runCli(args, fixture.path);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain(`of ${expected} total`);
+    });
+  }
+
+  it('rejects a malformed filter', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(['query', 'repos', '--filter', 'garbage'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/parse --filter/);
+  });
+});
+
+describe('query --group-by', () => {
+  it('emits faceted counts biggest-first', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(['query', 'repos', '--group-by', 'visibility'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('groups[2]');
+    expect(stdout).toContain('public,3');
+    expect(stdout).toContain('private,2');
+  });
+
+  it('groups over the filtered set', async () => {
+    const fixture = await seeded();
+    const { stdout } = await runCli(
+      ['query', 'repos', '--filter', 'status=classified', '--group-by', 'target_team'],
+      fixture.path,
+    );
+    expect(stdout).toContain('slate,2'); // a + e
+    expect(stdout).toContain('sencha,1'); // d
+  });
+});
+
+describe('query --sort', () => {
+  it('sorts ascending / descending, exported verbatim', async () => {
+    const fixture = await seeded();
+    const { stdout } = await runCli(['query', 'repos', '--sort', 'pushed_at', '--ndjson-out'], fixture.path);
+    const file = stdout.match(/wrote: (\S+)/)![1]!;
+    const rows = (await readFile(file, 'utf-8')).trim().split('\n').map((l) => JSON.parse(l));
+    expect(rows.map((r) => r.name)).toEqual(['e', 'c', 'b', 'a', 'd']);
+
+    const { stdout: desc } = await runCli(['query', 'repos', '--sort', 'pushed_at', '--desc', '--ndjson-out'], fixture.path);
+    const file2 = desc.match(/wrote: (\S+)/)![1]!;
+    const rows2 = (await readFile(file2, 'utf-8')).trim().split('\n').map((l) => JSON.parse(l));
+    expect(rows2.map((r) => r.name)).toEqual(['d', 'a', 'b', 'c', 'e']);
+  });
+});
+
+describe('distinct', () => {
+  it('lists unique values of a field with counts, sorted alphabetically', async () => {
+    const fixture = await seeded();
+    const { stdout, exitCode } = await runCli(['distinct', 'repos', 'visibility'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('values[2]');
+    expect(stdout).toContain('private,2');
+    expect(stdout).toContain('public,3');
+  });
+});

--- a/packages/gitsheets-axi/test/rename-delete.test.ts
+++ b/packages/gitsheets-axi/test/rename-delete.test.ts
@@ -1,0 +1,155 @@
+// rename (single-field re-key) and bulk delete (--filter / --dry-run). (#223 Medium.)
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const TEAMS_TOML = `[gitsheet]
+root = 'teams'
+path = '\${{ slug }}'
+`;
+
+async function seedTeams(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'teams.toml'), TEAMS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add teams');
+  await runCli(
+    ['upsert', 'teams', '--data', JSON.stringify([
+      { slug: 'kevin-clough', kind: 'client', members: 1 },
+      { slug: 'sencha', kind: 'functional', members: 3 },
+    ])],
+    fixture.path,
+  );
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+describe('rename', () => {
+  it('re-keys a record, preserving other fields, in one commit', async () => {
+    const fixture = await seedTeams();
+    const before = await commitCount(fixture);
+    const { stdout, exitCode } = await runCli(['rename', 'teams', 'kevin-clough', 'kingofthepark'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: renamed');
+    expect(stdout).toContain('from: kevin-clough');
+    expect(stdout).toContain('to: kingofthepark');
+    expect(await commitCount(fixture)).toBe(before + 1);
+
+    const { exitCode: oldGone } = await runCli(['read', 'teams', 'kevin-clough'], fixture.path);
+    expect(oldGone).not.toBe(0);
+    const { stdout: neu } = await runCli(['read', 'teams', 'kingofthepark'], fixture.path);
+    expect(neu).toContain('kind: client');
+    expect(neu).toContain('members: 1');
+  });
+
+  it('refuses to overwrite an existing target', async () => {
+    const fixture = await seedTeams();
+    const { stdout, exitCode } = await runCli(['rename', 'teams', 'kevin-clough', 'sencha'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/already exists/);
+  });
+
+  it('errors on a missing source record', async () => {
+    const fixture = await seedTeams();
+    const { stdout, exitCode } = await runCli(['rename', 'teams', 'ghost', 'x'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/no record at ghost|NOT_FOUND/);
+  });
+
+  it('rejects a multi-field path template', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'pairs.toml'), "[gitsheet]\nroot = 'pairs'\npath = '${{ a }}/${{ b }}'\n");
+    await fixture.git('add', '.gitsheets/');
+    await fixture.git('commit', '-m', 'add pairs');
+    const { stdout, exitCode } = await runCli(['rename', 'pairs', 'x/y', 'x/z'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toMatch(/single-field path template/);
+  });
+});
+
+const REPOS_TOML = `[gitsheet]
+root = 'repos'
+path = '\${{ name }}'
+`;
+
+async function seedRepos(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'repos.toml'), REPOS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add repos');
+  await runCli(
+    ['upsert', 'repos', '--data', JSON.stringify([
+      { name: 'a', disposition: 'keep' },
+      { name: 'b', disposition: 'delete-candidate' },
+      { name: 'c', disposition: 'delete-candidate' },
+      { name: 'd', disposition: 'keep' },
+    ])],
+    fixture.path,
+  );
+  return fixture;
+}
+
+describe('bulk delete', () => {
+  it('deletes every record matching a filter in one commit', async () => {
+    const fixture = await seedRepos();
+    const before = await commitCount(fixture);
+    const { stdout, exitCode } = await runCli(
+      ['delete', 'repos', '--filter', 'disposition=delete-candidate'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/deleted: 2\b/);
+    expect(await commitCount(fixture)).toBe(before + 1);
+    const { stdout: count } = await runCli(['count', 'repos'], fixture.path);
+    expect(count).toMatch(/count: 2\b/);
+  });
+
+  it('--dry-run reports the count without committing', async () => {
+    const fixture = await seedRepos();
+    const before = await commitCount(fixture);
+    const { stdout } = await runCli(
+      ['delete', 'repos', '--filter', 'disposition=delete-candidate', '--dry-run'],
+      fixture.path,
+    );
+    expect(stdout).toContain('result: dry-run');
+    expect(stdout).toMatch(/willDelete: 2\b/);
+    expect(await commitCount(fixture)).toBe(before);
+  });
+
+  it('is a no-op when nothing matches', async () => {
+    const fixture = await seedRepos();
+    const { stdout } = await runCli(['delete', 'repos', '--filter', 'disposition=nope'], fixture.path);
+    expect(stdout).toMatch(/result: no-op/);
+  });
+
+  it('still deletes a single record by path', async () => {
+    const fixture = await seedRepos();
+    const { stdout, exitCode } = await runCli(['delete', 'repos', 'a'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: committed');
+    expect(stdout).toContain('path: a');
+  });
+});

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -10,6 +10,8 @@ import { createContext, type GitsheetsContext } from '../src/context.js';
 import { homeCommand } from '../src/commands/home.js';
 import { sheetsCommand, SHEETS_HELP } from '../src/commands/sheets.js';
 import { queryCommand, QUERY_HELP } from '../src/commands/query.js';
+import { countCommand, COUNT_HELP } from '../src/commands/count.js';
+import { distinctCommand, DISTINCT_HELP } from '../src/commands/distinct.js';
 import { readCommand, READ_HELP } from '../src/commands/read.js';
 import { upsertCommand, UPSERT_HELP } from '../src/commands/upsert.js';
 import { patchCommand, PATCH_HELP } from '../src/commands/patch.js';
@@ -30,6 +32,8 @@ import { setupCommand, SETUP_HELP } from '../src/commands/setup.js';
 const COMMAND_HELP: Record<string, string> = {
   sheets: SHEETS_HELP,
   query: QUERY_HELP,
+  count: COUNT_HELP,
+  distinct: DISTINCT_HELP,
   read: READ_HELP,
   upsert: UPSERT_HELP,
   patch: PATCH_HELP,
@@ -48,6 +52,8 @@ const COMMAND_HELP: Record<string, string> = {
 const COMMANDS = {
   sheets: sheetsCommand,
   query: queryCommand,
+  count: countCommand,
+  distinct: distinctCommand,
   read: readCommand,
   upsert: upsertCommand,
   patch: patchCommand,

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -15,6 +15,7 @@ import { distinctCommand, DISTINCT_HELP } from '../src/commands/distinct.js';
 import { readCommand, READ_HELP } from '../src/commands/read.js';
 import { upsertCommand, UPSERT_HELP } from '../src/commands/upsert.js';
 import { patchCommand, PATCH_HELP } from '../src/commands/patch.js';
+import { renameCommand, RENAME_HELP } from '../src/commands/rename.js';
 import { deleteCommand, DELETE_HELP } from '../src/commands/delete.js';
 import { checkCommand, CHECK_HELP } from '../src/commands/check.js';
 import { diffCommand, DIFF_HELP } from '../src/commands/diff.js';
@@ -37,6 +38,7 @@ const COMMAND_HELP: Record<string, string> = {
   read: READ_HELP,
   upsert: UPSERT_HELP,
   patch: PATCH_HELP,
+  rename: RENAME_HELP,
   delete: DELETE_HELP,
   check: CHECK_HELP,
   diff: DIFF_HELP,
@@ -57,6 +59,7 @@ const COMMANDS = {
   read: readCommand,
   upsert: upsertCommand,
   patch: patchCommand,
+  rename: renameCommand,
   delete: deleteCommand,
   check: checkCommand,
   diff: diffCommand,

--- a/packages/gitsheets-axi/test/sheets-view-enum.test.ts
+++ b/packages/gitsheets-axi/test/sheets-view-enum.test.ts
@@ -1,0 +1,50 @@
+// sheets view surfaces enum options + [required] so an agent sees allowed
+// values before writing, not from a rejected upsert. (#223 Lower.)
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const TEAMS_TOML = `[gitsheet]
+root = 'teams'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'kind']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.kind]
+type = 'string'
+enum = ['functional', 'client', 'archive']
+`;
+
+describe('sheets view enum surfacing', () => {
+  it('shows enum options and required markers', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'teams.toml'), TEAMS_TOML);
+    await fixture.git('add', '.gitsheets/');
+    await fixture.git('commit', '-m', 'add teams');
+
+    const { stdout, exitCode } = await runCli(['sheets', 'view', 'teams'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('enum: functional|client|archive');
+    expect(stdout).toContain('[required]');
+  });
+});

--- a/packages/gitsheets-axi/test/write-robustness.test.ts
+++ b/packages/gitsheets-axi/test/write-robustness.test.ts
@@ -1,0 +1,168 @@
+// Incremental-write robustness: --dry-run / --delete-missing on bulk upsert,
+// and --on-missing / --delete-missing / --dry-run on bulk patch. (#223 Medium.)
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS_TOML = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug', 'email']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+[gitsheet.schema.properties.email]
+type = 'string'
+[gitsheet.schema.properties.role]
+type = 'string'
+`;
+
+const SEED = JSON.stringify([
+  { slug: 'jane', email: 'jane@x.org' },
+  { slug: 'bob', email: 'bob@x.org' },
+  { slug: 'mia', email: 'mia@x.org' },
+]);
+
+async function seeded(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS_TOML);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users');
+  await runCli(['upsert', 'users', '--data', SEED], fixture.path);
+  return fixture;
+}
+
+async function commitCount(fixture: TestRepoHandle): Promise<number> {
+  const { stdout } = await fixture.git('rev-list', '--count', 'HEAD');
+  return parseInt(stdout.trim(), 10);
+}
+
+async function total(fixture: TestRepoHandle): Promise<string> {
+  const { stdout } = await runCli(['count', 'users'], fixture.path);
+  return stdout;
+}
+
+describe('upsert --dry-run', () => {
+  it('previews will-change / no-op / invalid without committing', async () => {
+    const fixture = await seeded();
+    const before = await commitCount(fixture);
+    const batch = JSON.stringify([
+      { slug: 'jane', email: 'NEW@x.org' }, // changed
+      { slug: 'bob', email: 'bob@x.org' }, // no-op
+      { slug: 'zoe' }, // invalid (missing email)
+    ]);
+    const { stdout, exitCode } = await runCli(['upsert', 'users', '--data', batch, '--dry-run'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: dry-run');
+    expect(stdout).toMatch(/willChange: 1\b/);
+    expect(stdout).toMatch(/noOp: 1\b/);
+    expect(stdout).toMatch(/invalid: 1\b/);
+    expect(stdout).toContain('zoe'); // named in the invalid table
+    expect(await commitCount(fixture)).toBe(before); // nothing committed
+  });
+});
+
+describe('upsert --delete-missing', () => {
+  it('makes the sheet exactly match the input set', async () => {
+    const fixture = await seeded();
+    const subset = JSON.stringify([
+      { slug: 'jane', email: 'jane@x.org' },
+      { slug: 'bob', email: 'bob@x.org' },
+    ]);
+    const { stdout } = await runCli(['upsert', 'users', '--data', subset, '--delete-missing'], fixture.path);
+    expect(stdout).toMatch(/deleted: 1\b/); // mia
+    expect(await total(fixture)).toMatch(/count: 2\b/);
+    const { exitCode } = await runCli(['read', 'users', 'mia'], fixture.path);
+    expect(exitCode).not.toBe(0); // mia gone
+  });
+});
+
+describe('patch --on-missing', () => {
+  it('skip: patches the present rows, skips the missing ones (one commit)', async () => {
+    const fixture = await seeded();
+    const before = await commitCount(fixture);
+    const batch = JSON.stringify([
+      { slug: 'jane', role: 'lead' },
+      { slug: 'ghost', role: 'x' }, // no such record
+    ]);
+    const { stdout, exitCode } = await runCli(['patch', 'users', '--data', batch, '--on-missing', 'skip'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/patched: 1\b/);
+    expect(stdout).toMatch(/skipped: 1\b/);
+    expect(await commitCount(fixture)).toBe(before + 1);
+    expect(await total(fixture)).toMatch(/count: 3\b/); // ghost not created
+  });
+
+  it('insert: upserts a missing record as new', async () => {
+    const fixture = await seeded();
+    const batch = JSON.stringify([{ slug: 'ghost', email: 'ghost@x.org', role: 'x' }]);
+    const { stdout } = await runCli(['patch', 'users', '--data', batch, '--on-missing', 'insert'], fixture.path);
+    expect(stdout).toMatch(/inserted: 1\b/);
+    expect(await total(fixture)).toMatch(/count: 4\b/);
+    const { stdout: ghost } = await runCli(['read', 'users', 'ghost'], fixture.path);
+    expect(ghost).toContain('ghost@x.org');
+  });
+
+  it('abort (default) still aborts the whole batch, nothing committed', async () => {
+    const fixture = await seeded();
+    const before = await commitCount(fixture);
+    const batch = JSON.stringify([
+      { slug: 'jane', role: 'lead' },
+      { slug: 'ghost', role: 'x' },
+    ]);
+    const { exitCode } = await runCli(['patch', 'users', '--data', batch], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(await commitCount(fixture)).toBe(before);
+  });
+});
+
+describe('patch --delete-missing', () => {
+  it('deletes existing records not targeted by the batch', async () => {
+    const fixture = await seeded();
+    const batch = JSON.stringify([
+      { slug: 'jane', role: 'a' },
+      { slug: 'bob', role: 'b' },
+    ]);
+    const { stdout } = await runCli(['patch', 'users', '--data', batch, '--delete-missing'], fixture.path);
+    expect(stdout).toMatch(/deleted: 1\b/); // mia untargeted
+    expect(await total(fixture)).toMatch(/count: 2\b/);
+  });
+});
+
+describe('patch --dry-run', () => {
+  it('previews will-change / missing without committing', async () => {
+    const fixture = await seeded();
+    const before = await commitCount(fixture);
+    const batch = JSON.stringify([
+      { slug: 'jane', role: 'lead' },
+      { slug: 'ghost', role: 'x' },
+    ]);
+    const { stdout, exitCode } = await runCli(
+      ['patch', 'users', '--data', batch, '--on-missing', 'skip', '--dry-run'],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('result: dry-run');
+    expect(stdout).toMatch(/willChange: 1\b/);
+    expect(stdout).toMatch(/missing: 1\b/);
+    expect(await commitCount(fixture)).toBe(before);
+  });
+});

--- a/skills/gitsheets/SKILL.md
+++ b/skills/gitsheets/SKILL.md
@@ -51,6 +51,8 @@ When the user is building something, these idioms are usually the right shape:
 - **Secondary indices**: `sheet.defineIndex('byEmail', { unique: true }, r => r.email.toLowerCase())`. Built lazily on first `findByIndex` call; rebuilt when the underlying tree hash changes. For markdown sheets, index builds always use body-less reads — don't index on body content (returns `undefined` → record excluded).
 - **CSV import**: `gitsheets upsert <sheet> records.csv --format=csv` — first row is the header, each subsequent row becomes one record. Cell values stay strings; type coercion belongs in the schema.
 - **Bulk ingest a databank**: build a JSON array or NDJSON stream with `jq` (never hand-serialize TOML), then pipe it into **one** `upsert` — `jq -c '.[]' raw.json | gitsheets-axi upsert repos`. The whole batch commits once. To reshape existing data, `gitsheets-axi query <sheet> --ndjson-out`, transform the file, and pipe it back in (exports round-trip verbatim). See `references/axi.md` → "Bulk data engineering".
+- **Classify / update in bulk**: use bulk `gitsheets-axi patch` (array/NDJSON of `{<path-fields>, <fields-to-set>}` → one commit, merge-not-replace), not `upsert` (which replaces whole records). `--on-missing skip|insert` tolerates or inserts stale rows; `--dry-run` previews; `--delete-missing` makes the sheet exactly match a source.
+- **Review / audit without `jq`**: `gitsheets-axi count <sheet> --filter …` for totals, `query --group-by <field>` for distributions, `distinct <sheet> <field>` for the value set. The `--filter` DSL does comparison / `!=` / `in()` / regex / `:present` / `:empty`, not just equality.
 
 ## Anti-patterns to redirect
 

--- a/skills/gitsheets/references/axi.md
+++ b/skills/gitsheets/references/axi.md
@@ -60,7 +60,7 @@ List sheets configured in the current repo. Same data as the home view, separate
 
 ### `gitsheets-axi sheets view <name>`
 
-Single-sheet detail: config summary (root, format, path template), schema property types, record count. Surfaces `body_field` for content-typed sheets.
+Single-sheet detail: config summary (root, format, path template), schema property types, record count. Surfaces `body_field` for content-typed sheets. Each schema field renders as `type [required] enum: a|b|c`, so you see allowed enum values (and which fields are required) **before** writing rather than from a rejected upsert.
 
 ### `gitsheets-axi query <sheet> [flags]`
 
@@ -68,13 +68,28 @@ List records.
 
 | Flag | Notes |
 | --- | --- |
-| `--filter <k>=<v>` | Equality match; repeatable |
+| `--filter <expr>` | Filter clause; repeatable, clauses AND. See the filter DSL below. |
 | `--fields <list>` | Extra columns beyond the default schema |
+| `--sort <field>` | Sort records by a field (missing values sort last) |
+| `--desc` | Sort descending (with `--sort`) |
+| `--group-by <field>` | Emit `{value,count}` facets instead of a record list |
 | `--limit <n>` | Caps the **stdout preview**. Default 100, max 10000 |
 | `--prefix <p>` | Tenant sub-tree scope (matches the library's `prefix` option) |
 | `--json-out[=path]` | Also write the **full** result set to a JSON array file |
 | `--ndjson-out[=path]` | Also write the full result set to an NDJSON file |
 | `--csv-out[=path]` | Also write the full result set to a CSV file (flat, lossy) |
+
+**Filter DSL** (`--filter`, repeatable, AND-combined) — shared by `query`, `count`, `distinct`, and bulk `delete`:
+
+| Form | Meaning |
+| --- | --- |
+| `k=v` / `k!=v` | equality / inequality |
+| `k<v` `k>v` `k<=v` `k>=v` | comparison (numeric for number fields, time for dates, else lexical — ISO dates sort right) |
+| `k~regex` | `String(value)` matches the JS regex |
+| `"k in (a,b,c)"` | value is one of the listed strings |
+| `k:present` / `k:empty` | field exists and is non-empty / is absent, null, `""`, or `[]` |
+
+`--group-by <field>` aggregates over the **filtered** set (ignores `--limit`), biggest bucket first: `groups[K]{value,count}:`.
 
 **Default schema is format-aware:**
 
@@ -95,6 +110,14 @@ help[1]: Run `jq '.name' /tmp/gitsheets-axi/repos-….ndjson` to process all 463
 
 `--json-out` and `--ndjson-out` are written **verbatim** (record fields only, no injected keys), so they pipe straight back into `gitsheets-axi upsert` — export → transform → re-import is a clean loop. `--csv-out` is flat (nested values JSON-encoded into their cell): a lossy reporting view, not a round-trip format.
 
+### `gitsheets-axi count <sheet> [--filter expr ...]`
+
+Record count. With no `--filter`, counts candidate tree paths **without parsing** (cheap — the fast path for totals). A filter scans body-less records and reports `count: <matched>` + `of: <total>`. Same filter DSL as `query`. Use this instead of `query … --limit 1 | grep count`.
+
+### `gitsheets-axi distinct <sheet> <field> [--filter expr ...]`
+
+Unique values of `<field>` with counts, sorted alphabetically (`values[K]{value,count}:`). `query --group-by <field>` is the same facets ordered by count. Kills the `--ndjson-out | jq 'group_by'` loop for "what values does this field take?".
+
 ### `gitsheets-axi read <sheet> <path> [--full]`
 
 Single-record detail. For markdown/mdx sheets, the body field is truncated to ~500 chars with `(truncated, N chars total)` and a `--full` hint. Surfaces `_path` and `_sheet` as plain fields (the `RECORD_PATH_KEY` / `RECORD_SHEET_KEY` Symbol annotations).
@@ -106,6 +129,8 @@ Create or replace one **or many** records.
 | Flag | Notes |
 | --- | --- |
 | `--data <json>` | Record JSON inline. If omitted, reads stdin. |
+| `--delete-missing` | After the batch, delete existing records **not** in the input set (exact re-sync). One commit. |
+| `--dry-run` | Preview `{willChange, noOp, invalid, willDelete}` (+ invalid rows) — no commit. |
 | `--allow-missing-body` | Content-typed sheets only — opt in to upserting without body field |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message (default: `<sheet> upsert <path>`) |
@@ -149,6 +174,8 @@ help[1]: gitsheets committed to the git ref, not your working tree — run `git 
 
 Output on no-op mirrors the shape with `result: no-op` and no `commit`.
 
+**`--delete-missing`** makes the sheet exactly match the input set (upsert the batch, delete anything else) — the primitive for a periodic re-sync from a source. **`--dry-run`** validates a whole batch up front and reports `willChange` / `noOp` / `invalid` (with the offending rows) / `willDelete` without committing — use it before a big import instead of finding out about a bad row mid-batch.
+
 > **Working-tree gotcha.** gitsheets writes to the git **ref** via plumbing; it does **not** touch your working tree. Right after a commit, `git status` shows the new records as *deleted* on disk (the ref has them, the working tree doesn't). Run `git checkout HEAD -- .` to materialize them. This surprises every first-time user — it's not data loss.
 
 ### `gitsheets-axi patch <sheet> [<query-json>] [flags]`
@@ -159,6 +186,9 @@ RFC 7396 JSON Merge Patch — update fields without replacing the whole record. 
 | --- | --- |
 | `--patch <json>` | **Single mode**: partial JSON for the record matched by `<query-json>`. If omitted, reads stdin. |
 | `--data <json>` | **Bulk mode**: a JSON array / NDJSON of combined records. If omitted, reads stdin. |
+| `--on-missing <m>` | Bulk: when a record's query matches nothing — `abort` (default) \| `skip` \| `insert` (upsert it as new). |
+| `--delete-missing` | Bulk: delete existing records **not** targeted by the batch (exact re-sync). One commit. |
+| `--dry-run` | Bulk: preview `{willChange, insert, noOp, missing, invalid, willDelete}` — no commit. |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message |
 
@@ -177,20 +207,27 @@ jq -c '.[] | {name, target_team, status}' decisions.json | gitsheets-axi patch r
 
 Prefer bulk `patch` over bulk `upsert` for updates: `upsert` is a full-record *replace* (you must carry every existing field or lose it), while `patch` merges — you emit only the fields you're setting, and untouched fields are safe.
 
-**Idempotent.** Unchanged records are skipped; a batch where nothing changed is a `no-op` with no commit. In a batch, a record whose query matches nothing **aborts the whole transaction** (nothing committed) and names the offending row. Output mirrors bulk `upsert` (`patched:` / `unchanged:` / the materialize hint).
+**Idempotent.** Unchanged records are skipped; a batch where nothing changed is a `no-op` with no commit. By default a record whose query matches nothing **aborts the whole transaction** (nothing committed) and names the offending row — but `--on-missing skip` tolerates stale rows (handy re-running a classification pass after new records were ingested) and `--on-missing insert` upserts them as new. Output mirrors bulk `upsert` (`patched:` / `unchanged:` / `skipped:` / the materialize hint).
 
 Single mode throws `NOT_FOUND` if the query matches no record.
 
-### `gitsheets-axi delete <sheet> <path> [flags]`
+### `gitsheets-axi rename <sheet> <old-path> <new-path>`
 
-Delete the record at `<path>`.
+Re-key a record: read it, write it at `<new-path>`, delete the old one — atomically in **one commit**. Supported for a bare single-field path template (`path = '${{ field }}'`), where `<new-path>` maps directly onto the field's value; refuses to overwrite an existing target, errors on a missing source. For decorated/multi-field templates, use `patch` to change the path fields (or `upsert --delete-missing`). This reads as intent in git history vs. a manual write-new + delete-old.
+
+### `gitsheets-axi delete <sheet> <path> [flags]` · bulk: `delete <sheet> --filter … | --stdin`
+
+Delete the record at `<path>`, or many records at once.
 
 | Flag | Notes |
 | --- | --- |
+| `--filter <expr>` | Bulk: delete every record matching the filter DSL (repeatable). No `<path>`. |
+| `--stdin` | Bulk: delete records named one-per-line on stdin. No `<path>`. |
+| `--dry-run` | Bulk: report `willDelete` (of total) — no commit. |
 | `--prefix <p>` | Tenant scope |
 | `--message <m>` | Commit message |
 
-**Idempotent on already-missing.** Agents can call `delete` without checking existence; an already-absent record exits 0 with `result: "no-op"`.
+**Idempotent on already-missing.** Agents can call `delete` without checking existence; an already-absent record exits 0 with `result: "no-op"`. **Bulk delete** removes every matching record in **one commit** (absent ids skipped) — e.g. `delete repos --filter disposition=delete-candidate`. Always `--dry-run` first to confirm the count.
 
 ### `gitsheets-axi check <sheet> <file> [--fix]`
 
@@ -315,7 +352,11 @@ gitsheets-axi diff repos HEAD~1        # review what changed
 gitsheets-axi query repos --filter status=unclassified   # what's left
 ```
 
-`patch` merges, so you emit only the fields you're setting and the rest of each record is safe — whereas `upsert` would replace the whole record and drop anything you didn't re-send. Idempotency makes each pass re-runnable (already-classified records no-op), and `diff` per batch is your review surface.
+`patch` merges, so you emit only the fields you're setting and the rest of each record is safe — whereas `upsert` would replace the whole record and drop anything you didn't re-send. Idempotency makes each pass re-runnable (already-classified records no-op), and `diff` per batch is your review surface. Re-running a pass after new records were ingested? Add `--on-missing skip`.
+
+**Reviewing / auditing the data** — reach for the analytics commands, not `--ndjson-out | jq`: `count <sheet> --filter …` for totals, `query <sheet> --group-by <field>` for distributions (e.g. `--group-by target_team` → `{archive:110, sencha:49, …}`), `distinct <sheet> <field>` for the value set, and the filter operators (`k<v`, `k!=v`, `"k in (a,b)"`, `k:empty`) for slices like "delete-candidates not pushed since 2022".
+
+**Periodic re-sync from a source** — to make a sheet exactly match an upstream (repos created/archived since last sync), `upsert --delete-missing` (full replace) or `patch --on-missing insert --delete-missing` (merge + insert new + prune gone). Preview with `--dry-run` first. Purge a class of records with `delete --filter <expr>` (again, `--dry-run` first).
 
 Do **not** loop `upsert --data` (or `patch`) once per record — that produces one commit per record (hundreds of junk commits). Pass the whole array/stream to a single `upsert` / `patch`.
 


### PR DESCRIPTION
## What & why

Follow-ups to #222 from the same 463-repo databank workload (issue #223). #222 nailed the **write** path; this closes the **read/review** side and **incremental-write robustness** — the things that kept falling back to `--ndjson-out | jq`. Stacked on #222 (base retargets to `develop` when #222 merges). All additive; no public-API breakage.

## Read-side analytics (kills the export→jq loop)
- **Filter DSL** — `--filter` now does `k=v` · `k!=v` · `k<v` `k>v` `k<=v` `k>=v` · `k~regex` · `"k in (a,b)"` · `k:present` · `k:empty` (repeatable, AND). Comparison is numeric / time-aware / lexical. Shared by query, count, distinct, and bulk delete.
- **`count <sheet> [--filter …]`** — cheap candidate-path count with no filter; scan + `matched`/`total` with one.
- **`query --group-by <field>`** — `{value,count}` facets over the filtered set, biggest first.
- **`query --sort <field> [--desc]`** — top-N review; exports carry the sorted set.
- **`distinct <sheet> <field>`** — unique values + counts.

## Incremental-write robustness
- **`--dry-run`** on bulk `upsert`/`patch` — preview `{willChange, noOp, invalid (+rows), missing, willDelete}`, no commit.
- **`--delete-missing`** on bulk `upsert`/`patch` — exact re-sync (delete records not in the input set), atomic in one commit.
- **`patch --on-missing skip|insert|abort`** (default abort) — a stale query in an incremental pass no longer kills the batch.

## Mutations
- **`rename <sheet> <old> <new>`** — re-key a record (write new + delete old) atomically; bare single-field templates; refuses to clobber an existing target.
- **bulk `delete --filter <expr>` / `--stdin`** — delete many by query or id list in one commit; `--dry-run` first.

## Lower
- **`query --sort`** (above); **`sheets view`** now renders `type [required] enum: a|b|c` so allowed values are visible before writing.

## Skill docs
`references/axi.md` + `SKILL.md` updated for all of the above (filter DSL table, count/distinct/rename sections, group-by/sort, the robustness flags, bulk delete, enum surfacing, and review/re-sync additions to the Bulk data engineering recipe).

## Testing
New suites: read-analytics (15), write-robustness (7), rename-delete (8), sheets-view-enum (1). Full workspace suite **411 pass**, type-check clean; verified end-to-end against the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr8McAaAQC9SPXrzvXejRd
