### PR TITLE
chore(release): @gitsheets/core-napi 0.2.0 consumer bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       "link": true
     },
     "node_modules/@gitsheets/core-napi-darwin-arm64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-arm64/-/core-napi-darwin-arm64-0.1.0.tgz",
-      "integrity": "sha512-ZVGkHJJo1I9RtiQeX47tWaj7NfUFx/Bglu7ucgFSyzo08OI/xGpInN1Ax4hXLmXFGbqMmzLD088gTzGfcgNQcA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-arm64/-/core-napi-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-X9gFr9bMJ/faBmE3AepGARim0va3ONwGRVygdVOE4dSSruBzV+4SyjLrfqZ5NpX1Pg8K/XWkqxpnb1yaDdohIw==",
       "cpu": [
         "arm64"
       ],
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-darwin-x64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-x64/-/core-napi-darwin-x64-0.1.0.tgz",
-      "integrity": "sha512-+61AfffnzWrzPJCPgYrMkFZ4RigukjjxKV/0boKiOi+A9OZyqtlpgE8rvACOUfT9Z4+hokVRU849BS2BHtNjGA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-x64/-/core-napi-darwin-x64-0.2.0.tgz",
+      "integrity": "sha512-IuuM6ygcHZZNu6h/aHanHsQH+1VOndOUV1xAP9Kl77CF2vBvtR4/zLaR5SkLBkNtnjDDwodWasLBg97EZFrn/g==",
       "cpu": [
         "x64"
       ],
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-arm64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-arm64-gnu/-/core-napi-linux-arm64-gnu-0.1.0.tgz",
-      "integrity": "sha512-lc0/7dDM8zmKCY5BOCQDPzhNMrLddhViqzHPZg2GQlPtvW/i5chdlleix0EwbCbOqxg2BB2ByfjITmNAD76ipQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-arm64-gnu/-/core-napi-linux-arm64-gnu-0.2.0.tgz",
+      "integrity": "sha512-dYJeEv6zW6VpJOiiWkXGmIEy4VJdfaSzIPG+Din8Hlasv10UuvnnydxWjXAmW47zg6Q24cS5QAkKH7AE7itf9Q==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-x64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-gnu/-/core-napi-linux-x64-gnu-0.1.0.tgz",
-      "integrity": "sha512-3xD5o6OiGKilh+XRt/4JSUsjpxeIB4t8u07c2sPTBbOAF1Fl0EveaQBvzH7HTNZ/9UricWxzV64qgsO4U6Xfuw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-gnu/-/core-napi-linux-x64-gnu-0.2.0.tgz",
+      "integrity": "sha512-PWyXvJfE2mEwbSRJD9krA6g+2b4FNIp8N3kou3K4Ce8Vhr6dzFWd9u6VRHMohFYfCP9IYZedN/HkO/nzTXhzHg==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-x64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-musl/-/core-napi-linux-x64-musl-0.1.0.tgz",
-      "integrity": "sha512-T7dvvj5fi7GC9KHoqB8fFBc6Te/x0+71sCvNdbSEDeuypzFFVlv1fwyfetmtApbsDzmhcYkLuiTyVWXon+XLwg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-musl/-/core-napi-linux-x64-musl-0.2.0.tgz",
+      "integrity": "sha512-w/uiJiEvXQKY0+O6tj7UbGgVSKrV40QZ9L52Z3gQsxA5eQREpaEhgo70TBGgvqbgOwXOp1EeXEnQArqakctKUQ==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-win32-x64-msvc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-win32-x64-msvc/-/core-napi-win32-x64-msvc-0.1.0.tgz",
-      "integrity": "sha512-xdweIfb/zPoDJHRSzhCy9861T6AVEM+VDMrp/SKhzfGvAi+fM+1G3/7i71oqiaz1DXizG9qKU7Qh6TC0QYb8XA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-win32-x64-msvc/-/core-napi-win32-x64-msvc-0.2.0.tgz",
+      "integrity": "sha512-oSQvdK+1zzAP8VYk/rjykyIC5TI+axLCvvASagpAPyL0CKEa3ZEaNeB51vie5yy4YuXnrqmEn/DJDY/LeL6cpg==",
       "cpu": [
         "x64"
       ],
@@ -1804,7 +1804,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gitsheets/core-napi": "^0.1.0",
+        "@gitsheets/core-napi": "^0.2.0",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "rfc6902": "^5.2.0",
@@ -1848,9 +1848,26 @@
         "node": ">=20"
       }
     },
