### PR TITLE
docs(specs): correct attachment handle naming to shipped types

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -126,8 +126,8 @@ All write methods route through a transaction — permissive mode auto-opens one
 
 | Method | Purpose |
 | --- | --- |
-| `sheet.getAttachment(record, name)` | One attachment's BlobObject or null |
-| `sheet.getAttachments(record)` | Map of name → BlobObject |
+| `sheet.getAttachment(record, name)` | One attachment's `AttachmentBlobHandle` or null |
+| `sheet.getAttachments(record)` | Map of name → `AttachmentBlobHandle` |
 | `sheet.getAttachmentStream(recordOrPath, name)` | `Promise<Readable \| null>` — stream an attachment's bytes without materializing the record |
 | `sheet.setAttachment(record, name, content)` | Add or replace — `content` may be raw bytes (`Buffer`/`Uint8Array`), a UTF-8 `string`, or a `BlobHandle` |
 | `sheet.setAttachments(record, map)` | Bulk variant; values accept the same types, mixed freely |

--- a/plans/spec-attachment-handle-drift.md
+++ b/plans/spec-attachment-handle-drift.md
@@ -1,0 +1,40 @@
+---
+status: done
+depends: []
+specs:
+  - specs/behaviors/attachments.md
+  - specs/api/sheet.md
+issues: [244]
+pr: 246
+---
+
+# Close out attachment-handle spec↔code drift (#244)
+
+## Scope
+
+Resolve the spec drift flagged in #244: `specs/behaviors/attachments.md` documented a `repo.writeBlobFromFile('/path')` helper and hologit-era `BlobObject` handles that the 2.x surface never implemented.
+
+## Implements
+
+- `specs/behaviors/attachments.md`, `specs/api/sheet.md` (naming corrections; no behavior change)
+
+## Approach
+
+The primary drift (`writeBlobFromFile` example + "hologit BlobObject or whatever the new substrate provides" prose) was already superseded by #242's bytes-accepting `setAttachment` spec rewrite. This plan sweeps the residue: remaining `BlobObject` references corrected to the shipped types — `BlobHandle` for diff `srcBlob`/`dstBlob`, `AttachmentBlobHandle` for attachment getters — across `specs/api/sheet.md`, `specs/behaviors/attachments.md`, and `docs/api.md`. A file-path convenience helper was deliberately **not** added: with `setAttachment` accepting raw bytes (#234), `readFile` → one call covers the case; reopen if a consumer needs streaming file writes.
+
+## Validation
+
+- [x] `grep -rn "writeBlobFromFile\|BlobObject" specs/ docs/` returns only migration-guide historical references
+- [x] Names verified against the shipped surface (`packages/gitsheets/src/sheet.ts`: `BlobHandle`, `AttachmentBlobHandle`)
+
+## Risks / unknowns
+
+None — docs-only.
+
+## Notes
+
+Decision recorded: spec amended rather than implementing `writeBlobFromFile`; rationale above.
+
+## Follow-ups
+
+- None.

--- a/specs/api/sheet.md
+++ b/specs/api/sheet.md
@@ -248,12 +248,12 @@ for await (const change of sheet.diffFrom('HEAD~1', { records: true, patches: tr
   // change.srcHash / change.dstHash        // blob hashes (null on add/delete)
   // change.src / change.dst                // parsed records (records: true)
   // change.patch                           // RFC 6902 JSON Patch ops (patches: true)
-  // change.srcBlob / change.dstBlob        // hologit BlobObject handles (blobs: true)
+  // change.srcBlob / change.dstBlob        // gitsheets BlobHandle handles (blobs: true)
 }
 ```
 
 - `srcCommitHash` accepts a commit hash, a tree hash, or a ref name (`'HEAD~1'`, `'main'`). Defaults to the empty tree — every current record yields `status: 'added'`.
-- `opts.blobs?: boolean` — attach `srcBlob` / `dstBlob` (hologit `BlobObject`) handles.
+- `opts.blobs?: boolean` — attach `srcBlob` / `dstBlob` (gitsheets `BlobHandle`) handles.
 - `opts.records?: boolean` — parse src/dst TOML into records.
 - `opts.patches?: boolean` — produce an RFC 6902 JSON Patch (`Operation[]`) from src to dst. Add and delete entries get a single-op patch (`add` / `remove` on the root); modify entries get the full op sequence.
 

--- a/specs/behaviors/attachments.md
+++ b/specs/behaviors/attachments.md
@@ -69,7 +69,7 @@ Returns a blob map keyed by attachment name. Used for browsing.
 
 ```typescript
 const attachments = await sheet.getAttachments(record);
-// → { 'avatar.jpg': BlobObject, 'avatar-128.jpg': BlobObject }
+// → { 'avatar.jpg': AttachmentBlobHandle, 'avatar-128.jpg': AttachmentBlobHandle }
 ```
 
 Returns `null` if the record has no attachment directory.


### PR DESCRIPTION
Closes #244. The primary drift (`writeBlobFromFile` example + hologit-era prose) was already superseded by #242's `setAttachment` spec rewrite; this sweeps the residue — remaining `BlobObject` references corrected to the shipped `BlobHandle` (diff blobs) and `AttachmentBlobHandle` (attachment getters) types across specs and docs, verified against `packages/gitsheets/src/sheet.ts`. Decision recorded in the plan: no `writeBlobFromFile` implementation — with #234's bytes-accepting `setAttachment`, `readFile` → one call covers it; reopen if a consumer needs streaming file writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)