### PR TITLE
fix(marshal): drop null/undefined-valued keys instead of throwing (1.x parity)

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -216,6 +216,107 @@ Patch release. Two fixes in service of snapshot-importer-style workflows.
 
 - `hologit` bumped from `^0.49.1` to `^0.50.2` to pick up `TreeObject.clearChildren()` (the O(1) primitive backing the new `Sheet#clear()`).
 
+## v1.x → v2.0 (the Rust core)
+
+v2.0 replaces the Node.js engine with the Rust `gitsheets-core` crate: TOML
+parse/serialize, normalization, validation, path templates, record CRUD, and
+the tree/blob/commit substrate all run natively, and the npm package becomes a
+thin marshalling shell over the `@gitsheets/core-napi` addon. The API surface
+is intentionally unchanged — but three behavior changes bite real consumers.
+All three surfaced during the first production 1.4.1 → 2.x upgrade; this
+section is what turns "16 mystery test failures" into "read the section, apply
+3 changes."
+
+### 1. The `hologit` dependency is gone
+
+2.x drops `hologit` entirely (tree/blob/commit ops run on `holo-tree`/gitoxide
+*inside* the core). Anything that reached into it breaks:
+
+- `repo.hologitRepo` no longer exists.
+- `BlobObject` (e.g. `BlobObject.write`) is no longer importable via gitsheets.
+
+The replacement for the common pattern — hashing binary content and attaching
+it to a record — is the built-in blob primitive plus the attachment API:
+
+```typescript
+// 1.x
+import { BlobObject } from 'hologit';
+
+const blob = await BlobObject.write(repo.hologitRepo, buffer);
+await sheet.setAttachments(record, { 'avatar.jpg': blob });
+```
+
+```typescript
+// 2.x
+const blob = await repo.writeBlob(buffer); // Promise<BlobHandle>
+await sheet.setAttachments(record, { 'avatar.jpg': blob });
+```
+
+`repo.writeBlob(buf)` hashes the bytes into the object database and returns a
+`BlobHandle` accepted everywhere a hologit `BlobObject` used to be
+(`setAttachment`, `setAttachments`). `getAttachment`/`getAttachments`/
+`sheet.attachments()` likewise return `BlobHandle`s with `.read()`/`.stream()`.
+
+### 2. `null`/`undefined`-valued fields
+
+TOML has no `null`, so a cleared optional field and a never-set field are the
+same on-disk state: an absent key. 1.x (`@iarna/toml`) enforced this by
+silently dropping null-valued keys at serialize time. **The initial 2.x
+releases instead threw on marshal** (`cannot marshal JS value of type
+Null/Undefined to a TOML value`) — breaking the standard consumer pattern of
+`.nullable().optional()` schemas with `?? null` normalization on write.
+
+**Fixed in this release**: the 1.x drop semantics are restored and now
+specced ([`specs/behaviors/normalization.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/normalization.md#null--undefined-handling)).
+A `null`/`undefined`-valued key is dropped, recursively (top-level fields,
+nested tables, and objects inside arrays), before validation and
+serialization — byte-identical to 1.x output, in every binding (Node and
+Python). If you shimmed this with a `stripNullish` helper at your write
+boundary, you can delete it.
+
+One deliberate edge-case divergence from 1.x: a `null`/`undefined` **array
+element** is an error naming the index (1.x silently dropped elements —
+`[1, null, 2]` → `[1, 2]` — which shifts sibling indices and silently changes
+data). Remove the element yourself if that's what you mean. A required field
+set to `null` fails JSON-Schema validation as *missing*, same as 1.x.
+
+### 3. Canonical bytes re-baseline (one-time)
+
+The canonical serializer is now the core's `gitsheets-core::canonical` (the
+Rust `toml` crate's formatting over a deep key sort), replacing `@iarna/toml`.
+A record that was already canonical under 1.x may re-serialize to different —
+but *value-identical* — bytes, once ([#196](https://github.com/JarvusInnovations/gitsheets/issues/196)).
+Three reformat classes, all proven data-lossless and idempotent over a
+~29.5k-record corpus ([PR #205](https://github.com/JarvusInnovations/gitsheets/pull/205)):
+
+1. **Integer digit-group underscores drop** — `legacyId = 31_618` →
+   `legacyId = 31618` (the dominant class).
+2. **String requote** — strings containing both `"` and `'` move from escaped
+   single-line form to readable triple-quoted `"""…"""` form.
+3. **Multiline trailing-quote layout** — a multiline string ending in `"`
+   loses `@iarna`'s line-continuation dance (same value, fewer lines).
+
+Until you re-baseline, the first 2.x write of a record whose 1.x bytes fall in
+one of these classes shows a spurious-looking (but value-neutral) diff. The
+recommended migration is a **one-time re-serialize commit** over each existing
+repo, which is idempotent (a second run produces zero diff — that's the
+adoption check):
+
+```bash
+# Re-normalize every *.toml record under a directory, in place.
+cargo run -p gitsheets-core --example normalize_tree -- path/to/records
+
+git add path/to/records
+git commit -m "chore: re-baseline records to the Rust canonical form"
+
+# Verify idempotence — a second pass must report 0 files re-normalized:
+cargo run -p gitsheets-core --example normalize_tree -- path/to/records
+```
+
+(Or use `git sheet normalize <sheet>` per sheet from the CLI.) See the
+[canonical-form re-baseline notes](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/normalization.md#canonical-form-re-baseline-the-rust-serializer)
+for the full contract.
+
 ## Going forward
 
 Once migrated, the recipes are the fastest path to common patterns:

--- a/packages/gitsheets/src/sheet-nullish.test.ts
+++ b/packages/gitsheets/src/sheet-nullish.test.ts
@@ -1,0 +1,180 @@
+// End-to-end tests for null/undefined handling on write (#232) — the
+// specs/behaviors/normalization.md "Null / undefined handling" contract at the
+// package layer.
+//
+// The real-world consumer shape this protects: optional fields modeled as
+// `.nullable().optional()` (Zod/Valibot/…) with a `?? null` normalization at
+// the write boundary. 1.x (@iarna/toml) silently dropped null-valued keys at
+// serialize time; the Rust-core cutover initially threw on them; the specced
+// behavior is the 1.x drop — an absent optional field IS an absent key.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ValidationError } from './errors.js';
+import { openRepo } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+import { type StandardSchemaV1 } from './validation.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const PEOPLE_CONFIG = `[gitsheet]
+root = 'people'
+path = '\${{ slug }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['slug']
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.middleName]
+type = ['string', 'null']
+
+[gitsheet.schema.properties.bio]
+type = ['string', 'null']
+`;
+
+async function seededRepo(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'people.toml'), PEOPLE_CONFIG);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', 'add people sheet');
+  return fixture;
+}
+
+/**
+ * A Standard Schema validator mimicking the `.nullable().optional()` +
+ * `?? null` pattern: every cleared optional field is normalized to an explicit
+ * `null` on the validated output — exactly what Zod's
+ * `z.string().nullable().optional().transform((v) => v ?? null)` (or a manual
+ * write-boundary `?? null`) produces.
+ */
+const nullNormalizingValidator: StandardSchemaV1<unknown, Record<string, unknown>> = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate(value: unknown) {
+      const v = value as Record<string, unknown>;
+      return {
+        value: {
+          ...v,
+          middleName: v['middleName'] ?? null,
+          bio: v['bio'] ?? null,
+        },
+      };
+    },
+  },
+};
+
+describe('null/undefined-valued keys on write (#232)', () => {
+  it('a Standard Schema validator emitting nulls for cleared optionals writes cleanly, with no trace in the bytes', async () => {
+    const fixture = await seededRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    // 2.x initially threw here ("cannot marshal JS value of type Null").
+    const sheet = await repo.openSheet('people', { validator: nullNormalizingValidator });
+    await sheet.upsert({ slug: 'jane', middleName: undefined });
+
+    // Read back: the cleared optionals are absent keys, not nulls. (Records
+    // carry non-enumerable-ish symbol metadata; compare string keys.)
+    const fresh = await repo.openSheet('people');
+    const found = await fresh.queryFirst({ slug: 'jane' });
+    expect(found).toMatchObject({ slug: 'jane' });
+    expect(Object.keys(found ?? {})).toEqual(['slug']);
+    expect(found?.['middleName']).toBeUndefined();
+
+    // The on-disk bytes carry no trace — what 1.x @iarna/toml produced.
+    const { stdout: bytes } = await fixture.git('cat-file', 'blob', 'HEAD:people/jane.toml');
+    expect(bytes).toBe('slug = "jane"\n');
+  });
+
+  it('writing the null-cleared record over the stripped record is a byte-level no-op (no new commit)', async () => {
+    const fixture = await seededRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    // First write: the record with the optionals simply never set.
+    const first = await repo.transact({ message: 'stripped' }, async (tx) =>
+      tx.sheet('people').upsert({ slug: 'jane', bio: 'hi' }),
+    );
+    expect(first.commitHash).toMatch(/^[0-9a-f]{40}$/);
+
+    // Second write: logically the same record, but with cleared optionals as
+    // explicit nulls. Byte-identical canonical output ⇒ no-op transaction.
+    const second = await repo.transact({ message: 'null-cleared' }, async (tx) =>
+      tx.sheet('people').upsert({ slug: 'jane', bio: 'hi', middleName: null }),
+    );
+    expect(second.commitHash).toBeNull();
+  });
+
+  it('drops nullish keys recursively: nested tables and objects inside arrays', async () => {
+    const fixture = await seededRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'nested' }, async (tx) =>
+      tx.sheet('people').upsert({
+        slug: 'nested',
+        contact: { email: 'n@x.org', phone: null },
+        roles: [{ title: 'chair', until: null }, { title: 'member' }],
+      }),
+    );
+
+    const sheet = await repo.openSheet('people');
+    const found = await sheet.queryFirst({ slug: 'nested' });
+    expect(found).toMatchObject({
+      slug: 'nested',
+      contact: { email: 'n@x.org' },
+      roles: [{ title: 'chair' }, { title: 'member' }],
+    });
+    expect(Object.keys(found?.['contact'] as object)).toEqual(['email']);
+    expect(Object.keys((found?.['roles'] as object[])[0]!)).toEqual(['title']);
+
+    const { stdout: bytes } = await fixture.git('cat-file', 'blob', 'HEAD:people/nested.toml');
+    expect(bytes).not.toContain('phone');
+    expect(bytes).not.toContain('until');
+  });
+
+  it('a required field set to null fails validation as missing (absent == null)', async () => {
+    const fixture = await seededRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    try {
+      await repo.transact({ message: 'bad' }, async (tx) =>
+        tx.sheet('people').upsert({ slug: null, bio: 'x' } as never),
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const ve = err as ValidationError;
+      // The null-valued required key was dropped before validation, so the
+      // failure is "missing required property" — not a type error on null.
+      expect(ve.issues.some((i) => /required/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('a null array ELEMENT is rejected with the index named (not silently dropped)', async () => {
+    const fixture = await seededRepo();
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    const headBefore = await repo.resolveRef('HEAD');
+    await expect(
+      repo.transact({ message: 'bad' }, async (tx) =>
+        tx.sheet('people').upsert({ slug: 'holes', tags: ['a', null, 'c'] }),
+      ),
+    ).rejects.toThrow(/array element \(index 1\)/);
+
+    // No tree mutation happened.
+    expect(await repo.resolveRef('HEAD')).toBe(headBefore);
+  });
+});

--- a/plans/marshal-drop-nullish.md
+++ b/plans/marshal-drop-nullish.md
@@ -1,0 +1,132 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/behaviors/normalization.md
+  - specs/rust-core.md
+issues: [232, 233]
+---
+
+# Plan: drop null/undefined-valued keys at the marshal boundary
+
+## Scope
+
+Restore the 1.x `@iarna/toml` semantics the Rust-core cutover silently broke
+([#232](https://github.com/JarvusInnovations/gitsheets/issues/232)): a
+`null`/`undefined`-valued key in a record must be **dropped** on write, not
+rejected with `cannot marshal JS value of type Null/Undefined`. The drop is
+recursive (nested tables, and tables inside arrays) and applies identically in
+every binding. A null **array element** stays an error — but with a targeted,
+actionable message (see Approach for the rationale).
+
+Riding along ([#233](https://github.com/JarvusInnovations/gitsheets/issues/233)):
+the missing 1.x → 2.x breaking-changes section in `docs/migration-guide.md`
+(hologit drop, null handling, canonical byte re-baseline).
+
+Out of scope:
+
+- Merge-patch marshalling (`applyMergePatch` / `MergePatch`), where `null` is
+  the RFC 7396 delete sentinel — a separate, already-correct code path.
+- Any `Value::Null` variant in the core value type. The core stays
+  TOML-faithful; nulls are a host-language concept resolved at the marshal
+  boundary (see Approach).
+- Null-aware query-filter semantics (e.g. `{ field: null }` matching absent
+  fields) — a filter leaf of `null` keeps erroring, as it does today.
+
+## Implements
+
+- `specs/behaviors/normalization.md` — the (already-specced, newly-explicit)
+  rule that null values are omitted from output: "Null / undefined handling"
+  subsection under TOML serialization details.
+- `specs/rust-core.md` — the new "Nulls" type-fidelity rule for the marshal
+  boundary every binding implements.
+
+## Approach
+
+1. **Spec first**: make the existing one-liner ("Null values are *omitted* from
+   the output") explicit and complete in `specs/behaviors/normalization.md` —
+   recursive drop for table keys, error for array elements, the absent-key ==
+   cleared-optional equivalence — and add the matching "Nulls" bullet to
+   `specs/rust-core.md`'s type-fidelity rules.
+2. **Where the fix lives**: the host→core marshal in the two Rust binding
+   crates — `JsValue::from_napi_value` in `rust/gitsheets-napi/src/lib.rs` and
+   `py_to_value` in `rust/gitsheets-py/src/lib.rs`. The core `Value` enum is
+   deliberately TOML-faithful (no null variant), so the core never sees a null
+   by construction; the marshal recursion is the single place each binding can
+   see one. The rule itself is core-owned: `gitsheets-core` exports the shared
+   error-message helper so the rejection reads identically from Node and
+   Python, and the spec is the cross-binding contract, enforced by the existing
+   cross-binding byte-parity CI job.
+3. **Table entries**: a `null`/`undefined` (JS) or `None` (Python) property
+   value drops the key, recursively — the record serializes as if the key were
+   never set, matching 1.x bytes exactly.
+4. **Array elements**: reject with a dedicated error naming the index. TOML
+   arrays cannot contain nulls, and silently *dropping an element* — unlike
+   dropping a key — shifts sibling indices and changes data. This is a
+   **deliberate divergence from 1.x**: `@iarna/toml@2.2.5` silently dropped
+   null array elements (`[1, null, 2]` → `[1, 2]`), which is exactly the kind
+   of silent data mutation the bytes-authority refuses. Spec + migration guide
+   call the divergence out explicitly.
+5. **Top-level / scalar-position nulls** (a whole record, a filter leaf): keep
+   erroring, with the clarified message.
+6. **Tests at every layer**: core unit test for the shared message helper; napi
+   boundary tests (roundtrip drop, byte-equality with the pre-stripped record,
+   array-element error, upsert-through-`record_write`); Python mirror tests
+   plus a cross-binding byte-parity case with nullish keys; package-layer
+   vitest covering the real consumer pattern (Standard Schema validator
+   normalizing cleared optionals to `null` → upsert succeeds → serialized
+   record has no such keys).
+7. **Migration guide (#233)**: new "v1.x → v2.0 (Rust core)" section — hologit
+   dependency drop (`BlobObject.write`/`hologitRepo` → `repo.writeBlob` +
+   `setAttachments` before/after), null handling (initially threw, fixed in
+   this release; array-element edge case), canonical byte re-baseline per #196
+   with the one-time re-serialize commit recipe.
+
+## Validation
+
+- [ ] `cargo test` green across the workspace (core + bindings build, clippy
+  `-D warnings` clean)
+- [ ] napi suite (`npm test` in `rust/gitsheets-napi`) green, including new
+  cases: null/undefined table keys dropped recursively (nested tables, tables
+  inside arrays), serialized bytes identical to the pre-stripped record, null
+  array element rejected with an error naming the index, top-level null still
+  rejected
+- [ ] Python suite (`pytest` in `rust/gitsheets-py`) green, including the
+  mirrored `None` cases and a cross-binding byte-parity case for a record
+  with nullish keys
+- [ ] Package vitest suite (`npm test`) green, including the end-to-end
+  consumer pattern: `.nullable().optional()`-style Standard Schema validator
+  emitting `null` for cleared optionals → `upsert` succeeds → read-back has no
+  such keys → on-disk TOML bytes contain no trace of them
+- [ ] `docs/migration-guide.md` gains the 1.x → 2.x section enumerating the
+  three breaks from #233 with before/after for each
+
+## Risks / unknowns
+
+- **Blanket drop in the generic record marshal** also affects `roundtrip`,
+  `serializeRecords`, comparator args, `createPatch` src/dst, and
+  `recordQueryCandidates` partial records. This is intended: all of those
+  surfaces were plain JS in 1.x where a null-valued key was either dropped at
+  serialize time or behaved as absent. Filter leaves are unaffected (filters
+  recurse host-side and only marshal scalar/array leaves).
+- **Merge-patch adjacency** — the null-drop must not leak into
+  `MergePatch` marshalling where null means delete. Covered by existing
+  `apply_merge_patch` tests in both bindings.
+
+## Notes
+
+- 1.x array-element behavior verified against `@iarna/toml@2.2.5`:
+  `stringify({ a: [1, null, 2] })` silently emits `a = [ 1, 2 ]` — a silent
+  element drop that shifts indices. 2.x deliberately rejects instead; only the
+  key-drop is restored as 1.x-compatible.
+- JS sparse-array holes (`[1, , 2]`) read back as `undefined` and hit the same
+  array-element rejection — deliberate, since dropping them would also shift
+  indices.
+- The shared rejection-message helpers live in `gitsheets-core::value`
+  (`null_array_element_msg` / `null_scalar_msg`) so both bindings and any
+  future one emit identical diagnostics; the drop recursion itself is
+  ~6 lines per binding inside each marshal.
+
+## Follow-ups
+
+None.

--- a/plans/marshal-drop-nullish.md
+++ b/plans/marshal-drop-nullish.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/behaviors/normalization.md
   - specs/rust-core.md
 issues: [232, 233]
+pr: 241
 ---
 
 # Plan: drop null/undefined-valued keys at the marshal boundary
@@ -84,21 +85,21 @@ Out of scope:
 
 ## Validation
 
-- [ ] `cargo test` green across the workspace (core + bindings build, clippy
+- [x] `cargo test` green across the workspace (core + bindings build, clippy
   `-D warnings` clean)
-- [ ] napi suite (`npm test` in `rust/gitsheets-napi`) green, including new
+- [x] napi suite (`npm test` in `rust/gitsheets-napi`) green, including new
   cases: null/undefined table keys dropped recursively (nested tables, tables
   inside arrays), serialized bytes identical to the pre-stripped record, null
   array element rejected with an error naming the index, top-level null still
   rejected
-- [ ] Python suite (`pytest` in `rust/gitsheets-py`) green, including the
+- [x] Python suite (`pytest` in `rust/gitsheets-py`) green, including the
   mirrored `None` cases and a cross-binding byte-parity case for a record
   with nullish keys
-- [ ] Package vitest suite (`npm test`) green, including the end-to-end
+- [x] Package vitest suite (`npm test`) green, including the end-to-end
   consumer pattern: `.nullable().optional()`-style Standard Schema validator
   emitting `null` for cleared optionals → `upsert` succeeds → read-back has no
   such keys → on-disk TOML bytes contain no trace of them
-- [ ] `docs/migration-guide.md` gains the 1.x → 2.x section enumerating the
+- [x] `docs/migration-guide.md` gains the 1.x → 2.x section enumerating the
   three breaks from #233 with before/after for each
 
 ## Risks / unknowns
@@ -126,6 +127,14 @@ Out of scope:
   (`null_array_element_msg` / `null_scalar_msg`) so both bindings and any
   future one emit identical diagnostics; the drop recursion itself is
   ~6 lines per binding inside each marshal.
+- Considered and rejected a `Value::Null` core variant: it would break the
+  value type's "mirrors TOML's type set exactly" invariant and force a Null
+  arm on every exhaustive match across ~12 core modules, for no gain — the
+  marshal recursion is the only place a host null is visible, and the
+  cross-binding byte-parity suite pins the contract.
+- Verified totals at closeout: core 169, clippy `-D warnings` clean, napi 108,
+  pytest 31 (incl. the new `nullish` cross-binding parity fixture), vitest 298
+  (gitsheets) + 118 (gitsheets-axi), type-check clean.
 
 ## Follow-ups
 

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -47,7 +47,7 @@ pub use record::{
 };
 pub use sheet::{Sheet, StageOutcome, UpsertCandidate, WillChange};
 pub use transaction::{Author, Transaction, TransactionOptions, TransactionResult};
-pub use value::{Datetime, DatetimeKind, Value};
+pub use value::{null_array_element_msg, null_value_msg, Datetime, DatetimeKind, Value};
 
 /// Identity over a batch of records — the minimal exercise of the value type
 /// across a bulk boundary. Bindings call this to prove a whole array of records

--- a/rust/gitsheets-core/src/value.rs
+++ b/rust/gitsheets-core/src/value.rs
@@ -51,6 +51,43 @@ impl Value {
     }
 }
 
+// ── marshal-boundary null diagnostics ────────────────────────────────────────
+//
+// TOML has no `null`, so a host-language null (JS `null`/`undefined`, Python
+// `None`) never crosses the FFI — each binding resolves it during its
+// host→core marshal, per the contract in
+// `specs/behaviors/normalization.md` § "Null / undefined handling":
+//
+// 1. a null-valued **table key** is dropped, recursively (absent key ==
+//    cleared optional field — the 1.x `@iarna/toml` semantics);
+// 2. a null **array element** is an error (dropping an element would silently
+//    shift the remaining elements — a data mutation, not an omission);
+// 3. a null in any other value position (a whole record, a scalar) is an
+//    error.
+//
+// The drop/reject *recursion* necessarily lives in each binding (only the
+// binding can see host values), but the messages are minted here so the
+// contract's diagnostics read identically from every host language.
+
+/// The rejection message for rule 2 — a null array element. `null_name` is the
+/// host language's spelling ("null/undefined", "None").
+pub fn null_array_element_msg(null_name: &str, index: usize) -> String {
+    format!(
+        "cannot marshal {null_name} as an array element (index {index}): TOML arrays cannot \
+         contain nulls, and dropping the element would silently shift the rest of the array — \
+         remove the element instead (null-valued keys are dropped; array elements are not)"
+    )
+}
+
+/// The rejection message for rule 3 — a null where a value itself is required
+/// (a whole record, a scalar position). `null_name` as above.
+pub fn null_value_msg(null_name: &str) -> String {
+    format!(
+        "cannot marshal {null_name} to a TOML value: TOML has no null — null-valued keys are \
+         dropped from records, but a value itself cannot be {null_name}"
+    )
+}
+
 /// The four distinct TOML datetime kinds. They serialize to different bytes, so
 /// the core keeps them distinguishable even though a binding (e.g. Node) may
 /// surface them all as one host type (a JS `Date`).
@@ -156,6 +193,24 @@ mod tests {
                 assert_ne!(a, b, "datetime kinds must render to different bytes");
             }
         }
+    }
+
+    #[test]
+    fn null_diagnostics_name_the_host_null_and_the_index() {
+        let msg = null_array_element_msg("null/undefined", 3);
+        assert!(msg.contains("index 3"), "must name the offending index");
+        assert!(msg.contains("null/undefined"), "must use the host spelling");
+        assert!(
+            msg.contains("remove the element"),
+            "must tell the consumer the actionable fix"
+        );
+
+        let msg = null_value_msg("None");
+        assert!(msg.contains("None"), "must use the host spelling");
+        assert!(
+            msg.contains("null-valued keys are dropped"),
+            "must state the key-drop rule so the boundary reads consistently"
+        );
     }
 
     #[test]

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -13,6 +13,10 @@
 //!   them as JS `Date` (matching `@iarna` v1.x), with the precise kind retained
 //!   core-side. A `Date` round-trips to a `Date`.
 //! - **Tables ↔ plain objects, arrays ↔ arrays, strings/bools** — obvious.
+//! - **Nulls** — a `null`/`undefined`-valued key is dropped (recursively; the
+//!   1.x `@iarna` semantics), a `null`/`undefined` array element or value
+//!   itself is rejected. See `specs/behaviors/normalization.md`
+//!   ("Null / undefined handling").
 //!
 //! Errors cross as **structured, matchable** JS errors (a `code`/`status`/class
 //! discriminant, plus `issues`/`conflictingPaths` payloads), never an opaque
@@ -97,8 +101,29 @@ impl FromNapiValue for JsValue {
             ValueType::String => Value::String(String::from_napi_value(env, napi_val)?),
             ValueType::Object => {
                 if unknown.is_array()? {
-                    let items = Vec::<JsValue>::from_napi_value(env, napi_val)?;
-                    Value::Array(items.into_iter().map(|j| j.0).collect())
+                    let obj = JsObject::from_napi_value(env, napi_val)?;
+                    let len = obj.get_array_length()?;
+                    let mut items = Vec::with_capacity(len as usize);
+                    for i in 0..len {
+                        let el: JsUnknown = obj.get_element(i)?;
+                        // A null/undefined *element* is rejected — dropping it
+                        // (as @iarna v1.x silently did) would shift the rest of
+                        // the array. specs/behaviors/normalization.md, rule 2.
+                        if matches!(
+                            el.get_type()?,
+                            ValueType::Null | ValueType::Undefined
+                        ) {
+                            return Err(Error::new(
+                                Status::InvalidArg,
+                                gitsheets_core::null_array_element_msg(
+                                    "null/undefined",
+                                    i as usize,
+                                ),
+                            ));
+                        }
+                        items.push(JsValue::from_napi_value(env, el.raw())?.0);
+                    }
+                    Value::Array(items)
                 } else if unknown.is_date()? {
                     let date = JsDate::from_napi_value(env, napi_val)?;
                     let ms = date.value_of()?;
@@ -112,6 +137,16 @@ impl FromNapiValue for JsValue {
                         let key_js: JsString = names.get_element(i)?;
                         let key = key_js.into_utf8()?.as_str()?.to_owned();
                         let child: JsUnknown = obj.get_named_property(&key)?;
+                        // A null/undefined-valued *key* is dropped, recursively
+                        // — TOML has no null, so a cleared optional field IS an
+                        // absent key (the 1.x @iarna drop semantics).
+                        // specs/behaviors/normalization.md, rule 1.
+                        if matches!(
+                            child.get_type()?,
+                            ValueType::Null | ValueType::Undefined
+                        ) {
+                            continue;
+                        }
                         let child = JsValue::from_napi_value(env, child.raw())?;
                         map.insert(key, child.0);
                     }
@@ -119,9 +154,17 @@ impl FromNapiValue for JsValue {
                 }
             }
             other => {
+                // A null/undefined *value itself* (a whole record, a scalar
+                // position) — specs/behaviors/normalization.md, rule 3.
+                if matches!(other, ValueType::Null | ValueType::Undefined) {
+                    return Err(Error::new(
+                        Status::InvalidArg,
+                        gitsheets_core::null_value_msg("null/undefined"),
+                    ));
+                }
                 return Err(Error::new(
                     Status::InvalidArg,
-                    format!("cannot marshal JS value of type {other:?} to a TOML value (null/undefined have no TOML representation)"),
+                    format!("cannot marshal JS value of type {other:?} to a TOML value"),
                 ));
             }
         };

--- a/rust/gitsheets-napi/test/canonical.mjs
+++ b/rust/gitsheets-napi/test/canonical.mjs
@@ -80,3 +80,29 @@ test('a malformed document throws a typed ConfigError', () => {
     },
   );
 });
+
+test('nullish keys serialize byte-identically to the record without them', () => {
+  // The consumer pattern from #232: `.nullable().optional()` schemas with
+  // `?? null` normalization on write. A cleared optional field must produce
+  // the SAME bytes as never setting it — the 1.x @iarna drop semantics.
+  const [withNulls] = serializeRecords([
+    {
+      slug: 'jane',
+      middleName: null,
+      bio: undefined,
+      contact: { email: 'jane@x.org', phone: null },
+      roles: [{ title: 'chair', until: null }],
+    },
+  ]);
+  const [stripped] = serializeRecords([
+    {
+      slug: 'jane',
+      contact: { email: 'jane@x.org' },
+      roles: [{ title: 'chair' }],
+    },
+  ]);
+  assert.equal(withNulls, stripped, 'byte-identical to the pre-stripped record');
+  assert.ok(!withNulls.includes('middleName'), 'no trace of the cleared field');
+  assert.ok(!withNulls.includes('phone'));
+  assert.ok(!withNulls.includes('until'));
+});

--- a/rust/gitsheets-napi/test/roundtrip.mjs
+++ b/rust/gitsheets-napi/test/roundtrip.mjs
@@ -119,3 +119,52 @@ test('a top-level array of scalars round-trips', () => {
   const out = roundtrip([[1, 'two', true]]);
   assert.deepEqual(out[0], [1, 'two', true]);
 });
+
+// ── null / undefined handling (specs/behaviors/normalization.md) ─────────────
+//
+// TOML has no null: a null/undefined-valued KEY is dropped (recursively — the
+// 1.x @iarna semantics restored by #232), a null/undefined array ELEMENT or a
+// null/undefined value itself is rejected.
+
+test('null- and undefined-valued keys are dropped from a record', () => {
+  const out = trip({ keep: 'v', gone: null, alsoGone: undefined });
+  assert.deepEqual(out, { keep: 'v' });
+  assert.equal(out.gone, undefined, 'dropped key reads back as undefined');
+});
+
+test('the key drop is recursive: nested tables and objects inside arrays', () => {
+  const out = trip({
+    nested: { x: null, y: 2, deeper: { z: undefined, k: 'v' } },
+    arr: [{ a: null, b: 1 }, { c: 2 }],
+  });
+  assert.deepEqual(out, {
+    nested: { y: 2, deeper: { k: 'v' } },
+    arr: [{ b: 1 }, { c: 2 }],
+  });
+});
+
+test('a record of ONLY nullish keys becomes an empty table, not an error', () => {
+  const out = trip({ a: null, b: undefined });
+  assert.deepEqual(out, {});
+});
+
+test('a null array element is rejected with the index named', () => {
+  assert.throws(
+    () => roundtrip([{ tags: ['a', null, 'c'] }]),
+    (err) => {
+      assert.match(err.message, /array element \(index 1\)/);
+      assert.match(err.message, /remove the element/);
+      return true;
+    },
+  );
+});
+
+test('an undefined array element (and a sparse hole) is rejected the same way', () => {
+  assert.throws(() => roundtrip([{ tags: ['a', undefined] }]), /array element \(index 1\)/);
+  // eslint-disable-next-line no-sparse-arrays
+  assert.throws(() => roundtrip([{ tags: [1, , 3] }]), /array element \(index 1\)/);
+});
+
+test('a null record itself is still rejected', () => {
+  assert.throws(() => roundtrip([null]), /cannot marshal null\/undefined to a TOML value/);
+});

--- a/rust/gitsheets-py/src/lib.rs
+++ b/rust/gitsheets-py/src/lib.rs
@@ -17,6 +17,9 @@
 //!   them as an aware UTC `datetime.datetime`, mirroring the Node `Date` mapping
 //!   (an absolute instant at UTC), with the precise kind retained core-side.
 //! - **Tables ↔ `dict`, arrays ↔ `list`, strings/bools** — obvious.
+//! - **`None`** — a `None`-valued key is dropped (recursively; the 1.x
+//!   `@iarna` semantics), a `None` array element or value itself is rejected.
+//!   See `specs/behaviors/normalization.md` ("Null / undefined handling").
 //!
 //! Errors cross as typed Python exceptions (a `GitsheetsError` hierarchy mirroring
 //! the Node `binding.cjs` classes), each carrying `code`/`status`/
@@ -145,6 +148,12 @@ fn py_to_value(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
     if let Ok(d) = obj.cast::<PyDict>() {
         let mut map = IndexMap::new();
         for (k, v) in d.iter() {
+            // A None-valued *key* is dropped, recursively — TOML has no null,
+            // so a cleared optional field IS an absent key (the 1.x @iarna
+            // drop semantics). specs/behaviors/normalization.md, rule 1.
+            if v.is_none() {
+                continue;
+            }
             let key: String = k
                 .extract()
                 .map_err(|_| PyTypeError::new_err("table (dict) keys must be strings"))?;
@@ -154,21 +163,40 @@ fn py_to_value(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
     }
     if let Ok(l) = obj.cast::<PyList>() {
         let mut items = Vec::with_capacity(l.len());
-        for item in l.iter() {
+        for (i, item) in l.iter().enumerate() {
+            // A None *element* is rejected — dropping it would shift the rest
+            // of the array. specs/behaviors/normalization.md, rule 2.
+            if item.is_none() {
+                return Err(PyValueError::new_err(
+                    gitsheets_core::null_array_element_msg("None", i),
+                ));
+            }
             items.push(py_to_value(&item)?);
         }
         return Ok(Value::Array(items));
     }
     if let Ok(t) = obj.cast::<PyTuple>() {
         let mut items = Vec::with_capacity(t.len());
-        for item in t.iter() {
+        for (i, item) in t.iter().enumerate() {
+            if item.is_none() {
+                return Err(PyValueError::new_err(
+                    gitsheets_core::null_array_element_msg("None", i),
+                ));
+            }
             items.push(py_to_value(&item)?);
         }
         return Ok(Value::Array(items));
     }
+    // A None *value itself* (a whole record, a scalar position) —
+    // specs/behaviors/normalization.md, rule 3.
+    if obj.is_none() {
+        return Err(PyValueError::new_err(gitsheets_core::null_value_msg(
+            "None",
+        )));
+    }
     let type_name = obj.get_type().name()?.to_string();
     Err(PyTypeError::new_err(format!(
-        "cannot marshal Python value of type {type_name} to a TOML value (None has no TOML representation)"
+        "cannot marshal Python value of type {type_name} to a TOML value"
     )))
 }
 

--- a/rust/gitsheets-py/tests/_node_writer.mjs
+++ b/rust/gitsheets-py/tests/_node_writer.mjs
@@ -29,6 +29,18 @@ const FIXTURES = {
     ratio: 1.5, // → core Float
     when: new Date(Date.UTC(2026, 5, 26, 12, 0, 0)),
   },
+  // Nullish keys (cleared optionals) are DROPPED at the marshal boundary in
+  // every binding — the record serializes as if the keys were never set
+  // (specs/behaviors/normalization.md "Null / undefined handling", #232). The
+  // Python side mirrors this with None values (and simply never sets the
+  // `undefined` one); both must land on the same bytes.
+  nullish: {
+    slug: 'jane',
+    middleName: null,
+    bio: undefined,
+    contact: { email: 'jane@x.org', phone: null },
+    roles: [{ title: 'chair', until: null }],
+  },
 };
 
 function out(obj) {

--- a/rust/gitsheets-py/tests/test_cross_binding.py
+++ b/rust/gitsheets-py/tests/test_cross_binding.py
@@ -67,10 +67,19 @@ PY_FIXTURES = {
         "ratio": 1.5,
         "when": dt.datetime(2026, 6, 26, 12, 0, 0, tzinfo=dt.timezone.utc),
     },
+    # Nullish keys are dropped at the marshal boundary in every binding (the
+    # 1.x drop semantics, #232). The JS side also carries `bio: undefined`,
+    # which Python expresses by never setting the key — same bytes either way.
+    "nullish": {
+        "slug": "jane",
+        "middleName": None,
+        "contact": {"email": "jane@x.org", "phone": None},
+        "roles": [{"title": "chair", "until": None}],
+    },
 }
 
 
-@pytest.mark.parametrize("fixture", ["basic", "typed"])
+@pytest.mark.parametrize("fixture", ["basic", "typed", "nullish"])
 def test_tree_and_blob_bytes_identical_across_bindings(fixture):
     """record_write from Python and Node yields identical tree + blob hashes."""
     py_dir = tempfile.mkdtemp(prefix="gs-py-")

--- a/rust/gitsheets-py/tests/test_smoke.py
+++ b/rust/gitsheets-py/tests/test_smoke.py
@@ -113,6 +113,46 @@ def test_naive_datetime_is_treated_as_utc():
     assert "when = 2026-06-26T12:00:00Z\n" in text
 
 
+# ── None handling at the marshal boundary ─────────────────────────────────────
+# specs/behaviors/normalization.md "Null / undefined handling": None-valued
+# keys are dropped recursively (the 1.x drop semantics, #232); a None array
+# element or a None value itself is an error.
+
+
+def test_none_valued_keys_are_dropped_recursively():
+    [out] = gitsheets.roundtrip(
+        [
+            {
+                "keep": "v",
+                "gone": None,
+                "nested": {"x": None, "y": 2},
+                "arr": [{"a": None, "b": 1}],
+            }
+        ]
+    )
+    assert out == {"keep": "v", "nested": {"y": 2}, "arr": [{"b": 1}]}
+
+
+def test_none_keys_serialize_byte_identically_to_the_stripped_record():
+    [with_nones] = gitsheets.serialize_records(
+        [{"slug": "jane", "middleName": None, "contact": {"email": "j@x.org", "phone": None}}]
+    )
+    [stripped] = gitsheets.serialize_records([{"slug": "jane", "contact": {"email": "j@x.org"}}])
+    assert with_nones == stripped
+    assert "middleName" not in with_nones
+    assert "phone" not in with_nones
+
+
+def test_none_array_element_raises_with_the_index_named():
+    with pytest.raises(ValueError, match=r"array element \(index 1\)"):
+        gitsheets.roundtrip([{"tags": ["a", None, "c"]}])
+
+
+def test_none_record_itself_raises():
+    with pytest.raises(ValueError, match="cannot marshal None to a TOML value"):
+        gitsheets.roundtrip([None])
+
+
 # ── record CRUD over holo-tree ──────────────────────────────────────────────────
 
 

--- a/specs/behaviors/normalization.md
+++ b/specs/behaviors/normalization.md
@@ -103,8 +103,45 @@ Sorts an array of strings using locale-aware comparison (`localeCompare` with `s
 - The **canonical serializer** is the Rust core's `gitsheets-core::canonical::serialize` — the [`toml` crate](https://docs.rs/toml)'s default formatting applied to a deep-key-sorted value. It defines the canonical bytes: a value is lowered to `toml::Value` (whose `Table` is a `BTreeMap`, so the deep key sort happens structurally) and emitted with the crate's default rendering (triple-quoted multiline strings, literal-quoted strings where possible). Parsing is the same crate's parser. See [architecture.md](../architecture.md) and [rust-core.md](../rust-core.md#canonical-form-rebaseline).
 - Dates, datetimes, and date-times round-trip by native TOML datetime type — all four kinds (offset date-time, local date-time, local date, local time) parse to the core `Datetime` and serialize back to the matching TOML type byte-faithfully.
 - Multi-line string formatting follows the `toml` crate's defaults — strings with newlines emit as triple-quoted (`"""…"""`); the library imposes no length threshold of its own.
-- Null values are *omitted* from the output. TOML can't represent `null`; absent fields read back as `undefined` and are treated as null by validation.
+- Null values are *omitted* from the output — see [Null / undefined handling](#null--undefined-handling) below for the full rule.
 - Empty arrays and empty objects are preserved (they have semantic meaning distinct from absent).
+
+### Null / undefined handling
+
+TOML has no `null`. A cleared optional field and an absent key are the **same
+state** — there is exactly one on-disk representation for "this field has no
+value", and that is the key not existing. The rules, applied at the host-value
+marshal boundary in **every** binding (JS `null`/`undefined`, Python `None`),
+before the record reaches validation or serialization:
+
+1. **Table keys — dropped, recursively.** A key whose value is null/undefined
+   is dropped as if it were never set. This applies at every depth: top-level
+   fields, keys inside nested tables, and keys inside objects that live inside
+   arrays. Consequently the standard consumer pattern — `.nullable().optional()`
+   schemas with `?? null` normalization on write — serializes identically to
+   never setting the field, and a record round-trips as: write `{ bio: null }`,
+   read back `{}` (the field is `undefined`).
+2. **Array elements — rejected.** A null/undefined **element** of an array is
+   an error (a typed marshal error naming the element index). TOML arrays
+   cannot contain nulls, and silently dropping an element — unlike dropping a
+   key — shifts sibling indices and changes data. Consumers must remove the
+   element host-side if that is what they mean. *(Deliberate divergence from
+   1.x: `@iarna/toml` silently dropped null array elements. That was a silent
+   data mutation, not a semantics-preserving omission, and is not carried
+   forward.)* A JS sparse-array hole (`[1, , 2]`) reads as `undefined` and is
+   rejected the same way.
+3. **A null where a value itself is required** — a whole record, a scalar in
+   any other value position — is an error, as before.
+
+Because keys are dropped *before* validation, a required field set to `null`
+fails JSON-Schema validation as **missing** (exactly as if it were never set),
+and `null` for an optional field validates as absent. This preserves the
+equivalence: absent key == cleared optional field.
+
+These rules are part of the cross-binding bytes-authority contract: dropping
+the same keys in every binding is what keeps a record with cleared optionals
+byte-identical whether written from Node or Python (and byte-identical to what
+1.x `@iarna/toml` produced, which dropped null keys at serialize time).
 
 > **Substrate note.** The canonical form above is now in effect on the Node binding: TOML serialization (and the whole tree/commit substrate) runs through `gitsheets-core`, and the `@iarna/toml` / `smol-toml` dependencies are dropped (`node-binding-thin`). Existing repos re-normalize once via `git sheet normalize` per the [Canonical-form re-baseline](#canonical-form-re-baseline-the-rust-serializer).
 

--- a/specs/rust-core.md
+++ b/specs/rust-core.md
@@ -104,6 +104,17 @@ kind for faithful re-serialization.
   re-serialization.
 - **Strings, booleans, arrays, tables** map to their obvious idiomatic
   counterparts (table ↔ plain object / dict).
+- **Nulls — no core representation; resolved at the marshal boundary.** The
+  core value type is TOML-faithful and TOML has no `null`, so a host null
+  (JS `null`/`undefined`, Python `None`) never crosses the FFI. Each binding's
+  host→core marshal applies the same rule, specced in
+  [behaviors/normalization.md](behaviors/normalization.md#null--undefined-handling):
+  a null-valued **table key** is dropped (recursively — nested tables, and
+  tables inside arrays), restoring the 1.x `@iarna/toml` drop semantics; a
+  null **array element** is a typed marshal error naming the index (dropping
+  an element would silently shift data); a null in any other value position is
+  an error. The shared rejection messages come from `gitsheets-core` so
+  diagnostics read identically across bindings.
 
 ## Embedded code execution
 


### PR DESCRIPTION
## The regression (#232)

gitsheets 2.x (Rust core) **threw** when marshalling a `null`/`undefined`-valued field to TOML (`cannot marshal JS value of type Null/Undefined to a TOML value`). 1.x (`@iarna/toml`) silently dropped such keys at serialize time. That broke the standard consumer pattern — `.nullable().optional()` schemas with `?? null` normalization on write — 16 test failures in the first production 2.x migration, all one root cause.

## The fix + semantics

TOML has no `null`: a cleared optional field and a never-set field are the same on-disk state — an absent key. Specced in `specs/behaviors/normalization.md` ("Null / undefined handling") and `specs/rust-core.md` (type-fidelity rules), implemented at the host→core marshal boundary in **both Rust binding crates** (napi + pyo3), so Node and Python get identical behavior over the same core:

1. **Table keys — dropped, recursively.** A null/undefined (JS) / `None` (Python) valued key is dropped as if never set — top-level fields, nested tables, and objects inside arrays. Byte-identical to 1.x output; the drop happens *before* validation, so a null-valued required field fails as *missing* (same as 1.x).
2. **Array elements — rejected**, with a typed error naming the index. This is a **deliberate divergence from 1.x**, which *silently dropped* null elements (`[1, null, 2]` → `[1, 2]`) — an index-shifting silent data mutation, not a semantics-preserving omission. Verified against `@iarna/toml@2.2.5` and called out in the spec + migration guide.
3. **A null value itself** (a whole record, a scalar position) stays an error, with a clarified message.

Merge-patch marshalling (`applyMergePatch`), where `null` is the RFC 7396 delete sentinel, is deliberately untouched. The rejection messages are minted in `gitsheets-core` (`null_array_element_msg` / `null_value_msg`) so diagnostics read identically across bindings. (The core `Value` enum stays TOML-faithful — no `Null` variant; the marshal recursion is the one place a host null is visible, and the cross-binding byte-parity suite enforces the contract.)

## Migration guide (#233)

`docs/migration-guide.md` gains the missing **v1.x → v2.0 (Rust core)** section covering the three breaks from the first production upgrade, each with before/after:

1. `hologit` dropped — `BlobObject.write` + `repo.hologitRepo` → `repo.writeBlob(buf)` + `Sheet.setAttachments`.
2. null/undefined handling — initial 2.x releases threw; fixed in this release to restore the 1.x drop semantics, with the array-element edge case documented.
3. Canonical byte re-baseline (#196, integer underscores et al.) with the one-time re-serialize-commit recipe.

## Test evidence (all green locally)

| Layer | Suite | Result |
| --- | --- | --- |
| Rust core | `cargo test -p gitsheets-core` | 169 passed (incl. new message-contract test) |
| Rust workspace | `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| napi boundary | `npm test` in `rust/gitsheets-napi` (node --test) | 108 passed — recursive drop, byte-parity with pre-stripped record, element/scalar rejections, sparse holes |
| Python | `pytest rust/gitsheets-py/tests` | 31 passed — `None` mirrors + new `nullish` **cross-binding byte-parity** fixture (Node vs Python identical tree/blob hashes) |
| Package | `npm test` (vitest) | 298 passed — new `sheet-nullish.test.ts` drives the real consumer pattern end-to-end: Standard-Schema validator emitting nulls for cleared optionals → write succeeds → serialized record has no such keys → re-writing null-cleared over stripped is a byte-level no-op (no new commit) |
| Type-check | `npm run type-check` | clean |

Specops: plan at `plans/marshal-drop-nullish.md` (closed out in the final commit).

Closes #232
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5fwEknfSxpaGCVEME5D4h