+    "packages/gitsheets/node_modules/@gitsheets/core-napi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi/-/core-napi-0.2.0.tgz",
+      "integrity": "sha512-nmHKdJDruauMW2jmYa/g5FTTNVYDKFLUvPtlQgrP6WA6j9Vep526Zrk2ccBVeGoJCX7802sXXtmAcljUuR/GLA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@gitsheets/core-napi-darwin-arm64": "0.2.0",
+        "@gitsheets/core-napi-darwin-x64": "0.2.0",
+        "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
+        "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
+        "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
+        "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
+      }
+    },
     "rust/gitsheets-napi": {
       "name": "@gitsheets/core-napi",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -1863,12 +1880,12 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@gitsheets/core-napi-darwin-arm64": "0.1.0",
-        "@gitsheets/core-napi-darwin-x64": "0.1.0",
-        "@gitsheets/core-napi-linux-arm64-gnu": "0.1.0",
-        "@gitsheets/core-napi-linux-x64-gnu": "0.1.0",
-        "@gitsheets/core-napi-linux-x64-musl": "0.1.0",
-        "@gitsheets/core-napi-win32-x64-msvc": "0.1.0"
+        "@gitsheets/core-napi-darwin-arm64": "0.2.0",
+        "@gitsheets/core-napi-darwin-x64": "0.2.0",
+        "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
+        "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
+        "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
+        "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
       }
     }
   }

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
-    "@gitsheets/core-napi": "^0.1.0",
+    "@gitsheets/core-napi": "^0.2.0",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "rfc6902": "^5.2.0",

--- a/plans/core-napi-0.2.0-release.md
+++ b/plans/core-napi-0.2.0-release.md
@@ -17,8 +17,8 @@ Release engineering only; no spec changes.
 
 ## Approach
 
-1. Bump `@gitsheets/core-napi` → 0.2.0 (main + 6 platform packages via `napi version`), `packages/gitsheets` dep → `^0.2.0`.
-2. Tag `core-napi-v0.2.0` on the bump commit **before** merging — the platform packages must exist on npm for the PR's own `npm ci` to resolve; the tag workflow builds all targets natively from the tagged commit (no registry dependency).
+1. Bump only the consumer side: `packages/gitsheets` dep → `^0.2.0`. The napi package versions are **tag-stamped by the publish workflow** (`npm version $VERSION` from the tag name) and deliberately never committed — committing them breaks the stamp step ("Version not changed", learned the hard way on the first tag attempt).
+2. Tag `core-napi-v0.2.0` on develop (which carries the #241 core changes and the un-bumped 0.1.0 manifests) — the platform packages must exist on npm before the consumer-bump PR's `npm ci` can resolve.
 3. After publish: refresh `package-lock.json` against the live 0.2.0 packages, then merge.
 4. Re-run the release flow as v2.3.1 (v2.3.0's GitHub release exists; its npm publish never landed — v2.3.1 is the npm release of the same content).
 

--- a/plans/core-napi-0.2.0-release.md
+++ b/plans/core-napi-0.2.0-release.md
@@ -19,7 +19,7 @@ Release engineering only; no spec changes.
 
 1. Bump only the consumer side: `packages/gitsheets` dep → `^0.2.0`. The napi package versions are **tag-stamped by the publish workflow** (`npm version $VERSION` from the tag name) and deliberately never committed — committing them breaks the stamp step ("Version not changed", learned the hard way on the first tag attempt).
 2. Tag `core-napi-v0.2.0` on develop (which carries the #241 core changes and the un-bumped 0.1.0 manifests) — the platform packages must exist on npm before the consumer-bump PR's `npm ci` can resolve.
-3. After publish: refresh `package-lock.json` against the live 0.2.0 packages, then merge.
+3. After publish: **sync the workspace manifests to the released version** (main + platform packages + optionalDeps — safe now; stamping only fails when the committed version equals the tag being stamped) and refresh `package-lock.json` against the live 0.2.0 packages, then merge. Without the sync, workspace tests keep resolving the previous platform binaries.
 4. Re-run the release flow as v2.3.1 (v2.3.0's GitHub release exists; its npm publish never landed — v2.3.1 is the npm release of the same content).
 
 ## Validation

--- a/plans/core-napi-0.2.0-release.md
+++ b/plans/core-napi-0.2.0-release.md
@@ -1,0 +1,42 @@
+---
+status: in-progress
+depends: []
+specs: []
+issues: []
+---
+
+# Ship @gitsheets/core-napi 0.2.0 and unblock the gitsheets npm release
+
+## Scope
+
+gitsheets v2.3.0's `publish-npm` failed: the workspace napi tests resolve platform binaries from the published `@gitsheets/core-napi` packages (optionalDependencies), which were still 0.1.x — predating #241's core marshal changes, whose tests assert the new error messages. Core changes require a core-napi release before a gitsheets release; this plan ships 0.2.0 and re-cuts the JS package as v2.3.1.
+
+## Implements
+
+Release engineering only; no spec changes.
+
+## Approach
+
+1. Bump `@gitsheets/core-napi` → 0.2.0 (main + 6 platform packages via `napi version`), `packages/gitsheets` dep → `^0.2.0`.
+2. Tag `core-napi-v0.2.0` on the bump commit **before** merging — the platform packages must exist on npm for the PR's own `npm ci` to resolve; the tag workflow builds all targets natively from the tagged commit (no registry dependency).
+3. After publish: refresh `package-lock.json` against the live 0.2.0 packages, then merge.
+4. Re-run the release flow as v2.3.1 (v2.3.0's GitHub release exists; its npm publish never landed — v2.3.1 is the npm release of the same content).
+
+## Validation
+
+- [ ] @gitsheets/core-napi 0.2.0 (+6 platform packages) live on npm
+- [x] Local fresh linux-x64-gnu build passes the 108-test napi suite
+- [ ] PR CI green with lockfile resolving 0.2.0
+- [ ] gitsheets 2.3.1 on npm; `publish-npm` green
+
+## Risks / unknowns
+
+- Trusted-publishing config must already cover all 7 packages (bootstrapped at 0.1.0; assumed intact).
+
+## Notes
+
+Lesson: core-behavior changes must bump/release core-napi in the same batch as the consuming JS release.
+
+## Follow-ups
+
+- Consider a CI guard: fail fast with a clear "release core-napi first" message when workspace napi tests would resolve platform binaries older than the workspace core, instead of a mid-publish test failure.

--- a/rust/gitsheets-napi/npm/darwin-arm64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-darwin-arm64",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "os": [
     "darwin"
   ],

--- a/rust/gitsheets-napi/npm/darwin-arm64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "darwin"
   ],

--- a/rust/gitsheets-napi/npm/darwin-x64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-darwin-x64",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "os": [
     "darwin"
   ],

--- a/rust/gitsheets-napi/npm/darwin-x64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "darwin"
   ],

--- a/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-arm64-gnu",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-arm64-gnu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-x64-gnu",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-x64-musl/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-x64-musl",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-x64-musl/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-x64-musl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
+++ b/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-win32-x64-msvc",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "os": [
     "win32"
   ],

