### PR TITLE
feat(api): read freshness (refresh + transact auto-refresh) and streaming blob reads

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -83,6 +83,8 @@ const store = await openStore(repo, {
 | `repo.requireExplicitTransactions()` | Switch to strict mode (one-way) |
 | `repo.startPushDaemon(opts)` | Start async push to a configured remote |
 | `repo.resolveRef(ref)` | Resolve a ref or commit hash; returns `string \| null` |
+| `repo.refresh()` | Rebind every live Sheet to the current HEAD tree — for out-of-band ref movement (a successful `transact` auto-refreshes) |
+| `repo.readBlobStream(ref, path)` | `Promise<Readable>` — stream a blob's bytes at `<ref>:<path>`, resolved at call time. Throws `RefError` / `NotFoundError` |
 
 `opts.prefix` scopes records to a sub-tree under each sheet's configured root — useful for multi-tenant deployments where one git repo holds many tenants under `<root>/<tenant>/...`. Mirrors the CLI `--prefix` flag (env `GITSHEETS_PREFIX`). The sheet's `.gitsheets/<name>.toml` config file is unaffected — only the record data tree is scoped.
 
@@ -100,6 +102,7 @@ const store = await openStore(repo, {
 | `sheet.queryFirst(filter?, opts?)` | `Promise<T \| undefined>` — honors `opts.signal`, `opts.withBody` |
 | `sheet.queryAll(filter?, opts?)` | `Promise<T[]>` — honors `opts.signal`, `opts.withBody` |
 | `sheet.loadBody(record)` | `Promise<T>` — hydrate a body-less record (content-typed sheets) |
+| `sheet.refresh()` | Rebind this sheet's read snapshot to the current HEAD tree (out-of-band movement; own commits auto-refresh) |
 | `sheet.pathForRecord(record)` | `Promise<string>` — rendered path, no write |
 | `sheet.normalizeRecord(record)` | `Promise<T>` — canonical form, no write |
 
@@ -124,6 +127,7 @@ All write methods route through a transaction — permissive mode auto-opens one
 | --- | --- |
 | `sheet.getAttachment(record, name)` | One attachment's BlobObject or null |
 | `sheet.getAttachments(record)` | Map of name → BlobObject |
+| `sheet.getAttachmentStream(recordOrPath, name)` | `Promise<Readable \| null>` — stream an attachment's bytes without materializing the record |
 | `sheet.setAttachment(record, name, blob)` | Add or replace |
 | `sheet.setAttachments(record, map)` | Bulk variant |
 | `sheet.deleteAttachment(record, name)` | Remove a single attachment; throws `NotFoundError` if missing |
@@ -177,10 +181,13 @@ type Store<V extends ValidatorMap> = {
   readonly [K in keyof V]: Sheet<InferRecord<V[K]>>;
 } & {
   readonly transact: StoreTransactFn<V>;
+  readonly refresh: () => Promise<void>;
 };
 ```
 
-`store.<sheet>` for each sheet declared in `validators`. `store.transact(opts, async tx => ...)` mirrors `repo.transact` with `tx.<sheet>` aliases that thread validators through.
+`store.<sheet>` for each sheet declared in `validators`. `store.transact(opts, async tx => ...)` mirrors `repo.transact` with `tx.<sheet>` aliases that thread validators through. `store.refresh()` rebinds every sheet to the current HEAD tree (delegates to `repo.refresh()`).
+
+Reads through `store.<sheet>` follow the freshness model: a successful `store.transact` / `repo.transact` auto-refreshes, so post-commit reads reflect the committed state — see [`specs/behaviors/freshness.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/freshness.md).
 
 Sheets not in `validators` are accessible via `repo.openSheet(name)` for one-off un-typed access.
 

--- a/packages/gitsheets/src/repo-blob-stream.test.ts
+++ b/packages/gitsheets/src/repo-blob-stream.test.ts
@@ -1,0 +1,138 @@
+// Streaming blob reads by key/path — repo.readBlobStream + sheet.getAttachmentStream.
+// See specs/behaviors/attachments.md#streaming-reads-by-keypath.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Readable } from 'node:stream';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { NotFoundError, RefError } from './errors.js';
+import { openRepo, type Repository } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const USERS = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+`;
+
+async function seededRepo(): Promise<{ fixture: TestRepoHandle; repo: Repository }> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users sheet');
+  const repo = await openRepo({ gitDir: fixture.gitDir });
+  return { fixture, repo };
+}
+
+async function collect(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Binary bytes (not valid UTF-8) to prove byte fidelity end-to-end. */
+const BINARY = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe, 0x0a, 0x1b]);
+
+async function commitAvatar(repo: Repository, bytes: Buffer): Promise<void> {
+  await repo.transact({ message: 'avatar' }, async (tx) => {
+    const sheet = tx.sheet('users');
+    await sheet.upsert({ slug: 'jane' });
+    const blob = await repo.writeBlob(bytes);
+    await sheet.setAttachment('jane', 'avatar.png', blob);
+  });
+}
+
+describe('repo.readBlobStream', () => {
+  it('streams byte-identical content for a committed attachment', async () => {
+    const { repo } = await seededRepo();
+    await commitAvatar(repo, BINARY);
+
+    const stream = await repo.readBlobStream('HEAD', 'users/jane/avatar.png');
+    expect(Buffer.compare(await collect(stream), BINARY)).toBe(0);
+  });
+
+  it('resolves the ref at call time — a later commit is immediately visible', async () => {
+    const { repo } = await seededRepo();
+    await commitAvatar(repo, Buffer.from('v1'));
+    await commitAvatar(repo, Buffer.from('v2'));
+
+    const stream = await repo.readBlobStream('HEAD', 'users/jane/avatar.png');
+    expect((await collect(stream)).toString()).toBe('v2');
+  });
+
+  it('throws NotFoundError(record_not_found) for a missing path', async () => {
+    const { repo } = await seededRepo();
+    const err = await repo.readBlobStream('HEAD', 'users/nope/avatar.png').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect((err as NotFoundError).code).toBe('record_not_found');
+  });
+
+  it('throws NotFoundError(record_not_found) for a directory path', async () => {
+    const { repo } = await seededRepo();
+    await commitAvatar(repo, BINARY);
+    const err = await repo.readBlobStream('HEAD', 'users/jane').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws RefError(ref_not_found) for a ref that does not resolve', async () => {
+    const { repo } = await seededRepo();
+    const err = await repo.readBlobStream('no-such-ref', 'users/jane/avatar.png').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RefError);
+    expect((err as RefError).code).toBe('ref_not_found');
+  });
+});
+
+describe('sheet.getAttachmentStream', () => {
+  it('streams the attachment bytes by record path without materializing the record', async () => {
+    const { repo } = await seededRepo();
+    await commitAvatar(repo, BINARY);
+    const users = await repo.openSheet('users');
+
+    const stream = await users.getAttachmentStream('jane', 'avatar.png');
+    expect(stream).not.toBeNull();
+    expect(Buffer.compare(await collect(stream!), BINARY)).toBe(0);
+  });
+
+  it('accepts a record object too', async () => {
+    const { repo } = await seededRepo();
+    await commitAvatar(repo, BINARY);
+    const users = await repo.openSheet('users');
+
+    const stream = await users.getAttachmentStream({ slug: 'jane' }, 'avatar.png');
+    expect(Buffer.compare(await collect(stream!), BINARY)).toBe(0);
+  });
+
+  it('returns null when the attachment is absent', async () => {
+    const { repo } = await seededRepo();
+    await commitAvatar(repo, BINARY);
+    const users = await repo.openSheet('users');
+
+    expect(await users.getAttachmentStream('jane', 'missing.png')).toBeNull();
+  });
+
+  it('reads through the fresh snapshot after this repository commits (auto-refresh)', async () => {
+    const { repo } = await seededRepo();
+    const users = await repo.openSheet('users');
+
+    await commitAvatar(repo, Buffer.from('v1'));
+    let stream = await users.getAttachmentStream('jane', 'avatar.png');
+    expect((await collect(stream!)).toString()).toBe('v1');
+
+    await commitAvatar(repo, Buffer.from('v2'));
+    stream = await users.getAttachmentStream('jane', 'avatar.png');
+    expect((await collect(stream!)).toString()).toBe('v2');
+  });
+});

--- a/packages/gitsheets/src/repository.ts
+++ b/packages/gitsheets/src/repository.ts
@@ -4,11 +4,12 @@
 // remaining git shell-outs are genuine porcelain (ref resolution, sheet
 // discovery, author config). See specs/api/repository.md.
 
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
+import type { Readable } from 'node:stream';
 import { promisify } from 'node:util';
 
 import { addon, callCore, CoreTransaction } from './core.js';
-import { ConfigError, RefError, TransactionError } from './errors.js';
+import { ConfigError, NotFoundError, RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
 import {
   PushDaemon,
@@ -79,6 +80,13 @@ export class Repository {
   readonly #gitDir: string;
   readonly #mutex = new Mutex();
   readonly #postCommitHooks: Array<(commitHash: string) => void> = [];
+  /**
+   * Every live non-transaction Sheet this Repository has issued, held weakly
+   * so registration imposes no lifecycle obligation on consumers. Rebound to
+   * the current HEAD tree by {@link refresh} (and the transact auto-refresh).
+   * See specs/behaviors/freshness.md.
+   */
+  readonly #sheetRegistry = new Set<WeakRef<Sheet>>();
   #strictMode = false;
   #pushDaemon: PushDaemon | null = null;
 
@@ -109,6 +117,84 @@ export class Repository {
   /** Switch to strict mode — mutations outside repo.transact throw. One-way. */
   requireExplicitTransactions(): void {
     this.#strictMode = true;
+  }
+
+  /**
+   * @internal — called from the Sheet constructor so every non-transaction
+   * Sheet this Repository issues (openSheet / openSheets / openStore /
+   * Sheet.clone) participates in the freshness model. Weakly held.
+   */
+  registerSheet(sheet: Sheet): void {
+    this.#sheetRegistry.add(new WeakRef(sheet));
+  }
+
+  /**
+   * @internal — the tree hash non-transaction reads currently resolve
+   * against: HEAD's tree, or the empty tree on a fresh repo. Used by
+   * Sheet.refresh to rebind a single sheet.
+   */
+  async currentReadTree(): Promise<string> {
+    return this.#resolveReadTree();
+  }
+
+  /**
+   * Rebind every live Sheet this Repository has issued to the current HEAD
+   * tree. The consumer's tool after out-of-band ref movement; not needed
+   * after this repository's own transact (a successful commit auto-refreshes).
+   * See specs/behaviors/freshness.md.
+   */
+  async refresh(): Promise<void> {
+    const tree = await this.#resolveReadTree();
+    this.#rebindLiveSheets(tree);
+  }
+
+  #rebindLiveSheets(tree: string): void {
+    for (const ref of this.#sheetRegistry) {
+      const sheet = ref.deref();
+      if (sheet === undefined) {
+        this.#sheetRegistry.delete(ref);
+        continue;
+      }
+      sheet.rebindReadTree(tree);
+    }
+  }
+
+  /**
+   * Stream a blob's bytes by `<ref>:<path>`, resolved at call time —
+   * independent of any Sheet's read snapshot. Returns a Node Readable piped
+   * from `git cat-file blob`; the blob is never fully buffered by gitsheets.
+   *
+   * Throws RefError(ref_not_found) when `ref` doesn't resolve to a tree-ish,
+   * NotFoundError(record_not_found) when `path` is absent under the ref's
+   * tree or names a non-blob. See specs/api/repository.md and
+   * specs/behaviors/attachments.md#streaming-reads-by-keypath.
+   */
+  async readBlobStream(ref: string, path: string): Promise<Readable> {
+    const spec = `${ref}:${path}`;
+    let type: string | null = null;
+    try {
+      const { stdout } = await exec('git', ['cat-file', '-t', spec], { cwd: this.#gitDir });
+      type = stdout.trim() || null;
+    } catch {
+      type = null;
+    }
+    if (type === null) {
+      // Distinguish a bad ref from a missing path for typed errors.
+      const refResolves = await revParseVerify(this.#gitDir, `${ref}^{tree}`);
+      if (!refResolves) {
+        throw new RefError('ref_not_found', `readBlobStream: ref does not resolve: ${ref}`);
+      }
+      throw new NotFoundError('record_not_found', `readBlobStream: no object at ${spec}`);
+    }
+    if (type !== 'blob') {
+      throw new NotFoundError(
+        'record_not_found',
+        `readBlobStream: object at ${spec} is a ${type}, not a blob`,
+      );
+    }
+    const child = spawn('git', ['cat-file', 'blob', spec], { cwd: this.#gitDir });
+    child.stdin.end();
+    return child.stdout;
   }
 
   /** Resolve a ref or commit hash. Returns the full commit hash or null. */
@@ -240,6 +326,11 @@ export class Repository {
       }
       const result = await tx.finalize(value);
       if (result.commitHash !== null) {
+        // Auto-refresh: rebind every live sheet to the post-commit HEAD tree
+        // (read-your-writes — specs/behaviors/freshness.md). Resolved from
+        // HEAD rather than the result tree so a commit onto a non-HEAD branch
+        // doesn't shift HEAD-bound sheets.
+        this.#rebindLiveSheets(await this.#resolveReadTree());
         for (const hook of this.#postCommitHooks) {
           try {
             hook(result.commitHash);
@@ -350,6 +441,18 @@ export class Repository {
 /** Convenience factory: `openRepo({ gitDir? })`. */
 export async function openRepo(opts: OpenRepoOptions = {}): Promise<Repository> {
   return Repository.open(opts);
+}
+
+/** True when `git rev-parse --verify --quiet <rev>` resolves. */
+async function revParseVerify(gitDir: string, rev: string): Promise<boolean> {
+  try {
+    const { stdout } = await exec('git', ['rev-parse', '--verify', '--quiet', rev], {
+      cwd: gitDir,
+    });
+    return stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /** Resolve a ref/commit-ish to its full commit hash via git rev-parse; null on failure. */

--- a/packages/gitsheets/src/sheet-refresh.test.ts
+++ b/packages/gitsheets/src/sheet-refresh.test.ts
@@ -1,0 +1,242 @@
+// Read freshness — refresh + transact auto-refresh.
+// See specs/behaviors/freshness.md.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openRepo } from './repository.js';
+import { openStore } from './store.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+async function makeRepo(): Promise<TestRepoHandle> {
+  const h = await testRepo({ withInitialCommit: true });
+  handles.push(h);
+  return h;
+}
+
+const USERS = `[gitsheet]
+root = 'users'
+path = '\${{ slug }}'
+`;
+
+async function seedUsers(fixture: TestRepoHandle): Promise<void> {
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'users.toml'), USERS);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add users sheet');
+}
+
+describe('transact auto-refresh (read-your-writes)', () => {
+  it('standing Sheet reads reflect a repo.transact commit without re-opening', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+
+    expect(await users.queryAll()).toEqual([]);
+
+    await repo.transact({ message: 'add jane' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    const rows = await users.queryAll();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ slug: 'jane', email: 'jane@x.org' });
+  });
+
+  it('store sheets read post-commit state after store.transact', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const store = await openStore(repo);
+
+    await store.transact({ message: 'add jane' }, async (tx) => {
+      await (tx as Record<string, import('./sheet.js').Sheet>)['users']!.upsert({
+        slug: 'jane',
+        email: 'jane@x.org',
+      });
+    });
+
+    const users = (store as unknown as Record<string, import('./sheet.js').Sheet>)['users']!;
+    expect(await users.queryAll()).toHaveLength(1);
+  });
+
+  it('permissive-mode auto-transactions refresh sibling sheets too', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const writer = await repo.openSheet('users');
+    const reader = await repo.openSheet('users');
+
+    await writer.upsert({ slug: 'jane' });
+
+    expect(await reader.queryAll()).toHaveLength(1);
+  });
+
+  it('attachment reads through a standing sheet see post-commit state', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+
+    await repo.transact({ message: 'add jane + avatar' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await sheet.upsert({ slug: 'jane' });
+      const blob = await repo.writeBlob(Buffer.from('png-bytes'));
+      await sheet.setAttachment('jane', 'avatar.png', blob);
+    });
+
+    const att = await users.getAttachment('jane', 'avatar.png');
+    expect(att).not.toBeNull();
+    expect((await att!.read()).toString()).toBe('png-bytes');
+  });
+
+  it('a commit onto a non-HEAD branch does not shift standing sheets', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    await fixture.git('branch', 'side');
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+
+    const result = await repo.transact(
+      { message: 'add jane on side', parent: 'side' },
+      async (tx) => {
+        await tx.sheet('users').upsert({ slug: 'jane' });
+      },
+    );
+    expect(result.commitHash).not.toBeNull();
+    expect(result.ref).toBe('refs/heads/side');
+
+    // HEAD (main) is unchanged, so the standing sheet stays empty.
+    expect(await users.queryAll()).toEqual([]);
+  });
+
+  it('a no-op transaction leaves the snapshot untouched', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+
+    const result = await repo.transact({ message: 'noop' }, async () => 'nothing');
+    expect(result.commitHash).toBeNull();
+    expect(await users.queryAll()).toEqual([]);
+  });
+});
+
+describe('explicit refresh after out-of-band movement', () => {
+  it('an external commit is invisible until sheet.refresh()', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+    expect(await users.queryAll()).toEqual([]);
+
+    // Out-of-band writer: a second Repository instance over the same git dir.
+    const external = await openRepo({ gitDir: fixture.gitDir });
+    await external.transact({ message: 'external add' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'ext' });
+    });
+
+    // The first repo instance did not commit; its sheets are still pinned.
+    expect(await users.queryAll()).toEqual([]);
+
+    await users.refresh();
+    expect(await users.queryAll()).toHaveLength(1);
+  });
+
+  it('repo.refresh() rebinds every open sheet at once', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const a = await repo.openSheet('users');
+    const b = await repo.openSheet('users');
+
+    const external = await openRepo({ gitDir: fixture.gitDir });
+    await external.transact({ message: 'external add' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'ext' });
+    });
+
+    await repo.refresh();
+    expect(await a.queryAll()).toHaveLength(1);
+    expect(await b.queryAll()).toHaveLength(1);
+  });
+
+  it('store.refresh() delegates to repo.refresh()', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const store = await openStore(repo);
+    const users = (store as unknown as Record<string, import('./sheet.js').Sheet>)['users']!;
+
+    const external = await openRepo({ gitDir: fixture.gitDir });
+    await external.transact({ message: 'external add' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'ext' });
+    });
+
+    expect(await users.queryAll()).toEqual([]);
+    await store.refresh();
+    expect(await users.queryAll()).toHaveLength(1);
+  });
+
+  it('refresh() throws TypeError on a transaction-bound sheet', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'probe' }, async (tx) => {
+      const sheet = tx.sheet('users');
+      await expect(sheet.refresh()).rejects.toBeInstanceOf(TypeError);
+      await sheet.upsert({ slug: 'jane' });
+    });
+  });
+});
+
+describe('rebind re-derivations', () => {
+  it('findByIndex reflects the post-commit tree via lazy rebuild', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+    users.defineIndex('byEmail', { unique: true }, (r) => (r['email'] as string) ?? undefined);
+
+    expect(await users.findByIndex('byEmail', 'jane@x.org')).toBeUndefined();
+
+    await repo.transact({ message: 'add jane' }, async (tx) => {
+      await tx.sheet('users').upsert({ slug: 'jane', email: 'jane@x.org' });
+    });
+
+    const hit = await users.findByIndex('byEmail', 'jane@x.org');
+    expect(hit).toMatchObject({ slug: 'jane' });
+  });
+
+  it('a committed sheet-config change becomes visible after rebind', async () => {
+    const fixture = await makeRepo();
+    await seedUsers(fixture);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const users = await repo.openSheet('users');
+    expect((await users.readConfig()).schema).toBeNull();
+
+    const withSchema = `${USERS}
+[gitsheet.schema]
+type = 'object'
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+`;
+    await repo.transact({ message: 'tighten config' }, async (tx) => {
+      tx.writeFile('.gitsheets/users.toml', withSchema);
+    });
+
+    expect((await users.readConfig()).schema).not.toBeNull();
+  });
+});

--- a/packages/gitsheets/src/sheet.ts
+++ b/packages/gitsheets/src/sheet.ts
@@ -741,7 +741,12 @@ export class Sheet<T extends RecordLike = RecordLike> {
   readonly #name: string;
   readonly #configPath: string;
   readonly #transaction: Transaction | undefined;
-  readonly #readRef: string | undefined;
+  /**
+   * Non-transactional read snapshot — mutable: rebound to the current HEAD
+   * tree by the owning Repository's refresh/auto-refresh, or by
+   * {@link refresh}. See specs/behaviors/freshness.md.
+   */
+  #readRef: string | undefined;
   readonly #dataBase: string;
   readonly #validator: StandardSchemaV1<unknown, T> | undefined;
   readonly #prefix: string;
@@ -757,6 +762,11 @@ export class Sheet<T extends RecordLike = RecordLike> {
     this.#dataBase = (opts.dataBase ?? '').replace(/^\/+|\/+$/g, '');
     this.#validator = opts.validator;
     this.#prefix = (opts.prefix ?? '').replace(/^\/+|\/+$/g, '');
+    if (this.#transaction === undefined) {
+      // Participate in the freshness model: the Repository rebinds every live
+      // non-tx sheet after each of its own commits, and on repo.refresh().
+      this.#repo.registerSheet(this as unknown as Sheet);
+    }
   }
 
   /** The git dir this sheet reads/writes through. */
@@ -811,10 +821,43 @@ export class Sheet<T extends RecordLike = RecordLike> {
     return this.#transaction !== undefined;
   }
 
+  /**
+   * Rebind this sheet's read snapshot to the repository's current HEAD tree.
+   * Only this sheet — the "did my row land?" primitive; use `repo.refresh()`
+   * or `store.refresh()` to rebind every open sheet at once. Not needed after
+   * this repository's own `repo.transact` (a successful commit
+   * auto-refreshes). See specs/behaviors/freshness.md.
+   *
+   * Throws TypeError on a transaction-bound sheet — those read the
+   * transaction's private in-progress tree and are never rebound.
+   */
+  async refresh(): Promise<void> {
+    if (this.#transaction !== undefined) {
+      throw new TypeError(
+        'Sheet.refresh() is not available on a transaction-bound Sheet — it reads the transaction’s private tree',
+      );
+    }
+    this.rebindReadTree(await this.#repo.currentReadTree());
+  }
+
+  /**
+   * @internal — swap the read snapshot to `tree` and lazily re-derive
+   * everything downstream: the memoized config drops (re-read from the new
+   * tree on next access) and index builds invalidate via the existing
+   * `treeHashAtBuild` comparison in `#ensureIndexBuilt`. No-op when the tree
+   * hasn't moved, or on a transaction-bound sheet.
+   */
+  rebindReadTree(tree: string): void {
+    if (this.#transaction !== undefined) return;
+    if (this.#readRef === tree) return;
+    this.#readRef = tree;
+    this.#configPromise = undefined;
+  }
+
   async readConfig(): Promise<SheetConfig> {
-    // A Sheet reads a single, immutable tree ref (the open snapshot, or the tx
-    // parent), so its config never changes over the instance's lifetime.
-    // Memoize to avoid a `git rev-parse` per call on hot write/query loops.
+    // A Sheet reads a stable snapshot tree ref (rebound only via
+    // rebindReadTree, which resets this memo), so config is memoized to avoid
+    // a `git rev-parse` per call on hot write/query loops.
     if (this.#configPromise === undefined) {
       this.#configPromise = loadConfig(this.#gitDir, this.#configTreeRef(), this.#configPath);
     }
@@ -1440,6 +1483,21 @@ export class Sheet<T extends RecordLike = RecordLike> {
       out[name] = makeBlobHandle(this.#gitDir, hash, mode);
     }
     return out;
+  }
+
+  /**
+   * Stream an attachment's bytes without materializing the record. Accepts a
+   * record object or a rendered record path (like `getAttachment`); returns a
+   * Node Readable over the blob's bytes, or `null` when the attachment is
+   * absent. Resolved through the sheet's read snapshot — fresh after this
+   * repository's own commits (auto-refresh) or an explicit `refresh()`.
+   *
+   * See specs/behaviors/attachments.md#streaming-reads-by-keypath.
+   */
+  async getAttachmentStream(record: T | string, name: string): Promise<Readable | null> {
+    const blob = await this.getAttachment(record, name);
+    if (blob === null) return null;
+    return makeAttachmentBlobHandle(this.#gitDir, blob.hash).stream();
   }
 
   /**

--- a/packages/gitsheets/src/store.ts
+++ b/packages/gitsheets/src/store.ts
@@ -39,6 +39,13 @@ export type Store<V extends ValidatorMap = ValidatorMap> = {
   readonly [K in keyof V]: Sheet<InferRecord<V[K]>>;
 } & {
   readonly transact: StoreTransactFn<V>;
+  /**
+   * Rebind every sheet to the repository's current HEAD tree — delegates to
+   * `repo.refresh()`. Use after out-of-band ref movement; not needed after
+   * this store's own transact (a successful commit auto-refreshes).
+   * See specs/behaviors/freshness.md.
+   */
+  readonly refresh: () => Promise<void>;
 };
 
 /** tx object passed into Store.transact's handler. */
@@ -109,5 +116,7 @@ export async function openStore<V extends ValidatorMap = ValidatorMap>(
     return repo.transact(txOpts, innerHandler);
   };
 
-  return Object.assign(Object.create(null), sheets, { transact }) as Store<V>;
+  const refresh = (): Promise<void> => repo.refresh();
+
+  return Object.assign(Object.create(null), sheets, { transact, refresh }) as Store<V>;
 }

--- a/plans/sheet-freshness-streaming.md
+++ b/plans/sheet-freshness-streaming.md
@@ -1,5 +1,6 @@
 ---
-status: in-progress
+status: done
+pr: 239
 depends: []
 specs:
   - specs/behaviors/freshness.md
@@ -82,21 +83,21 @@ lives inside a `CoreTransaction`). No core or napi changes.
 
 ## Validation
 
-- [ ] Standing `Sheet`/`Store` reads reflect a `repo.transact` commit
+- [x] Standing `Sheet`/`Store` reads reflect a `repo.transact` commit
       immediately after it resolves (no re-open) — vitest.
-- [ ] External commit (second `Repository` instance) is invisible until
+- [x] External commit (second `Repository` instance) is invisible until
       `sheet.refresh()` / `repo.refresh()` / `store.refresh()`, visible after —
       vitest.
-- [ ] A commit onto a non-HEAD branch does **not** shift standing sheets — vitest.
-- [ ] `findByIndex` after a commit reflects the new tree (lazy rebuild), and a
+- [x] A commit onto a non-HEAD branch does **not** shift standing sheets — vitest.
+- [x] `findByIndex` after a commit reflects the new tree (lazy rebuild), and a
       committed sheet-config change is visible after rebind — vitest.
-- [ ] `refresh()` on a tx-bound sheet throws `TypeError` — vitest.
-- [ ] `repo.readBlobStream` streams byte-identical content for a committed
+- [x] `refresh()` on a tx-bound sheet throws `TypeError` — vitest.
+- [x] `repo.readBlobStream` streams byte-identical content for a committed
       attachment; missing path / non-blob → `NotFoundError(record_not_found)`;
       bad ref → `RefError(ref_not_found)` — vitest.
-- [ ] `sheet.getAttachmentStream` streams current bytes through the snapshot
+- [x] `sheet.getAttachmentStream` streams current bytes through the snapshot
       (fresh after auto-refresh) and returns `null` when absent — vitest.
-- [ ] Full suites green: package vitest + type-check, `cargo test`, napi
+- [x] Full suites green: package vitest + type-check, `cargo test`, napi
       `node --test` (core untouched — suites prove no regression).
 
 ## Risks / unknowns
@@ -114,8 +115,22 @@ lives inside a `CoreTransaction`). No core or napi changes.
 
 ## Notes
 
-(Populated at closeout.)
+- **Core statelessness confirmed** — the entire freshness model landed in the
+  Node host shell; `recordQuery`/`recordQueryCandidates`/`coreDiscoverSheets`
+  take `gitDir` + `treeRef` per call, so no core/napi change was needed and
+  the napi suite (101) + `cargo test` pass untouched.
+- **Auto-refresh resolves HEAD, not the result tree** — keeps non-HEAD-branch
+  commits from shifting HEAD-bound sheets; covered by a dedicated test.
+- **Indexes went fresh, not stale-pinned** — the existing `treeHashAtBuild`
+  comparison made #184's "indices stay at the snapshot" carve-out unnecessary;
+  rebinding invalidates builds and `findByIndex` lazily rebuilds.
+- **Branch/PR churn** — the original branch (`feat/sheet-freshness-streaming`,
+  PR #238) picked up two unrelated commits from the parallel #232 work via a
+  shared working tree; rebased clean onto develop as
+  `feat/read-freshness-streaming` (PR #239). #238 closed as superseded.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- Issue [#240](https://github.com/JarvusInnovations/gitsheets/issues/240) —
+  Python-binding parity: rebindable snapshot + `refresh()` + auto-refresh +
+  streaming blob read in `rust/gitsheets-py` (spec is binding-agnostic).

--- a/plans/sheet-freshness-streaming.md
+++ b/plans/sheet-freshness-streaming.md
@@ -1,0 +1,121 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/behaviors/freshness.md
+  - specs/api/repository.md
+  - specs/api/sheet.md
+  - specs/api/store.md
+  - specs/behaviors/attachments.md
+  - specs/behaviors/indexing.md
+  - specs/behaviors/transactions.md
+issues: [184, 235]
+---
+
+# Plan: Read freshness (refresh + auto-refresh) and streaming blob reads
+
+## Scope
+
+Consumer-hardening from the first production 2.x migration
+([#184](https://github.com/JarvusInnovations/gitsheets/issues/184),
+[#235](https://github.com/JarvusInnovations/gitsheets/issues/235)):
+
+**In:**
+
+- The freshness model ([`specs/behaviors/freshness.md`](../specs/behaviors/freshness.md)):
+  non-transaction `Sheet` reads resolve through a rebindable read snapshot.
+  `sheet.refresh()`, `store.refresh()`, `repo.refresh()`, and **auto-refresh of
+  every live sheet after a successful `repo.transact` commit** (read-your-writes).
+- Streaming blob reads by key/path without materializing the record:
+  `repo.readBlobStream(ref, path)` (call-time ref resolution) and
+  `sheet.getAttachmentStream(recordOrPath, name)` (snapshot-resolved).
+
+**Out:**
+
+- Python-binding freshness parity (`rust/gitsheets-py` has its own host shell) —
+  follow-up issue at closeout.
+- Pinning a `Sheet` to an old tree (explicitly rejected by the freshness spec's
+  read-your-writes principle; historical reads go through `diffFrom(srcRef)` /
+  `readBlobStream(ref, path)`).
+- #234/#236/#237 — the parallel `consumer-api-ergonomics` plan.
+
+## Implements
+
+- [`specs/behaviors/freshness.md`](../specs/behaviors/freshness.md) — whole spec (new).
+- [`specs/api/repository.md`](../specs/api/repository.md) — `refresh`,
+  `readBlobStream`, transact auto-refresh note.
+- [`specs/api/sheet.md`](../specs/api/sheet.md) — `refresh`,
+  `getAttachmentStream`, clone-freshness note.
+- [`specs/api/store.md`](../specs/api/store.md) — `store.refresh()`.
+- [`specs/behaviors/attachments.md`](../specs/behaviors/attachments.md) —
+  "Streaming reads by key/path".
+- [`specs/behaviors/indexing.md`](../specs/behaviors/indexing.md) /
+  [`specs/behaviors/transactions.md`](../specs/behaviors/transactions.md) —
+  invalidation/visibility wording aligned to the rebind model.
+
+## Approach
+
+All host-shell (TypeScript) work — verified the Rust core is stateless for
+non-transaction reads (`recordQuery`/`recordQueryCandidates`/`coreDiscoverSheets`
+take `gitDir` + `treeRef` per call; the core `Sheet`/`Store` state machine only
+lives inside a `CoreTransaction`). No core or napi changes.
+
+- **`Sheet`** — make `#readRef` mutable; `_rebindReadTree(tree)` (internal)
+  swaps the snapshot and drops the memoized config promise; index builds
+  invalidate automatically via the existing `treeHashAtBuild` comparison.
+  Public `refresh()` re-resolves via the repo; throws `TypeError` when
+  transaction-bound.
+- **`Repository`** — weak registry (`Set<WeakRef<Sheet>>`) populated from the
+  `Sheet` constructor for non-tx sheets (covers `openSheet`, `openSheets`,
+  `openStore`, `clone`); `refresh()` resolves `HEAD^{tree}` once and rebinds
+  live sheets, pruning dead refs; `transact` calls it after a commit-producing
+  finalize (before post-commit hooks).
+- **`Store`** — `refresh` property delegating to `repo.refresh()`; `Store<V>`
+  type gains `readonly refresh: () => Promise<void>`.
+- **`repo.readBlobStream(ref, path)`** — `git cat-file -t <ref>:<path>` type
+  probe → typed `RefError`/`NotFoundError`, then a spawned
+  `git cat-file blob` stdout as the `Readable` (consistent with the existing
+  attachment-handle streaming; genuine git porcelain).
+- **`sheet.getAttachmentStream`** — `getAttachment` (snapshot-resolved hash)
+  → stream by hash; `null` passthrough.
+- Docs: `docs/api.md` Repository/Sheet/Store sections.
+
+## Validation
+
+- [ ] Standing `Sheet`/`Store` reads reflect a `repo.transact` commit
+      immediately after it resolves (no re-open) — vitest.
+- [ ] External commit (second `Repository` instance) is invisible until
+      `sheet.refresh()` / `repo.refresh()` / `store.refresh()`, visible after —
+      vitest.
+- [ ] A commit onto a non-HEAD branch does **not** shift standing sheets — vitest.
+- [ ] `findByIndex` after a commit reflects the new tree (lazy rebuild), and a
+      committed sheet-config change is visible after rebind — vitest.
+- [ ] `refresh()` on a tx-bound sheet throws `TypeError` — vitest.
+- [ ] `repo.readBlobStream` streams byte-identical content for a committed
+      attachment; missing path / non-blob → `NotFoundError(record_not_found)`;
+      bad ref → `RefError(ref_not_found)` — vitest.
+- [ ] `sheet.getAttachmentStream` streams current bytes through the snapshot
+      (fresh after auto-refresh) and returns `null` when absent — vitest.
+- [ ] Full suites green: package vitest + type-check, `cargo test`, napi
+      `node --test` (core untouched — suites prove no regression).
+
+## Risks / unknowns
+
+- **Behavior change for snapshot-reliant consumers** — auto-refresh replaces
+  the accidental pinned-at-open behavior. Mitigated: the old behavior was
+  never specified as a snapshot guarantee (repository.md said "bound to this
+  repository's current state"), and the known consumers all worked around
+  staleness rather than relying on it. Spec'd as the read-your-writes
+  principle.
+- **WeakRef registry growth** — long-lived repos opening many short-lived
+  sheets. Mitigated: dead refs pruned on every refresh.
+- **In-flight iteration during rebind** — `query()` captures its tree ref at
+  call start; spec'd as iteration stability, no code change needed.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/specs/README.md
+++ b/specs/README.md
@@ -44,6 +44,7 @@ specs/
     ├── validation.md
     ├── normalization.md
     ├── transactions.md
+    ├── freshness.md
     ├── indexing.md
     ├── push-sync.md
     ├── attachments.md

--- a/specs/api/repository.md
+++ b/specs/api/repository.md
@@ -78,6 +78,35 @@ const result = await repo.transact(
 
 See [behaviors/transactions.md](../behaviors/transactions.md) for semantics (mutex, commit-on-success, trailer formatting).
 
+**Auto-refresh on commit.** When the transaction produces a commit, `repo.transact` rebinds every live `Sheet` this repository has issued to the current `HEAD` tree before resolving — reads through standing sheets (including `store.<sheet>`) immediately reflect the committed state. A no-op or discarded transaction rebinds nothing. See [behaviors/freshness.md](../behaviors/freshness.md).
+
+### `repo.refresh()`
+
+Rebind every live `Sheet` this `Repository` has issued (via `openSheet`, `openSheets`, `openStore`, or `Sheet.clone()`) to the repository's current `HEAD` tree. Returns `Promise<void>`.
+
+```typescript
+// after an out-of-band ref movement (external process commit, fetch+reset):
+await repo.refresh();
+```
+
+Cheap: one ref resolution, then a lazy rebind per sheet — records, attachments, config, and indexes re-derive on their next read. Consumers do **not** need to call this after their own `repo.transact` — a successful commit auto-refreshes (see below). See [behaviors/freshness.md](../behaviors/freshness.md).
+
+### `repo.readBlobStream(ref, path)`
+
+Stream a blob's bytes by `<ref>:<path>`, resolved **at call time** — independent of any sheet's read snapshot. Returns `Promise<Readable>` (a Node stream); bytes are piped from the object store without materializing the whole blob in memory.
+
+```typescript
+const stream = await repo.readBlobStream('HEAD', 'people/janedoe/avatar.jpg');
+stream.pipe(httpResponse);
+```
+
+- `ref` — any tree-ish: ref name, commit hash, or tree hash.
+- `path` — tree path under the ref (e.g. an attachment's key: `<sheetRoot>/<recordPath>/<name>`).
+- Throws `RefError` (`ref_not_found`) when `ref` doesn't resolve to a tree-ish.
+- Throws `NotFoundError` (`record_not_found`) when `path` is absent under the ref's tree, or names a non-blob (a directory).
+
+The typical consumer is an HTTP handler serving attachment bytes by key (see [behaviors/attachments.md](../behaviors/attachments.md#streaming-reads-by-keypath)); `Sheet.getAttachmentStream` is the sheet-scoped sibling.
+
 ### `repo.requireExplicitTransactions()`
 
 Opt into strict mode. After this is called on a `Repository`, calling `Sheet.upsert` / `delete` / `patch` outside a transaction throws `TransactionError` with `code: 'transaction_required'`.
@@ -131,7 +160,8 @@ When the handler stages no mutations, the transaction does **not** commit — `c
 
 | Class | Code | When |
 | --- | --- | --- |
-| `RefError` | `ref_not_found` | `parent` ref doesn't exist |
+| `RefError` | `ref_not_found` | `parent` ref doesn't exist; `readBlobStream` ref doesn't resolve |
+| `NotFoundError` | `record_not_found` | `readBlobStream` path absent under the ref, or not a blob |
 | `TransactionError` | `transaction_in_progress` | Another transaction is open on this repo |
 | `TransactionError` | `commit_failed` | The underlying `git commit-tree` or `update-ref` failed |
 | `TransactionError` | `parent_moved` | Optimistic concurrency: parent ref moved between transaction start and commit |
@@ -168,4 +198,5 @@ await daemon.stop();
 - [api/store.md](store.md)
 - [api/errors.md](errors.md)
 - [behaviors/transactions.md](../behaviors/transactions.md)
+- [behaviors/freshness.md](../behaviors/freshness.md)
 - [behaviors/push-sync.md](../behaviors/push-sync.md)

--- a/specs/api/sheet.md
+++ b/specs/api/sheet.md
@@ -12,6 +12,22 @@ A `Sheet<T>` represents one declared sheet in `.gitsheets/<name>.toml`. It owns 
 
 ## Reading
 
+Non-transaction reads resolve against the sheet's **read snapshot** — rebound automatically after each commit by the owning `Repository`, and explicitly via `refresh()`. See [behaviors/freshness.md](../behaviors/freshness.md).
+
+### `sheet.refresh()`
+
+Rebind this sheet's read snapshot to the repository's current `HEAD` tree. Returns `Promise<void>`.
+
+```typescript
+await sheet.refresh();       // pick up out-of-band ref movement
+await sheet.queryAll();      // now reflects the current HEAD tree
+```
+
+- Rebinds **only this sheet** — the "did my row land?" primitive. For every open sheet at once, use `repo.refresh()` / `store.refresh()`.
+- Not needed after this repository's own `repo.transact` — a successful commit auto-refreshes every live sheet.
+- Lazily re-derives records, attachments, config, and index builds from the new tree ([behaviors/freshness.md](../behaviors/freshness.md#what-a-rebind-refreshes)).
+- Throws `TypeError` on a transaction-bound sheet (`tx.sheet(name)`) — those read the transaction's private tree.
+
 ### `sheet.query(filter?, opts?)`
 
 Async iterator yielding records matching `filter`.
@@ -146,7 +162,7 @@ Pairs naturally with `Transaction#finalize`'s no-op detection (see [transaction.
 
 ### `sheet.clone()`
 
-Returns a deep clone of the `Sheet` instance with a cloned data tree. Used to stage a tentative state for diffing / proposing without mutating the original.
+Returns a deep clone of the `Sheet` instance with a cloned data tree. Used to stage a tentative state for diffing / proposing without mutating the original. A clone is a Repository-issued sheet like any other: it participates in the freshness model (auto-refresh on commit, `refresh()`), and is **not** a pinned snapshot — see [behaviors/freshness.md](../behaviors/freshness.md#pinned--historical-reads).
 
 ## Indexing
 
@@ -195,6 +211,15 @@ const avatar = await sheet.getAttachment(record, 'avatar.jpg');
 await sheet.deleteAttachment(record, 'avatar.jpg');     // throws NotFoundError if missing
 await sheet.deleteAttachments(record);                  // no-op if record has no attachment dir
 ```
+
+Streaming read without materializing the record:
+
+```typescript
+const stream = await sheet.getAttachmentStream('janedoe', 'avatar.jpg'); // Readable | null
+stream?.pipe(httpResponse);
+```
+
+`getAttachmentStream(recordOrPath, name)` accepts a record object or a rendered record path (like `getAttachment`), returns a Node `Readable` over the attachment's bytes, or `null` when the attachment is absent — resolved through the sheet's read snapshot. See [behaviors/attachments.md](../behaviors/attachments.md#streaming-reads-by-keypath).
 
 Iterator surface:
 
@@ -247,6 +272,7 @@ See [api/errors.md](errors.md). Common: `ValidationError`, `NotFoundError`, `Pat
 - [behaviors/validation.md](../behaviors/validation.md)
 - [behaviors/normalization.md](../behaviors/normalization.md)
 - [behaviors/transactions.md](../behaviors/transactions.md)
+- [behaviors/freshness.md](../behaviors/freshness.md)
 - [behaviors/indexing.md](../behaviors/indexing.md)
 - [behaviors/patch-semantics.md](../behaviors/patch-semantics.md)
 - [behaviors/attachments.md](../behaviors/attachments.md)

--- a/specs/api/store.md
+++ b/specs/api/store.md
@@ -90,6 +90,21 @@ await store.transact({ message: '...' }, async (tx) => {
 
 The transaction's commit message, trailers, author, parent, etc. follow the same options as `repo.transact` (see [api/transaction.md](transaction.md)).
 
+## Freshness
+
+`store.<sheet>` reads follow the standard freshness model ([behaviors/freshness.md](../behaviors/freshness.md)): a successful `store.transact` / `repo.transact` auto-refreshes every sheet, so post-commit reads through `store.<sheet>` reflect the committed state.
+
+### `store.refresh()`
+
+Rebind every sheet to the repository's current `HEAD` tree — delegates to `repo.refresh()` (a Store's sheets are Repository-issued sheets; partial-store freshness is not a meaningful state). Returns `Promise<void>`. Use after out-of-band ref movement.
+
+```typescript
+await store.refresh();
+const fresh = await store.users.queryAll();
+```
+
+Like `transact`, `refresh` is a reserved property name on the `Store` surface — a sheet named `refresh` or `transact` is shadowed by the method and must be reached via `repo.openSheet(name)`.
+
 ## Why `Store` and not just `Repository`?
 
 `Repository.openSheets()` returns `{ [name]: Sheet<unknown> }` — a flat dictionary with no type-level connection between sheet names and shapes. `Store` adds:
@@ -114,3 +129,4 @@ Both APIs are public. Use `Repository` for one-off scripts and dynamic discovery
 - [api/sheet.md](sheet.md)
 - [api/transaction.md](transaction.md)
 - [behaviors/validation.md](../behaviors/validation.md)
+- [behaviors/freshness.md](../behaviors/freshness.md)

--- a/specs/behaviors/attachments.md
+++ b/specs/behaviors/attachments.md
@@ -6,7 +6,8 @@ A record may have any number of **attachments** — binary blobs colocated with 
 
 ## Applies To
 
-- [api/sheet.md](../api/sheet.md) — `getAttachment`, `getAttachments`, `setAttachment`, `setAttachments`, `deleteAttachment`, `deleteAttachments`, `attachments` (iterator)
+- [api/sheet.md](../api/sheet.md) — `getAttachment`, `getAttachments`, `getAttachmentStream`, `setAttachment`, `setAttachments`, `deleteAttachment`, `deleteAttachments`, `attachments` (iterator)
+- [api/repository.md](../api/repository.md) — `readBlobStream`
 - [behaviors/path-templates.md](path-templates.md) — query traversal skips attachment subtrees
 
 ## Storage layout
@@ -93,6 +94,26 @@ await sheet.deleteAttachments(record);
 ```
 
 **No-op** when the record has no attachment directory — idempotent, mirroring the cascade behavior on `Sheet.delete(record)`. The transaction is not marked mutated in the no-op case (so a transaction that does nothing else still completes without a commit).
+
+## Streaming reads by key/path
+
+Two surfaces stream an attachment's bytes **without materializing its record** — for HTTP handlers serving blobs (avatars, uploads) where "load the record, then get the attachment" is pure overhead:
+
+### `sheet.getAttachmentStream(recordOrPath, name)`
+
+```typescript
+const stream = await sheet.getAttachmentStream('janedoe', 'avatar.jpg');
+if (stream === null) reply.code(404);
+else stream.pipe(reply.raw);
+```
+
+Accepts a record object or a rendered record path (like `getAttachment`); returns `Promise<Readable | null>` — `null` when the attachment is absent, mirroring `getAttachment`. Resolves through the sheet's read snapshot ([freshness.md](freshness.md)), so it reflects this repository's commits without re-opening the sheet.
+
+### `repo.readBlobStream(ref, path)`
+
+The repository-level primitive for consumers whose attachment key **is** the tree path (`<sheetRoot>/<recordPath>/<name>`): resolves `<ref>:<path>` at call time — no sheet, no snapshot — and returns `Promise<Readable>`. Throws `RefError` (`ref_not_found`) / `NotFoundError` (`record_not_found`) rather than returning `null`, since the caller named an explicit ref. See [api/repository.md](../api/repository.md#reporeadblobstreamref-path).
+
+Both are backed by a streamed `git cat-file blob` read — bytes are piped, never fully buffered by gitsheets.
 
 ## Iterator API
 

--- a/specs/behaviors/freshness.md
+++ b/specs/behaviors/freshness.md
@@ -1,0 +1,118 @@
+# Behavior: Read Freshness
+
+## Rule
+
+A non-transaction `Sheet` reads through a **read snapshot** — the repository's
+`HEAD` tree hash, captured when the sheet was opened. The snapshot is **rebound
+to the current `HEAD` tree**:
+
+1. **Automatically**, after every transaction on the owning `Repository`
+   instance that produces a commit (explicit `repo.transact` / `store.transact`
+   *and* permissive-mode auto-transactions). This gives **read-your-writes**: a
+   record committed through any surface of a `Repository` is immediately
+   visible to every standing `Sheet` that repository has issued.
+2. **Explicitly**, via `sheet.refresh()`, `store.refresh()`, or
+   `repo.refresh()` — the consumer's tool after **out-of-band ref movement**
+   (another process committed, a `git fetch` + reset, a hot-reload merge).
+
+gitsheets never watches the ref: there is no polling and no automatic detection
+of commits made outside the `Repository` instance. That is deliberate — the
+single-writer model ([push-sync.md](push-sync.md)) makes the owning process the
+source of truth for when the ref can move underneath it.
+
+## Applies To
+
+- [api/sheet.md](../api/sheet.md) — `query`/`queryFirst`/`queryAll`, `count`,
+  `loadBody`, `findByIndex`, `getAttachment(s)`, `attachments()`,
+  `getAttachmentStream`, `diffFrom` (dst side), `readConfig`
+- [api/repository.md](../api/repository.md) — `repo.refresh()`, and the
+  auto-refresh performed by `repo.transact`
+- [api/store.md](../api/store.md) — `store.refresh()`
+- [behaviors/indexing.md](indexing.md) — index invalidation on rebind
+
+## Details
+
+### What a rebind refreshes
+
+Rebinding swaps the sheet's snapshot tree and lazily re-derives everything
+downstream of it:
+
+- **Record reads** — `query`/`queryFirst`/`queryAll`/`count`/`loadBody`
+  resolve against the new tree on their next call.
+- **Attachment reads** — `getAttachment`/`getAttachments`/`attachments()`/
+  `getAttachmentStream` resolve against the new tree.
+- **`diffFrom`** — the dst side of the diff is the new tree.
+- **Sheet config** — the memoized `.gitsheets/<name>.toml` is dropped and
+  re-read lazily from the new tree, so a *committed* config change becomes
+  visible without re-opening the sheet.
+- **Indexes** — every index build is invalidated by the snapshot-hash
+  comparison and lazily rebuilt on its next `findByIndex` (the "out-of-band
+  ref movement" path in [indexing.md](indexing.md#invalidation)). Note the
+  cost: a rebuild is a full body-less scan of the sheet, per index, per
+  rebind that actually changed the tree.
+
+### Rebind semantics
+
+- The snapshot always comes from **`HEAD` at rebind time** — not from the
+  transaction's result tree. A transaction that commits onto a non-`HEAD`
+  branch (`opts.parent: 'feature-x'`) leaves `HEAD`'s tree unchanged, so
+  standing sheets do **not** shift onto the other branch's state.
+- A rebind to a tree hash identical to the current snapshot is a no-op
+  (memoized config and index builds are kept).
+- Rebinding applies to every live `Sheet` the `Repository` instance has
+  issued — via `openSheet`, `openSheets`, `openStore`, or `Sheet.clone()`.
+  Sheets are tracked weakly; holding a `Sheet` does not leak, and dropping one
+  requires no lifecycle call.
+- `repo.refresh()` re-resolves `HEAD^{tree}` once and rebinds every live
+  sheet. `sheet.refresh()` rebinds only that sheet (the "did my row land?"
+  primitive). `store.refresh()` delegates to `repo.refresh()` — a Store's
+  sheets are Repository-issued sheets, and partial-store freshness is not a
+  meaningful state.
+
+### Interaction with transactions
+
+- **Transaction-bound sheets** (`tx.sheet(name)`, `tx.<sheet>` in
+  `store.transact`) always read the transaction's private in-progress tree.
+  They are never rebound; calling `refresh()` on one throws `TypeError`.
+- Reads through standing sheets **while a transaction is open** still see the
+  pre-commit snapshot ([transactions.md](transactions.md#single-writer-model)
+  — reads don't take the mutex). The rebind happens only after the commit
+  succeeds; a discarded transaction rebinds nothing.
+- A no-op transaction (no commit produced) does not rebind — the tree didn't
+  move.
+
+### Iteration stability
+
+A `query()` async iterator captures the snapshot when iteration starts and
+continues against it even if a rebind happens mid-iteration. The rebind
+affects subsequent calls, never an in-flight traversal.
+
+### Pinned / historical reads
+
+There is no API to pin a `Sheet` to an old tree. Point-in-time reads go
+through explicit refs: `sheet.diffFrom(srcRef)` for record-level change
+feeds, `repo.readBlobStream(ref, path)` for raw blob bytes at any ref.
+
+## Principles
+
+**Local:**
+
+- **Read-your-writes beats frozen snapshots.** A standing `Sheet` is a live
+  view of the repository's committed state *as this process advances it* —
+  not an immutable snapshot pinned at open time. When snapshot stability and
+  post-write visibility conflict, gitsheets picks visibility: a consumer that
+  just committed a record must be able to read it back through the handles it
+  already holds. (First production consumers universally worked around the
+  pinned-snapshot behavior rather than relying on it — see
+  [#184](https://github.com/JarvusInnovations/gitsheets/issues/184).) Pinned
+  historical reads go through explicit refs, not through withholding refresh.
+
+## Coordinates with
+
+- [api/repository.md](../api/repository.md)
+- [api/sheet.md](../api/sheet.md)
+- [api/store.md](../api/store.md)
+- [behaviors/transactions.md](transactions.md)
+- [behaviors/indexing.md](indexing.md)
+- [behaviors/push-sync.md](push-sync.md)
+- [GitHub #184](https://github.com/JarvusInnovations/gitsheets/issues/184) — motivating issue

--- a/specs/behaviors/indexing.md
+++ b/specs/behaviors/indexing.md
@@ -78,13 +78,13 @@ Without a pre-mutation read (e.g., a brand-new upsert), there's no old key to re
 
 For updates where the record changed identity-fields (the key from `keyFn` differs from before), the old key is removed and the new key is added in one synchronous step.
 
-### On out-of-band ref movement
+### On read-snapshot rebind (ref movement)
 
-If the sheet's underlying ref moves due to a change made outside this `Sheet` instance — another process committed, the data repo was re-clone, etc. — every index on the sheet is marked dirty.
+If the sheet's read snapshot is rebound — automatically after this repository's own commit, or explicitly via `refresh()` after out-of-band movement (see [freshness.md](freshness.md)) — every index on the sheet is marked dirty.
 
 Next `findByIndex(name, ...)` call:
 
-1. Detects the dirty state (by comparing the current ref's commit hash against the hash captured at last build)
+1. Detects the dirty state (by comparing the current snapshot's tree hash against the hash captured at last build)
 2. Discards the existing index for that name
 3. Re-runs the build pipeline
 4. Serves the lookup

--- a/specs/behaviors/transactions.md
+++ b/specs/behaviors/transactions.md
@@ -20,7 +20,7 @@ One open transaction per `Repository` at a time, serialized by an in-process mut
 | Two concurrent `repo.transact` calls from independent async contexts | Second waits on the mutex; runs after the first commits or releases. |
 | **Nested** `repo.transact` — opening one inside another's handler (same async context) | Throws `TransactionError` (`transaction_in_progress`) immediately; it does not queue. Use `tx.sheet(name)` inside the handler instead. |
 | Concurrent `repo.transact` *and* a permissive-mode `Sheet.upsert` outside a transaction | The permissive `upsert` opens its own transaction, contends for the same mutex. |
-| Same-process concurrent reads | Reads don't take the mutex. They see the *committed* state (pre-transaction tree). |
+| Same-process concurrent reads | Reads don't take the mutex. They see the *committed* state (pre-transaction tree). After a successful commit, standing sheets rebind to the new tree — see [freshness.md](freshness.md). |
 
 Multi-process / multi-host writers are explicitly out of scope. If another process commits to the same ref while a transaction is open, the transaction throws `TransactionError` (`parent_moved`) when it tries to commit. Detection is via comparing the parent ref's commit hash at transaction open vs. at commit.
 


### PR DESCRIPTION
Consumer-hardening from the first production 2.x migration (CodeForPhilly/codeforphilly-ng#150): the read-freshness model plus streaming blob reads.

Closes #184
Closes #235

## What shipped

### #184 — read freshness

Non-transaction `Sheet` reads resolve through a **rebindable read snapshot** (the HEAD tree captured at open). The snapshot rebinds:

- **Automatically after every commit-producing `repo.transact` / `store.transact` / permissive auto-transaction** on the owning `Repository` — *read-your-writes*: a record you just committed is immediately visible through the standing sheets you already hold, no re-open, no `Store.swapPublic()`-style workaround.
- **Explicitly** via `sheet.refresh()` (per-sheet, the "did my row land?" primitive), `repo.refresh()` (every live sheet), and `store.refresh()` (delegates to `repo.refresh()`) — for out-of-band ref movement (external process commit, fetch + reset, hot reload).

**Decision + rationale (auto-refresh):** yes, a successful transact auto-refreshes — that's what consumers expect, and the pinned-at-open behavior was an implementation accident, never a specified snapshot guarantee (`api/repository.md` already said sheets are "bound to this repository's current state"). The tradeoff, spec'd as the **read-your-writes beats frozen snapshots** principle: standing sheets are a live view of the committed state as this process advances it, not immutable snapshots; pinned/historical reads go through explicit refs (`diffFrom(srcRef)`, `readBlobStream(ref, path)`). Rebinding always resolves **HEAD at rebind time** (not the transaction's result tree), so a commit onto a non-HEAD branch doesn't shift HEAD-bound sheets.

Rebinding lazily re-derives everything downstream: records, attachments, the memoized sheet config, and index builds (invalidated via the existing tree-hash comparison; each index lazily rebuilds on its next `findByIndex` — so indexes go *fresh*, not stale-pinned as #184's carve-out offered; the rebuild cost is documented).

Implementation is entirely host-shell: the Rust core is stateless for non-transaction reads (`recordQuery` et al. take `gitDir` + `treeRef` per call; the core `Sheet`/`Store` state machine lives only inside `CoreTransaction`), so no core/napi changes. The `Repository` tracks its issued sheets weakly (`WeakRef` registry, pruned on refresh) — no consumer lifecycle obligation.

### #235 — streaming blob reads by key/path

- `repo.readBlobStream(ref, path): Promise<Readable>` — streams the blob at `<ref>:<path>` **resolved at call time** (never through a cached tree), with typed errors: `RefError(ref_not_found)` for a bad ref, `NotFoundError(record_not_found)` for a missing path or non-blob. Replaces the raw `git cat-file blob HEAD:<key>` reach-around for HTTP attachment serving.
- `sheet.getAttachmentStream(recordOrPath, name): Promise<Readable | null>` — the sheet-scoped sibling; resolves through the read snapshot (so it composes with #184's freshness), `null` when absent (mirrors `getAttachment`).

Honest mechanics, per the spec: both are backed by a streamed `git cat-file blob` subprocess read (the same substrate as the existing attachment-iterator `blob.stream()`), so bytes are piped, never fully buffered by gitsheets.

## Spec sections added (spec-first)

- **`specs/behaviors/freshness.md`** (new) — the whole model: rebind triggers, what a rebind refreshes, rebind semantics, transaction interaction, iteration stability, pinned-read guidance, and the read-your-writes principle.
- `specs/api/repository.md` — `repo.refresh()`, `repo.readBlobStream(ref, path)`, transact auto-refresh note, error table rows.
- `specs/api/sheet.md` — `sheet.refresh()`, `getAttachmentStream`, clone-freshness note.
- `specs/api/store.md` — `store.refresh()` + freshness section.
- `specs/behaviors/attachments.md` — "Streaming reads by key/path".
- `specs/behaviors/indexing.md` / `specs/behaviors/transactions.md` — invalidation/visibility wording aligned to the rebind model.
- Plan: `plans/sheet-freshness-streaming.md` (issues #184, #235).

## Test evidence

- **21 new vitest cases** (`sheet-refresh.test.ts`, `repo-blob-stream.test.ts`): post-transact visibility through standing Sheet/Store handles, permissive-mode auto-transaction refresh, external-commit invisibility until explicit refresh (per-sheet / repo-wide / store), non-HEAD-branch commit non-shift, no-op transaction non-rebind, lazy index rebuild post-commit, committed config-change visibility, tx-bound `refresh()` TypeError, byte-identical binary streaming, call-time ref resolution, typed error cases, `null` on absent attachment, post-commit stream freshness.
- Full package suite: **314 passed** (293 baseline + 21 new), `type-check` clean.
- `cargo test` + napi `node --test` green from a clean worktree of this branch (core untouched — proves no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5fwEknfSxpaGCVEME5D4h