--- a/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
+++ b/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "win32"
   ],

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gitsheets/core-napi",
-  "version": "0.2.0",
-  "description": "Node.js native binding for gitsheets-core \u2014 the FFI marshalling boundary.",
+  "version": "0.1.0",
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
   "main": "binding.cjs",
   "types": "index.d.ts",
   "license": "Apache-2.0",
@@ -33,12 +33,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
-    "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
-    "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
-    "@gitsheets/core-napi-darwin-arm64": "0.2.0",
-    "@gitsheets/core-napi-darwin-x64": "0.2.0",
-    "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
+    "@gitsheets/core-napi-linux-x64-gnu": "0.1.0",
+    "@gitsheets/core-napi-linux-arm64-gnu": "0.1.0",
+    "@gitsheets/core-napi-linux-x64-musl": "0.1.0",
+    "@gitsheets/core-napi-darwin-arm64": "0.1.0",
+    "@gitsheets/core-napi-darwin-x64": "0.1.0",
+    "@gitsheets/core-napi-win32-x64-msvc": "0.1.0"
   },
   "scripts": {
     "artifacts": "napi artifacts",

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gitsheets/core-napi",
-  "version": "0.1.0",
-  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
+  "version": "0.2.0",
+  "description": "Node.js native binding for gitsheets-core \u2014 the FFI marshalling boundary.",
   "main": "binding.cjs",
   "types": "index.d.ts",
   "license": "Apache-2.0",
@@ -33,12 +33,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@gitsheets/core-napi-linux-x64-gnu": "0.1.0",
-    "@gitsheets/core-napi-linux-arm64-gnu": "0.1.0",
-    "@gitsheets/core-napi-linux-x64-musl": "0.1.0",
-    "@gitsheets/core-napi-darwin-arm64": "0.1.0",
-    "@gitsheets/core-napi-darwin-x64": "0.1.0",
-    "@gitsheets/core-napi-win32-x64-msvc": "0.1.0"
+    "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
+    "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
+    "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
+    "@gitsheets/core-napi-darwin-arm64": "0.2.0",
+    "@gitsheets/core-napi-darwin-x64": "0.2.0",
+    "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
   },
   "scripts": {
     "artifacts": "napi artifacts",


### PR DESCRIPTION
Unblocks the gitsheets npm release after v2.3.0's `publish-npm` failure (workspace napi tests resolved 0.1.x platform binaries predating #241's core changes).

- `@gitsheets/core-napi` 0.2.0 published from tag `core-napi-v0.2.0` (all 6 platforms, trusted publishing) — done.
- This PR: `packages/gitsheets` dep → `^0.2.0`, workspace manifest sync to the released version, lockfile refresh. 338/338 vitest + 108/108 napi tests green locally against the fresh binaries.
- Release-flow lessons recorded in `plans/core-napi-0.2.0-release.md`: napi versions are tag-stamped (never pre-commit them); manifest sync happens post-publish; core-behavior changes require a core-napi release before the JS release.

Next: merge opens the v2.3.1 Release PR — the npm re-cut of v2.3.0's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)