### PR TITLE
feat: declarative date-bucket path keys (YYYY/MM/DD, YYYY/MM, YYYY/WW)

### DIFF
--- a/docs/path-templates.md
+++ b/docs/path-templates.md
@@ -12,6 +12,7 @@ For the full spec see
 | --- | --- | --- |
 | Literal | `users/by-domain/` | Static path text |
 | Field reference | `${{ slug }}` | The value of `record.slug` |
+| Date bucket | `${{ publishedAt: YYYY/MM/DD }}` | UTC date partitions of the field — one directory level per format part |
 | Expression | `${{ slug.toLowerCase() }}` | Arbitrary JS expression with record fields in scope |
 | Recursive | `${{ path/** }}` | Field's value may contain `/` — for nested-path fields |
 | Prefix/suffix | `user-${{ id }}.draft` | Literal text attached to an expression |
@@ -26,12 +27,45 @@ path = "${{ slug }}"
 # Composite key (two-level directory)
 path = "${{ domain }}/${{ username }}"
 
-# Sharded by date
-path = "${{ publishedAt.getFullYear() }}/${{ publishedAt.getMonth() }}/${{ slug }}"
+# Date-bucketed (2026/03/09/my-post.toml)
+path = "${{ publishedAt: YYYY/MM/DD }}/${{ slug }}"
 
 # Nested path field
 path = "${{ contentPath/** }}"
 ```
+
+## Date buckets
+
+A date-bucket reference partitions records by a date field — by day, month,
+year, or ISO week:
+
+```toml
+path = "${{ publishedAt: YYYY/MM/DD }}/${{ slug }}"   # 2026/03/09/my-post.toml
+path = "${{ publishedAt: YYYY/MM }}/${{ slug }}"      # 2026/03/my-post.toml
+path = "${{ publishedAt: YYYY/WW }}/${{ slug }}"      # 2026/11/my-post.toml (ISO week)
+path = "${{ day: YYYY/MM/DD }}"                       # daily rollup: the bucket IS the key
+```
+
+The format is a **closed set** — `YYYY`, `YYYY/MM`, `YYYY/MM/DD`, `YYYY/WW`;
+anything else throws `ConfigError(config_invalid)` when the sheet is opened.
+Fancier partitioning falls back to the expression form.
+
+Semantics worth knowing:
+
+- **UTC always.** Buckets never consult the host timezone, so the same record
+  produces the same path on every machine. (The expression spelling
+  `getFullYear()` doesn't have this guarantee — it renders host-local dates.)
+- **`YYYY/WW` is ISO-8601 week numbering**, and its year part is the ISO
+  *week-based* year: 2027-01-01 belongs to ISO week 2026-W53 and renders as
+  `2026/53`.
+- **`MM`, `DD`, `WW` are always two digits** — partitions sort correctly.
+- The field may hold a datetime/date value or an ISO 8601 string. One bucket
+  token expands to multiple real directory levels, and must stand alone
+  between slashes.
+- Queries that supply the bucketed field (e.g.
+  `posts.queryAll({ publishedAt })`) descend the exact partition instead of
+  scanning every record; without it, the partition levels are walked like any
+  other unconstrained segment.
 
 ## How queries use the template
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,23 +1848,6 @@
         "node": ">=20"
       }
     },
-    "packages/gitsheets/node_modules/@gitsheets/core-napi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi/-/core-napi-0.2.0.tgz",
-      "integrity": "sha512-nmHKdJDruauMW2jmYa/g5FTTNVYDKFLUvPtlQgrP6WA6j9Vep526Zrk2ccBVeGoJCX7802sXXtmAcljUuR/GLA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
-      },
-      "optionalDependencies": {
-        "@gitsheets/core-napi-darwin-arm64": "0.2.0",
-        "@gitsheets/core-napi-darwin-x64": "0.2.0",
-        "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
-        "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
-        "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
-        "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
-      }
-    },
     "rust/gitsheets-napi": {
       "name": "@gitsheets/core-napi",
       "version": "0.2.0",

--- a/packages/gitsheets/src/path-template/index.test.ts
+++ b/packages/gitsheets/src/path-template/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { PathTemplateError } from '../errors.js';
+import { ConfigError, PathTemplateError } from '../errors.js';
 import {
   Template,
   type PathTemplateBlob,
@@ -345,5 +345,188 @@ describe('Template.queryTree', () => {
       found.push(r.path);
     }
     expect(found.sort()).toEqual(['2026/active--1', '2026/closed--2']);
+  });
+});
+
+// --- Date-bucket references (specs/behaviors/path-templates.md § "Date-bucket references") ---
+
+describe('Template date buckets — rendering', () => {
+  const at = new Date('2026-03-09T12:00:00Z');
+
+  it('renders each format of the closed enum', () => {
+    expect(Template.fromString('${{ publishedAt: YYYY }}/${{ slug }}').render({ publishedAt: at, slug: 'hi' }))
+      .toBe('2026/hi');
+    expect(Template.fromString('${{ publishedAt: YYYY/MM }}/${{ slug }}').render({ publishedAt: at, slug: 'hi' }))
+      .toBe('2026/03/hi');
+    expect(Template.fromString('${{ publishedAt: YYYY/MM/DD }}/${{ slug }}').render({ publishedAt: at, slug: 'hi' }))
+      .toBe('2026/03/09/hi');
+    // 2026-03-09 is a Monday in ISO week 11 of week-year 2026.
+    expect(Template.fromString('${{ publishedAt: YYYY/WW }}/${{ slug }}').render({ publishedAt: at, slug: 'hi' }))
+      .toBe('2026/11/hi');
+  });
+
+  it('zero-pads MM, DD, and WW to two digits', () => {
+    const jan2 = new Date('2026-01-02T00:00:00Z');
+    expect(Template.fromString('${{ d: YYYY/MM/DD }}').render({ d: jan2 })).toBe('2026/01/02');
+    expect(Template.fromString('${{ d: YYYY/WW }}').render({ d: jan2 })).toBe('2026/01');
+  });
+
+  it('YYYY/WW uses the ISO week-based year, not the calendar year', () => {
+    // January 1 belonging to week 53 of the PRIOR ISO year.
+    expect(Template.fromString('${{ d: YYYY/WW }}').render({ d: new Date('2027-01-01T00:00:00Z') }))
+      .toBe('2026/53');
+    expect(Template.fromString('${{ d: YYYY }}').render({ d: new Date('2027-01-01T00:00:00Z') }))
+      .toBe('2027');
+    // Late December belonging to week 1 of the NEXT ISO year.
+    expect(Template.fromString('${{ d: YYYY/WW }}').render({ d: new Date('2024-12-30T00:00:00Z') }))
+      .toBe('2025/01');
+  });
+
+  it('renders in UTC regardless of host timezone (Date instants)', () => {
+    // 23:30-05:00 is 04:30 the NEXT day in UTC; a Date is an instant, so
+    // the bucket must land on the UTC date on every host.
+    expect(Template.fromString('${{ d: YYYY/MM/DD }}').render({ d: new Date('2025-12-31T23:30:00-05:00') }))
+      .toBe('2026/01/01');
+  });
+
+  it('accepts ISO 8601 strings', () => {
+    expect(Template.fromString('${{ d: YYYY/MM }}').render({ d: '2026-03-09' })).toBe('2026/03');
+    // Explicit offset normalizes to UTC.
+    expect(Template.fromString('${{ d: YYYY/MM/DD }}').render({ d: '2025-12-31T23:30:00-05:00' }))
+      .toBe('2026/01/01');
+    // Offset-less datetime string reads at face value — never host-TZ parsed.
+    expect(Template.fromString('${{ d: YYYY/MM/DD }}').render({ d: '2026-03-09T23:59:59' }))
+      .toBe('2026/03/09');
+  });
+
+  it('may be the entire path (daily-rollup identity)', () => {
+    expect(Template.fromString('${{ day: YYYY/MM/DD }}').render({ day: '2026-03-09' }))
+      .toBe('2026/03/09');
+  });
+
+  it('composes anywhere in the template', () => {
+    const t = Template.fromString('posts/${{ region }}/${{ d: YYYY/MM }}/${{ slug }}');
+    expect(t.render({ region: 'us', d: '2026-03-09', slug: 'x' })).toBe('posts/us/2026/03/x');
+  });
+
+  it('reads dotted fields from nested objects', () => {
+    const t = Template.fromString('${{ meta.publishedAt: YYYY/MM }}/${{ slug }}');
+    expect(t.render({ meta: { publishedAt: '2026-03-09' }, slug: 'x' })).toBe('2026/03/x');
+  });
+
+  it('getFieldNames includes the bucket base field once', () => {
+    expect(Template.fromString('${{ publishedAt: YYYY/MM/DD }}/${{ slug }}').getFieldNames())
+      .toEqual(['publishedAt', 'slug']);
+    expect(Template.fromString('${{ meta.publishedAt: YYYY/MM }}/${{ slug }}').getFieldNames())
+      .toEqual(['meta', 'slug']);
+  });
+});
+
+describe('Template date buckets — rejections', () => {
+  it('missing field follows the missing-field rule (path_render_failed)', () => {
+    const t = Template.fromString('${{ d: YYYY/MM }}/${{ slug }}');
+    expect(() => t.render({ slug: 'x' })).toThrowError(PathTemplateError);
+    try {
+      t.render({ slug: 'x' });
+    } catch (err) {
+      expect((err as PathTemplateError).code).toBe('path_render_failed');
+    }
+  });
+
+  it('wrong-typed values fail the render naming the field', () => {
+    const t = Template.fromString('${{ d: YYYY/MM }}');
+    for (const d of [42, true, { nested: 1 }, ['2026-03-09']]) {
+      try {
+        t.render({ d });
+        expect.unreachable('render should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PathTemplateError);
+        expect((err as PathTemplateError).code).toBe('path_render_failed');
+        expect((err as PathTemplateError).message).toContain('"d"');
+      }
+    }
+  });
+
+  it('unparseable and unreal date strings fail the render', () => {
+    const t = Template.fromString('${{ d: YYYY }}');
+    for (const d of ['not-a-date', '2026-02-30', '2026-13-01', '2026-03-09T99:00:00']) {
+      expect(() => t.render({ d })).toThrowError(PathTemplateError);
+    }
+  });
+
+  it('an unknown format is ConfigError(config_invalid) at parse (sheet-open) time', () => {
+    for (const bad of ['YYYY-MM', 'MM/DD', 'YYYY/MM/DD/HH', 'yyyy', 'WW', '']) {
+      try {
+        Template.fromString(`\${{ d: ${bad} }}/\${{ slug }}`);
+        expect.unreachable(`format ${JSON.stringify(bad)} should have thrown`);
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConfigError);
+        expect((err as ConfigError).code).toBe('config_invalid');
+        expect((err as ConfigError).message).toContain('YYYY/MM/DD');
+      }
+    }
+  });
+
+  it('a bucket must stand alone in its path segment', () => {
+    for (const bad of [
+      'posts-${{ d: YYYY }}',
+      '${{ d: YYYY }}.draft',
+      '${{ d: YYYY }}${{ slug }}',
+      '${{ slug }}-${{ d: YYYY/MM }}',
+    ]) {
+      try {
+        Template.fromString(bad);
+        expect.unreachable(`template ${JSON.stringify(bad)} should have thrown`);
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConfigError);
+        expect((err as ConfigError).code).toBe('config_invalid');
+      }
+    }
+  });
+
+  it('does not hijack non-bucket colon expressions (ternaries still work)', () => {
+    const t = Template.fromString("${{ status === 'live' ? 'published' : 'drafts' }}/${{ slug }}");
+    expect(t.render({ status: 'live', slug: 'x' })).toBe('published/x');
+    expect(t.render({ status: 'draft', slug: 'x' })).toBe('drafts/x');
+  });
+});
+
+describe('Template date buckets — queryTree', () => {
+  const bucketTree = (): FakeTree =>
+    new FakeTree({
+      '2026': new FakeTree({
+        '03': new FakeTree({ 'a.toml': new FakeBlob('a') }),
+        '04': new FakeTree({ 'b.toml': new FakeBlob('b') }),
+      }),
+      '2025': new FakeTree({
+        '12': new FakeTree({ 'c.toml': new FakeBlob('c') }),
+      }),
+    });
+
+  it('descends the exact rendered bucket path when the field is supplied', async () => {
+    const t = Template.fromString('${{ publishedAt: YYYY/MM }}/${{ slug }}');
+    const found = [];
+    for await (const r of t.queryTree(bucketTree(), { publishedAt: new Date('2026-03-09T12:00:00Z') })) {
+      found.push(r.path);
+    }
+    expect(found).toEqual(['2026/03/a']);
+  });
+
+  it('treats bucket segments as wildcards when the field is absent', async () => {
+    const t = Template.fromString('${{ publishedAt: YYYY/MM }}/${{ slug }}');
+    const found = [];
+    for await (const r of t.queryTree(bucketTree(), {})) {
+      found.push(r.path);
+    }
+    expect(found.sort()).toEqual(['2025/12/c', '2026/03/a', '2026/04/b']);
+  });
+
+  it('widens (never throws) on a wrong-typed query value', async () => {
+    const t = Template.fromString('${{ publishedAt: YYYY/MM }}/${{ slug }}');
+    const found = [];
+    for await (const r of t.queryTree(bucketTree(), { publishedAt: 42 })) {
+      found.push(r.path);
+    }
+    expect(found.sort()).toEqual(['2025/12/c', '2026/03/a', '2026/04/b']);
   });
 });

--- a/packages/gitsheets/src/path-template/index.ts
+++ b/packages/gitsheets/src/path-template/index.ts
@@ -3,7 +3,7 @@
 
 import { runInNewContext } from 'node:vm';
 
-import { PathTemplateError } from '../errors.js';
+import { ConfigError, PathTemplateError } from '../errors.js';
 
 // --- Public types ---
 
@@ -44,7 +44,25 @@ interface ExpressionPart {
   readonly evaluate: (record: RecordLike) => unknown;
 }
 
-type Part = LiteralPart | FieldPart | ExpressionPart;
+/**
+ * One path segment of a date-bucket reference (`${{ field: YYYY/MM/DD }}`).
+ * The parser expands a bucket token into one `bucket` part per format part,
+ * each its own component, so a `YYYY/MM/DD` bucket creates three real tree
+ * levels. `YYYY` in a `YYYY/WW` bucket is the ISO *week-based* year
+ * (`isoYYYY`) — a different value from the calendar year near year
+ * boundaries. See specs/behaviors/path-templates.md § "Date-bucket
+ * references".
+ */
+interface BucketPart {
+  readonly kind: 'bucket';
+  /** The referenced field, split on `.` (dotted references read nested objects). */
+  readonly field: readonly string[];
+  readonly unit: BucketUnit;
+}
+
+type BucketUnit = 'YYYY' | 'MM' | 'DD' | 'isoYYYY' | 'WW';
+
+type Part = LiteralPart | FieldPart | ExpressionPart | BucketPart;
 
 interface Component {
   readonly parts: readonly Part[];
@@ -126,25 +144,229 @@ function stringifyValue(value: unknown): string | undefined {
   return undefined;
 }
 
-function renderPart(part: Part, record: RecordLike): string | undefined {
+function renderPart(part: Part, record: RecordLike, strict: boolean): string | undefined {
   switch (part.kind) {
     case 'literal':
       return part.text;
     case 'field':
       return stringifyValue(record[part.name]);
+    case 'bucket': {
+      const date = bucketDate(record, part.field, strict);
+      return date === undefined ? undefined : renderBucketUnit(date, part.unit);
+    }
     case 'expression':
       return stringifyValue(part.evaluate(record));
   }
 }
 
-function renderComponent(c: Component, record: RecordLike): string | undefined {
+/**
+ * Render a component to text, or `undefined` (un-renderable). `strict` is
+ * true for full-record `render` — where a date-bucket field holding a
+ * non-date value throws `PathTemplateError` — and false for `queryTree`
+ * planning, where a bad bucket value degrades to un-renderable so the walk
+ * widens instead of erroring (matching how opaque filter values widen the
+ * walk).
+ */
+function renderComponent(c: Component, record: RecordLike, strict: boolean): string | undefined {
   let out = '';
   for (const part of c.parts) {
-    const piece = renderPart(part, record);
+    const piece = renderPart(part, record, strict);
     if (piece === undefined) return undefined;
     out += piece;
   }
   return out;
+}
+
+// --- Date buckets (specs/behaviors/path-templates.md § "Date-bucket references") ---
+
+/**
+ * The closed format enum. Deliberately not a format language: anything else
+ * in the format position is `ConfigError('config_invalid')` at sheet-open.
+ */
+const BUCKET_FORMATS: Record<string, readonly BucketUnit[]> = {
+  'YYYY': ['YYYY'],
+  'YYYY/MM': ['YYYY', 'MM'],
+  'YYYY/MM/DD': ['YYYY', 'MM', 'DD'],
+  'YYYY/WW': ['isoYYYY', 'WW'],
+};
+
+const BUCKET_FIELD_SEGMENT_RE = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Recognize a date-bucket *attempt*: `<field(.dotted)?> : <format>`. Format
+ * validation against the closed enum happens at the call site, so an unknown
+ * format is `config_invalid` rather than falling through to the expression
+ * compiler.
+ *
+ * Recognizing this shape breaks no working template: `(field: ...)` is a JS
+ * labeled statement inside the renderer's `return (...)` wrapper — a
+ * guaranteed syntax error — so the colon-after-identifier space was dead.
+ */
+function splitBucketAttempt(
+  source: string,
+): { field: readonly string[]; format: string } | undefined {
+  const idx = source.indexOf(':');
+  if (idx === -1) return undefined;
+  const head = source.slice(0, idx).trim();
+  if (head === '') return undefined;
+  const field = head.split('.');
+  if (!field.every((seg) => BUCKET_FIELD_SEGMENT_RE.test(seg))) return undefined;
+  return { field, format: source.slice(idx + 1).trim() };
+}
+
+/** A UTC calendar date — the value a bucket partitions on. */
+interface UtcDate {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+}
+
+// ISO 8601 shapes accepted for bucket string values, mirroring the core
+// (chrono): RFC 3339 offsets only (`Z` or `±hh:mm`), seconds required in
+// datetimes, optional fraction.
+const BUCKET_DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BUCKET_DATETIME_RE =
+  /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?([Zz]|[+-]\d{2}:\d{2})?$/;
+
+/** Is `y-m-d` a real proleptic-Gregorian calendar date? */
+function isRealDate(year: number, month: number, day: number): boolean {
+  const t = new Date(Date.UTC(year, month - 1, day));
+  return (
+    t.getUTCFullYear() === year && t.getUTCMonth() === month - 1 && t.getUTCDate() === day
+  );
+}
+
+/**
+ * Resolve a (possibly dotted) bucket field against `record` and reduce it to
+ * the **UTC calendar date** the bucket partitions on. **UTC always**: a JS
+ * `Date` (an absolute instant) is read through its UTC accessors; a string
+ * with an explicit offset is normalized to UTC; offset-less strings are read
+ * at face value — never via `new Date(string)`, which would consult the host
+ * timezone. Absent field → `undefined` (un-renderable); present-but-not-a-
+ * date → throws in strict mode, `undefined` otherwise.
+ */
+function bucketDate(
+  record: RecordLike,
+  field: readonly string[],
+  strict: boolean,
+): UtcDate | undefined {
+  let current: unknown = record;
+  for (const seg of field) {
+    if (current === null || typeof current !== 'object' || Array.isArray(current)) {
+      return undefined;
+    }
+    current = (current as RecordLike)[seg];
+    if (current === undefined) return undefined;
+  }
+  const fail = (detail: string): undefined => {
+    if (strict) {
+      throw new PathTemplateError(
+        'path_render_failed',
+        `date-bucket reference: ${detail}`,
+      );
+    }
+    return undefined;
+  };
+  const name = field.join('.');
+
+  if (current instanceof Date) {
+    if (Number.isNaN(current.getTime())) {
+      return fail(`field "${name}" is an invalid Date`);
+    }
+    return {
+      year: current.getUTCFullYear(),
+      month: current.getUTCMonth() + 1,
+      day: current.getUTCDate(),
+    };
+  }
+
+  if (typeof current === 'string') {
+    const dateOnly = BUCKET_DATE_ONLY_RE.exec(current);
+    if (dateOnly) {
+      const [, y, m, d] = dateOnly;
+      const year = Number(y);
+      const month = Number(m);
+      const day = Number(d);
+      if (!isRealDate(year, month, day)) {
+        return fail(`field "${name}" value ${JSON.stringify(current)} is not a real date`);
+      }
+      return { year, month, day };
+    }
+    const dt = BUCKET_DATETIME_RE.exec(current);
+    if (dt) {
+      const [, y, m, d, hh, mm, ss, offset] = dt;
+      const year = Number(y);
+      const month = Number(m);
+      const day = Number(d);
+      if (
+        !isRealDate(year, month, day) ||
+        Number(hh) > 23 ||
+        Number(mm) > 59 ||
+        Number(ss) > 60
+      ) {
+        return fail(
+          `field "${name}" value ${JSON.stringify(current)} is not a real date or time`,
+        );
+      }
+      if (offset === undefined) {
+        // Offset-less datetime: face value, no TZ math.
+        return { year, month, day };
+      }
+      // Explicit offset (Z or ±hh:mm): normalize the instant to UTC.
+      const epoch = Date.parse(current);
+      if (Number.isNaN(epoch)) {
+        return fail(`field "${name}" value ${JSON.stringify(current)} is not parseable`);
+      }
+      const at = new Date(epoch);
+      return {
+        year: at.getUTCFullYear(),
+        month: at.getUTCMonth() + 1,
+        day: at.getUTCDate(),
+      };
+    }
+    return fail(
+      `field "${name}" value ${JSON.stringify(current)} is not an ISO 8601 date or datetime`,
+    );
+  }
+
+  return fail(
+    `field "${name}" has type ${Array.isArray(current) ? 'array' : typeof current} — ` +
+      'date-bucket fields accept Date values or ISO 8601 strings',
+  );
+}
+
+/**
+ * ISO-8601 week and week-based year of a UTC date (nearest-Thursday rule).
+ * Must agree exactly with chrono's `iso_week()` in the core — covered by the
+ * boundary-date parity tests.
+ */
+function isoWeekOf(d: UtcDate): { year: number; week: number } {
+  const t = new Date(Date.UTC(d.year, d.month - 1, d.day));
+  const dayNum = (t.getUTCDay() + 6) % 7; // Mon=0 … Sun=6
+  t.setUTCDate(t.getUTCDate() - dayNum + 3); // this ISO week's Thursday
+  const isoYear = t.getUTCFullYear();
+  const jan1 = Date.UTC(isoYear, 0, 1);
+  const week = Math.floor((t.getTime() - jan1) / 86_400_000 / 7) + 1;
+  return { year: isoYear, week };
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+const pad4 = (n: number): string => String(n).padStart(4, '0');
+
+/** Render one bucket unit, zero-padded (`MM`/`DD`/`WW` two digits, years four). */
+function renderBucketUnit(date: UtcDate, unit: BucketUnit): string {
+  switch (unit) {
+    case 'YYYY':
+      return pad4(date.year);
+    case 'MM':
+      return pad2(date.month);
+    case 'DD':
+      return pad2(date.day);
+    case 'isoYYYY':
+      return pad4(isoWeekOf(date).year);
+    case 'WW':
+      return pad2(isoWeekOf(date).week);
+  }
 }
 
 // --- Parser ---
@@ -189,6 +411,42 @@ function parseTemplateString(source: string): readonly Component[] {
       }
       exprSource = exprSource.trim();
       i += 2;
+
+      // Date-bucket reference — recognized BEFORE the expression fallback
+      // (specs/behaviors/path-templates.md § "Date-bucket references").
+      const bucket = splitBucketAttempt(exprSource);
+      if (bucket !== undefined) {
+        const units = BUCKET_FORMATS[bucket.format];
+        if (units === undefined) {
+          throw new ConfigError(
+            'config_invalid',
+            `invalid date-bucket format ${JSON.stringify(bucket.format)} in ` +
+              `"\${{ ${exprSource} }}" — supported formats: YYYY, YYYY/MM, YYYY/MM/DD, YYYY/WW`,
+          );
+        }
+        // A bucket expands into multiple real segments, so it must stand
+        // alone in its path segment: nothing already in the segment (any
+        // pending literal was flushed above), and a `/` or end-of-template
+        // after it.
+        const standaloneBefore = segments[segments.length - 1]!.length === 0;
+        const standaloneAfter = i >= normalized.length || normalized[i] === '/';
+        if (!standaloneBefore || !standaloneAfter) {
+          throw new ConfigError(
+            'config_invalid',
+            `date-bucket reference "\${{ ${exprSource} }}" must stand alone in its ` +
+              'path segment — no literal prefix/suffix or adjacent references',
+          );
+        }
+        for (let u = 0; u < units.length; u++) {
+          if (u > 0) segments.push([]);
+          segments[segments.length - 1]!.push({
+            kind: 'bucket',
+            field: bucket.field,
+            unit: units[u]!,
+          });
+        }
+        continue;
+      }
 
       if (FIELD_NAME_RE.test(exprSource)) {
         const recursive = exprSource.endsWith('/**');
@@ -340,6 +598,10 @@ export class Template {
       for (const p of c.parts) {
         if (p.kind === 'field') {
           seen.add(p.name);
+        } else if (p.kind === 'bucket') {
+          // A bucket contributes its base (top-level) field name — the same
+          // contribution an expression scan would make for a dotted member.
+          seen.add(p.field[0]!);
         } else if (p.kind === 'expression') {
           for (const id of extractIdentifiers(p.source)) {
             seen.add(id);
@@ -361,7 +623,7 @@ export class Template {
     const segments: string[] = [];
     for (let i = 0; i < this.#components.length; i++) {
       const c = this.#components[i]!;
-      const rendered = renderComponent(c, record);
+      const rendered = renderComponent(c, record, true);
       if (rendered === undefined) {
         throw new PathTemplateError(
           'path_render_failed',
@@ -406,7 +668,7 @@ export class Template {
     for (let i = depth; i < numComponents; i++) {
       const isLast = i + 1 === numComponents;
       const c = this.#components[i]!;
-      const rendered = renderComponent(c, query);
+      const rendered = renderComponent(c, query, false);
 
       if (isLast) {
         if (rendered !== undefined) {

--- a/packages/gitsheets/src/sheet-date-bucket.test.ts
+++ b/packages/gitsheets/src/sheet-date-bucket.test.ts
@@ -1,0 +1,145 @@
+// End-to-end date-bucket path keys: a sheet whose path template uses the
+// declarative bucket form writes records into date-partitioned trees and
+// prunes queries by the bucketed field.
+// See specs/behaviors/path-templates.md § "Date-bucket references".
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ConfigError } from './errors.js';
+import { openRepo } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+async function makeRepo(): Promise<TestRepoHandle> {
+  const h = await testRepo({ withInitialCommit: true });
+  handles.push(h);
+  return h;
+}
+
+async function seedConfig(fixture: TestRepoHandle, name: string, toml: string): Promise<void> {
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', `${name}.toml`), toml);
+  await fixture.git('add', '.gitsheets/');
+  await fixture.git('commit', '-m', `add ${name} sheet`);
+}
+
+const POSTS_CONFIG = `[gitsheet]
+root = 'posts'
+path = '\${{ publishedAt: YYYY/MM/DD }}/\${{ slug }}'
+`;
+
+describe('date-bucket path keys end to end', () => {
+  it('writes records into UTC date-partitioned paths and reads them back', async () => {
+    const fixture = await makeRepo();
+    await seedConfig(fixture, 'posts', POSTS_CONFIG);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed posts' }, async (tx) => {
+      await tx.sheet('posts').upsert({
+        slug: 'hello',
+        publishedAt: new Date('2026-03-09T12:00:00Z'),
+      });
+      // 23:30-05:00 is 04:30 the NEXT day in UTC — the partition must be
+      // the UTC date on every host.
+      await tx.sheet('posts').upsert({
+        slug: 'offset',
+        publishedAt: new Date('2025-12-31T23:30:00-05:00'),
+      });
+    });
+
+    const { stdout } = await fixture.git('ls-tree', '-r', '--name-only', 'main', 'posts/');
+    const paths = stdout.trim().split('\n').sort();
+    expect(paths).toEqual(['posts/2026/01/01/offset.toml', 'posts/2026/03/09/hello.toml']);
+  });
+
+  it('prunes a query by the bucketed field and wildcards without it', async () => {
+    const fixture = await makeRepo();
+    await seedConfig(fixture, 'posts', POSTS_CONFIG);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed posts' }, async (tx) => {
+      await tx.sheet('posts').upsert({ slug: 'a', publishedAt: new Date('2026-03-09T12:00:00Z') });
+      await tx.sheet('posts').upsert({ slug: 'b', publishedAt: new Date('2026-04-01T00:00:00Z') });
+      await tx.sheet('posts').upsert({ slug: 'c', publishedAt: new Date('2025-12-31T09:00:00Z') });
+    });
+
+    const posts = await repo.openSheet('posts');
+
+    // Bucketed field supplied → the walk descends the exact bucket path.
+    const march = await posts.queryAll({ publishedAt: new Date('2026-03-09T12:00:00Z') });
+    expect(march.map((r) => r['slug'])).toEqual(['a']);
+
+    // Without it, every partition is walked.
+    const all = await posts.queryAll({});
+    expect(all.map((r) => r['slug']).sort()).toEqual(['a', 'b', 'c']);
+
+    // Non-bucket filters still apply record-level across partitions.
+    const bySlug = await posts.queryAll({ slug: 'c' });
+    expect(bySlug).toHaveLength(1);
+    expect(bySlug[0]?.['publishedAt']).toBeInstanceOf(Date);
+  });
+
+  it('pathForRecord renders the bucketed path host-side identically', async () => {
+    const fixture = await makeRepo();
+    await seedConfig(fixture, 'posts', POSTS_CONFIG);
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const posts = await repo.openSheet('posts');
+
+    expect(
+      await posts.pathForRecord({ slug: 'hello', publishedAt: new Date('2026-03-09T12:00:00Z') }),
+    ).toBe('2026/03/09/hello');
+  });
+
+  it('supports the bucket as the entire path (daily-rollup identity)', async () => {
+    const fixture = await makeRepo();
+    await seedConfig(
+      fixture,
+      'rollups',
+      `[gitsheet]
+root = 'rollups'
+path = '\${{ day: YYYY/MM/DD }}'
+`,
+    );
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    await repo.transact({ message: 'seed rollups' }, async (tx) => {
+      await tx.sheet('rollups').upsert({ day: new Date('2026-03-09T00:00:00Z'), total: 5 });
+    });
+
+    const { stdout } = await fixture.git('ls-tree', '-r', '--name-only', 'main', 'rollups/');
+    expect(stdout.trim()).toBe('rollups/2026/03/09.toml');
+  });
+
+  it('rejects an unknown bucket format with ConfigError at sheet-open', async () => {
+    const fixture = await makeRepo();
+    await seedConfig(
+      fixture,
+      'bad',
+      `[gitsheet]
+root = 'bad'
+path = '\${{ publishedAt: YYYY-MM }}/\${{ slug }}'
+`,
+    );
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+
+    try {
+      const sheet = await repo.openSheet('bad');
+      // Config parse is lazy in some paths — force it.
+      await sheet.queryAll({});
+      expect.unreachable('sheet-open should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect((err as ConfigError).code).toBe('config_invalid');
+    }
+  });
+});

--- a/plans/date-bucket-path-keys.md
+++ b/plans/date-bucket-path-keys.md
@@ -1,0 +1,126 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/behaviors/path-templates.md
+issues: [252]
+---
+
+# Plan: declarative date-bucket path keys
+
+## Scope
+
+Implement the date-bucket path-template reference specced in
+`specs/behaviors/path-templates.md` § "Date-bucket references"
+([#252](https://github.com/JarvusInnovations/gitsheets/issues/252)):
+
+```toml
+path = '${{ publishedAt: YYYY/MM/DD }}/${{ slug }}'
+```
+
+- Closed format enum (`YYYY`, `YYYY/MM`, `YYYY/MM/DD`, `YYYY/WW`); anything
+  else in the format position → `ConfigError('config_invalid')` at sheet-open.
+- UTC-always rendering; `YYYY/WW` = ISO-8601 week + ISO week-based year;
+  two-digit zero-padding for `MM`/`DD`/`WW`.
+- One token → multiple real path segments, composing with the existing
+  query-tree pruning walk (present field prunes; absent field wildcards).
+- Implemented in the Rust core (native chrono rendering, no boa involvement)
+  **and** the host TS `Template` (public export, used by `pathForRecord` and
+  `getFieldNames`), byte-identical.
+
+Out of scope:
+
+- **Range-pruned queries** (date-range filters mapped onto bounded subtree
+  walks) — the follow-up the declarative form enables; noted in the spec and
+  tracked on [#252](https://github.com/JarvusInnovations/gitsheets/issues/252).
+- Any change to bare `${{ dateField }}` rendering (the host-side `.toString()`
+  wart stands for non-bucket references, per the spec's rejected-alternative
+  note).
+- New format-enum members (`HH` time buckets, quarter buckets, …) — the enum
+  is deliberately closed; fancier needs use the expression form.
+
+## Implements
+
+- `specs/behaviors/path-templates.md` — "Date-bucket references" (grammar,
+  rendering semantics, query-traversal semantics, backward compatibility) and
+  the date-bucket line item in "Query traversal § Algorithm".
+
+## Approach
+
+1. **Rust core** (`rust/gitsheets-core/src/path_template.rs`): recognize the
+   bucket form during template parse, **before** the expression fallback —
+   content matching `ident(.ident)*: <format>` is a bucket attempt; a valid
+   format expands into one `Part::Bucket { field, unit }` component per
+   format part (`CalendarYear`/`Month`/`Day` | `IsoWeekYear`/`IsoWeek`); an
+   invalid format is `Error::ConfigInvalid` (surfaces at `Sheet::open`, which
+   compiles the template). A bucket must stand alone in its segment.
+   Rendering is native via `chrono` (no boa): TOML datetimes normalize
+   offset → UTC before date-part extraction; ISO 8601 strings parse via
+   chrono; `iso_week()` for `YYYY/WW`. Wrong-typed values →
+   `PathRenderFailed` at render; missing field → un-renderable. In
+   `plan_query`, a wrong-typed/unparseable query value degrades to
+   un-renderable (wildcard walk) instead of erroring, matching how opaque
+   filter values widen the walk today.
+2. **Query pruning** (`rust/gitsheets-core/src/query.rs`): include
+   `Value::Datetime` in `prune_record`'s scalar set so a datetime-valued
+   equality filter reaches the bucket components and prunes the walk.
+3. **Host TS renderer** (`packages/gitsheets/src/path-template/index.ts`):
+   mirror the parser rule and add a `bucket` part kind; render from JS `Date`
+   (UTC accessors) and ISO strings — offset-less strings are read literally
+   (never `new Date(...)`, which would consult the host timezone); ISO week
+   via the standard nearest-Thursday algorithm, matching chrono exactly.
+   Invalid format → `ConfigError('config_invalid')`; `getFieldNames`
+   contributes the bucket's (base) field name.
+4. **napi reference renderer** (`rust/gitsheets-napi/test/_ref-path-template.mjs`):
+   extend in lockstep (it is the parity oracle), plus bucket corpus cases and
+   error cases in `test/path-template.mjs`, and a bucket-pruning walk case in
+   `test/record-query.mjs`.
+5. **Python cross-binding parity**: bucket render cases over the same core via
+   `render_paths_batch` in `rust/gitsheets-py` tests if the harness builds
+   cheaply in this environment.
+6. **Package tests**: vitest cases in `path-template/index.test.ts` (each
+   format, padding, ISO week-year boundaries, string vs Date inputs,
+   rejections, config-time enum validation) plus an end-to-end sheet
+   write/query with a bucketed config.
+7. **Docs**: extend `docs/path-templates.md` with the bucket form and
+   day/week/month examples.
+
+## Validation
+
+- [ ] `cargo test` green across the workspace, including new core cases: each
+  format; zero-padding; ISO week-year boundaries (2027-01-01 → `2026/53`,
+  2024-12-30 → `2025/01`); offset-datetime UTC conversion; string vs datetime
+  inputs; wrong-type and unparseable-string rejection; invalid-format
+  `config_invalid` at compile; bucket-must-stand-alone rejection; bucket
+  pruning + wildcard walk in `query.rs`
+- [ ] napi suite green (`node --test`), including bucket parity vs the
+  reference renderer and the error-path cases
+- [ ] Package vitest suite green, including TS `Template` bucket cases and an
+  end-to-end bucketed sheet upsert/query through the core
+- [ ] `npm run type-check` clean
+- [ ] `docs/path-templates.md` documents the bucket forms with day/month/week
+  examples
+
+## Risks / unknowns
+
+- **Multi-segment expansion vs the walk** — the walk machinery is strictly
+  one-component-per-tree-level, so expansion must happen at parse time (one
+  bucket token → N components), not at render time. Mitigated by expanding in
+  the parser; `component_count` and the walk see ordinary components.
+- **ISO-week parity between chrono and the TS implementation** — hand-rolled
+  TS week math could diverge from `iso_week()` on boundary dates. Mitigated
+  with boundary-date tests on both sides and napi parity cases.
+- **`prune_record` widening** — admitting datetimes into the prune record
+  also exposes them to expression components at plan time (previously they
+  were stripped, so expressions were un-renderable and the walk widened).
+  Rendered plans stay consistent with write-time renders (same engine, same
+  marshal), so results are identical and pruning only improves; the
+  divergence note in `query.rs` is updated.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/date-bucket-path-keys.md
+++ b/plans/date-bucket-path-keys.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/behaviors/path-templates.md
 issues: [252]
+pr: 253
 ---
 
 # Plan: declarative date-bucket path keys
@@ -87,18 +88,18 @@ Out of scope:
 
 ## Validation
 
-- [ ] `cargo test` green across the workspace, including new core cases: each
+- [x] `cargo test` green across the workspace, including new core cases: each
   format; zero-padding; ISO week-year boundaries (2027-01-01 → `2026/53`,
   2024-12-30 → `2025/01`); offset-datetime UTC conversion; string vs datetime
   inputs; wrong-type and unparseable-string rejection; invalid-format
   `config_invalid` at compile; bucket-must-stand-alone rejection; bucket
   pruning + wildcard walk in `query.rs`
-- [ ] napi suite green (`node --test`), including bucket parity vs the
+- [x] napi suite green (`node --test`), including bucket parity vs the
   reference renderer and the error-path cases
-- [ ] Package vitest suite green, including TS `Template` bucket cases and an
+- [x] Package vitest suite green, including TS `Template` bucket cases and an
   end-to-end bucketed sheet upsert/query through the core
-- [ ] `npm run type-check` clean
-- [ ] `docs/path-templates.md` documents the bucket forms with day/month/week
+- [x] `npm run type-check` clean
+- [x] `docs/path-templates.md` documents the bucket forms with day/month/week
   examples
 
 ## Risks / unknowns
@@ -119,8 +120,39 @@ Out of scope:
 
 ## Notes
 
-(Populated at closeout.)
+- Verified totals at closeout: core 184 (`cargo test`, 18 new bucket cases) +
+  clippy `-D warnings` clean, napi 113 (`node --test`, 5 new), vitest 361
+  (gitsheets, 23 new) + 118 (gitsheets-axi), pytest 36 (5 new), type-check
+  clean.
+- **Rider fix shipped with this plan**: the 0.2.0 manifest-sync lockfile
+  refresh had pinned a nested *registry* copy of `@gitsheets/core-napi` under
+  `packages/gitsheets/node_modules`, so all core-routed vitest ran against
+  the published binaries — masking any core behavior change (this branch's
+  e2e tests failed against it until fixed). Resolved with a targeted
+  `npm uninstall`/`npm install -w gitsheets` that drops the nested lockfile
+  entry; the workspace link now resolves everywhere, matching what the CI
+  workflow comment already claimed. Watch for the nested entry reappearing
+  on future post-release lockfile refreshes.
+- Query-time semantics decided during implementation (specced): a
+  wrong-typed / unparseable query value on a bucketed field degrades to a
+  wildcard walk (record-level filter still applies) rather than erroring —
+  consistent with how opaque filter values widen the walk. Write-time stays
+  a hard `PathTemplateError`.
+- Datetime equality filters now enter `prune_record` (they were previously
+  stripped). Plain `${{ field }}` references still treat datetimes as
+  un-renderable; bucket and UTC-accessor expression components can now prune
+  on them. Results identical, strictly better pruning; divergence note in
+  `query.rs` updated.
+- Dotted bucket fields (`${{ meta.publishedAt: YYYY/MM }}`) read nested
+  tables; `getFieldNames` contributes the base segment, matching the
+  expression scan's member-access behavior.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- Tracked as: range-pruned queries (date-range filters mapped onto bounded
+  subtree walks) — the follow-up the declarative bucket form enables; noted
+  in the spec's "Query traversal semantics" and on
+  [#252](https://github.com/JarvusInnovations/gitsheets/issues/252).
+- Tracked as: bare `Date`-in-path `.toString()` rendering remains a wart for
+  non-bucket references (host-formatted, TZ-dependent) — recorded in the
+  spec's rejected-alternative note.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -836,6 +836,7 @@ name = "gitsheets-core"
 version = "0.0.0"
 dependencies = [
  "boa_engine",
+ "chrono",
  "dprint-plugin-markdown",
  "gix",
  "holo-tree",

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -83,6 +83,13 @@ dprint-plugin-markdown = "=0.22.1"
 # (no runtime data load). Held to 2.0.x because boa_engine 0.21.1 pins
 # `icu_normalizer ~2.0`; a newer icu_collator would diverge that shared dep.
 icu_collator = "=2.0.0"
+# ── date-bucket path keys (declarative `${{ field: YYYY/MM/DD }}` rendering) ─
+# Calendar math for date-bucket path segments: UTC normalization of offset
+# datetimes, ISO 8601 string parsing, and ISO-8601 week / week-based-year
+# (`iso_week()`) for the `YYYY/WW` format — deliberately NOT hand-rolled and
+# NOT routed through the boa engine, so bucket paths are UTC-deterministic on
+# every host. default-features off: no clock/TZ lookup — the core never
+# consults host time or timezone. Already in-tree transitively (gix, bindings).
 chrono = { version = "0.4.45", default-features = false, features = ["std"] }
 
 [dev-dependencies]

--- a/rust/gitsheets-core/Cargo.toml
+++ b/rust/gitsheets-core/Cargo.toml
@@ -83,6 +83,7 @@ dprint-plugin-markdown = "=0.22.1"
 # (no runtime data load). Held to 2.0.x because boa_engine 0.21.1 pins
 # `icu_normalizer ~2.0`; a newer icu_collator would diverge that shared dep.
 icu_collator = "=2.0.0"
+chrono = { version = "0.4.45", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 # Throwaway git repos for the record-CRUD + diff integration tests.

--- a/rust/gitsheets-core/src/path_template.rs
+++ b/rust/gitsheets-core/src/path_template.rs
@@ -11,17 +11,24 @@
 //!
 //! - **Literal** and **field-reference** (`${{ slug }}`) components render
 //!   **natively** over the core [`Value`] — the declarative-first common case.
+//! - **Date-bucket** components (`${{ publishedAt: YYYY/MM/DD }}`) also render
+//!   **natively**, via chrono — never through the engine, so bucket paths are
+//!   UTC-deterministic by construction (see the spec's "Date-bucket
+//!   references"). One bucket token expands at *parse* time into one component
+//!   per format part, so the query walk sees ordinary one-level components.
 //! - **Expression** components (`${{ publishedAt.getUTCFullYear() }}`) are the
 //!   escape hatch: compiled once into the embedded [`Engine`] and evaluated per
-//!   record. This is where partition derivations (date-parts, etc.) live, and
-//!   it is the path-template half of the `node:vm` parity gate.
+//!   record. This is where partition derivations beyond the closed bucket enum
+//!   live, and it is the path-template half of the `node:vm` parity gate.
 //!
 //! Query-tree traversal/pruning (the *other* job of a parsed template) is a
 //! record-engine concern and lands downstream; this module owns parse + render.
 
+use chrono::{Datelike, NaiveDate};
+
 use crate::engine::{Engine, SnippetError, SnippetHandle};
 use crate::error::{Error, Result};
-use crate::value::Value;
+use crate::value::{Datetime, Value};
 
 /// One parsed path component (a slash-separated segment), made of one or more
 /// parts. A pure field-reference / literal component renders natively; a
@@ -40,6 +47,16 @@ enum Part {
         name: String,
         recursive: bool,
     },
+    /// One segment of a date-bucket reference (`${{ field: YYYY/MM/DD }}`).
+    /// The parser expands a bucket token into one `Bucket` part per format
+    /// part, each its own component, so a `YYYY/MM/DD` bucket creates three
+    /// real tree levels.
+    Bucket {
+        /// The referenced field, split on `.` (dotted references read nested
+        /// tables).
+        field: Vec<String>,
+        unit: BucketUnit,
+    },
     Expression {
         handle: SnippetHandle,
         /// The raw expression source (inside `${{ … }}`), retained for
@@ -47,6 +64,30 @@ enum Part {
         source: String,
     },
 }
+
+/// One path segment's date-bucket unit. `YYYY` in a `YYYY/WW` bucket is the
+/// ISO week-based year ([`BucketUnit::IsoWeekYear`]), a *different* value from
+/// the calendar year near year boundaries — see the spec's ISO-week rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BucketUnit {
+    CalendarYear,
+    Month,
+    Day,
+    IsoWeekYear,
+    IsoWeek,
+}
+
+/// The closed format enum. Deliberately not a format language: anything
+/// outside this set is `ConfigError('config_invalid')` at sheet-open.
+const BUCKET_FORMATS: &[(&str, &[BucketUnit])] = &[
+    ("YYYY", &[BucketUnit::CalendarYear]),
+    ("YYYY/MM", &[BucketUnit::CalendarYear, BucketUnit::Month]),
+    (
+        "YYYY/MM/DD",
+        &[BucketUnit::CalendarYear, BucketUnit::Month, BucketUnit::Day],
+    ),
+    ("YYYY/WW", &[BucketUnit::IsoWeekYear, BucketUnit::IsoWeek]),
+];
 
 /// One component's contribution to a query-tree walk: the value it renders to
 /// against the (partial) query — `None` when un-renderable, in which case the
@@ -101,7 +142,7 @@ impl Template {
     pub fn render(&self, record: &Value, engine: &mut Engine) -> Result<String> {
         let mut segments = Vec::with_capacity(self.components.len());
         for (i, component) in self.components.iter().enumerate() {
-            let rendered = self.render_component(component, record, engine)?;
+            let rendered = self.render_component(component, record, engine, true)?;
             let Some(rendered) = rendered else {
                 return Err(Error::PathRenderFailed {
                     message: format!(
@@ -117,19 +158,38 @@ impl Template {
     }
 
     /// Render a single component to `Some(text)` or `None` (un-renderable).
-    /// Returns `Err` only for a genuine engine failure (a non-reference JS
-    /// exception while evaluating an expression).
+    /// Returns `Err` for a genuine engine failure (a non-reference JS
+    /// exception while evaluating an expression) — and, in `strict` mode
+    /// (full-record `render`), for a date-bucket field holding a value that
+    /// isn't a date (wrong type / unparseable string). In non-strict mode
+    /// (query planning) a bad bucket value degrades to un-renderable so the
+    /// walk widens instead of erroring — matching how opaque filter values
+    /// widen the walk today (spec: "Query traversal semantics").
     fn render_component(
         &self,
         component: &Component,
         record: &Value,
         engine: &mut Engine,
+        strict: bool,
     ) -> Result<Option<String>> {
         let mut out = String::new();
         for part in &component.parts {
             let piece = match part {
                 Part::Literal(text) => Some(text.clone()),
                 Part::Field { name, .. } => field_to_string(record, name),
+                Part::Bucket { field, unit } => match bucket_date(record, field) {
+                    Ok(Some(date)) => Some(render_bucket_unit(&date, *unit)),
+                    Ok(None) => None,
+                    Err(detail) if strict => {
+                        return Err(Error::PathRenderFailed {
+                            message: format!(
+                                "date-bucket reference in \"{}\": {detail}",
+                                self.source
+                            ),
+                        });
+                    }
+                    Err(_) => None,
+                },
                 Part::Expression { handle, .. } => match engine.call(*handle, std::slice::from_ref(record)) {
                     Ok(value) => engine.to_path_string(&value),
                     // An undefined identifier is "un-renderable", not fatal —
@@ -176,6 +236,15 @@ impl Template {
                             out.push(name.clone());
                         }
                     }
+                    // A bucket contributes its base (top-level) field name —
+                    // the same contribution an expression scan would make for
+                    // a dotted member access.
+                    Part::Bucket { field, .. } => {
+                        let name = &field[0];
+                        if seen.insert(name.clone()) {
+                            out.push(name.clone());
+                        }
+                    }
                     Part::Expression { source, .. } => {
                         for id in extract_identifiers(source) {
                             if seen.insert(id.clone()) {
@@ -204,7 +273,7 @@ impl Template {
     ) -> Result<Vec<QueryComponentPlan>> {
         let mut out = Vec::with_capacity(self.components.len());
         for c in &self.components {
-            let rendered = self.render_component(c, query, engine)?;
+            let rendered = self.render_component(c, query, engine, false)?;
             out.push(QueryComponentPlan {
                 rendered,
                 recursive: c.recursive,
@@ -296,6 +365,102 @@ fn format_js_number(f: f64) -> String {
     }
 }
 
+// ── date-bucket rendering (spec: "Date-bucket references") ───────────────────
+
+/// Resolve a (possibly dotted) bucket field against `record` and reduce it to
+/// the **UTC calendar date** the bucket partitions on.
+///
+/// - `Ok(None)` — the field (or a dotted ancestor) is absent: the component is
+///   un-renderable, same as the existing missing-field rule.
+/// - `Err(detail)` — the field is present but isn't a date: wrong type, a TOML
+///   local-time, or an unparseable string. `render` (strict) surfaces this as
+///   `PathRenderFailed`; query planning degrades it to un-renderable.
+fn bucket_date(record: &Value, field: &[String]) -> std::result::Result<Option<NaiveDate>, String> {
+    let mut current = record;
+    for seg in field {
+        let Value::Table(map) = current else {
+            return Ok(None);
+        };
+        match map.get(seg) {
+            Some(v) => current = v,
+            None => return Ok(None),
+        }
+    }
+    let name = field.join(".");
+    match current {
+        Value::Datetime(dt) => date_from_toml_datetime(dt, &name).map(Some),
+        Value::String(s) => parse_iso_date(s, &name).map(Some),
+        other => Err(format!(
+            "field \"{name}\" has type {} — date-bucket fields accept TOML \
+             datetime/local-datetime/local-date values or ISO 8601 strings",
+            other.type_name()
+        )),
+    }
+}
+
+/// The UTC calendar date of a TOML datetime. **UTC always**: an offset
+/// datetime is normalized to UTC before its date parts are read; offset-less
+/// kinds (local datetime, local date) are taken at face value — bucket
+/// rendering never consults a timezone.
+fn date_from_toml_datetime(
+    dt: &Datetime,
+    name: &str,
+) -> std::result::Result<NaiveDate, String> {
+    let Datetime(inner) = dt;
+    let Some(date) = inner.date else {
+        return Err(format!(
+            "field \"{name}\" is a TOML local-time, which has no date to bucket on"
+        ));
+    };
+    let date = NaiveDate::from_ymd_opt(date.year as i32, date.month as u32, date.day as u32)
+        .ok_or_else(|| format!("field \"{name}\" has an out-of-range date"))?;
+    let (Some(time), Some(offset)) = (inner.time, inner.offset) else {
+        return Ok(date);
+    };
+    // Wall-clock components at `offset` → the instant's UTC date.
+    let offset_minutes: i64 = match offset {
+        toml::value::Offset::Z => 0,
+        toml::value::Offset::Custom { minutes } => minutes as i64,
+    };
+    let wall = date
+        .and_hms_opt(time.hour as u32, time.minute as u32, time.second as u32)
+        .ok_or_else(|| format!("field \"{name}\" has an out-of-range time"))?;
+    let utc = wall - chrono::Duration::minutes(offset_minutes);
+    Ok(utc.date())
+}
+
+/// The UTC calendar date of an ISO 8601 string: date-only (`2026-03-09`),
+/// datetime without offset (taken at face value), or datetime with offset /
+/// `Z` (normalized to UTC).
+fn parse_iso_date(s: &str, name: &str) -> std::result::Result<NaiveDate, String> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.to_utc().date_naive());
+    }
+    if let Ok(dt) = s.parse::<chrono::NaiveDateTime>() {
+        return Ok(dt.date());
+    }
+    if let Ok(d) = s.parse::<NaiveDate>() {
+        return Ok(d);
+    }
+    Err(format!(
+        "field \"{name}\" value {s:?} is not an ISO 8601 date or datetime"
+    ))
+}
+
+/// Render one bucket unit of `date`, zero-padded (`MM`/`DD`/`WW` two digits,
+/// years four). `YYYY/WW` uses ISO-8601 week numbering, where the year is the
+/// ISO **week-based** year — near January 1 / December 31 it can differ from
+/// the calendar year (2027-01-01 is ISO 2026-W53).
+fn render_bucket_unit(date: &NaiveDate, unit: BucketUnit) -> String {
+    match unit {
+        BucketUnit::CalendarYear => format!("{:04}", date.year()),
+        BucketUnit::Month => format!("{:02}", date.month()),
+        BucketUnit::Day => format!("{:02}", date.day()),
+        BucketUnit::IsoWeekYear => format!("{:04}", date.iso_week().year()),
+        BucketUnit::IsoWeek => format!("{:02}", date.iso_week().week()),
+    }
+}
+
 // ── invalid-character rejection ───────────────────────────────────────────────
 
 fn is_windows_invalid(c: char) -> bool {
@@ -336,6 +501,35 @@ fn is_field_name(s: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
+/// Recognize a date-bucket *attempt*: `<field(.dotted)?> : <format>`. Returns
+/// the dotted field segments and the raw format text. Format validation
+/// against the closed enum happens at the call site, so an unknown format is
+/// `config_invalid` rather than falling through to the expression compiler.
+///
+/// Recognizing this shape breaks no working template: `(field: ...)` is a JS
+/// labeled statement inside the renderer's `return (...)` wrapper — a
+/// guaranteed syntax error — so the colon-after-identifier space was dead.
+fn split_bucket_attempt(expr: &str) -> Option<(Vec<String>, &str)> {
+    let (head, tail) = expr.split_once(':')?;
+    let head = head.trim();
+    if head.is_empty() {
+        return None;
+    }
+    let segments: Vec<&str> = head.split('.').collect();
+    let is_ident = |s: &&str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    };
+    if !segments.iter().all(is_ident) {
+        return None;
+    }
+    Some((
+        segments.into_iter().map(str::to_string).collect(),
+        tail.trim(),
+    ))
+}
+
 fn parse_template(source: &str, engine: &mut Engine) -> Result<Vec<Component>> {
     let normalized = source.trim_matches('/');
     if normalized.is_empty() {
@@ -372,6 +566,47 @@ fn parse_template(source: &str, engine: &mut Engine) -> Result<Vec<Component>> {
             }
             let expr = expr.trim().to_string();
             i += 2;
+
+            // Date-bucket reference — recognized BEFORE the expression
+            // fallback (spec: "Date-bucket references § Grammar").
+            if let Some((field, format_src)) = split_bucket_attempt(&expr) {
+                let units = BUCKET_FORMATS
+                    .iter()
+                    .find(|(f, _)| *f == format_src)
+                    .map(|(_, units)| *units);
+                let Some(units) = units else {
+                    return Err(Error::ConfigInvalid {
+                        message: format!(
+                            "invalid date-bucket format {format_src:?} in \"${{{{ {expr} }}}}\" — \
+                             supported formats: YYYY, YYYY/MM, YYYY/MM/DD, YYYY/WW"
+                        ),
+                    });
+                };
+                // A bucket expands into multiple real segments, so it must
+                // stand alone in its path segment: nothing already in the
+                // segment (any pending literal was flushed above), and a `/`
+                // or end-of-template after it.
+                let standalone_before = segments.last().unwrap().is_empty();
+                let standalone_after = i >= chars.len() || chars[i] == '/';
+                if !standalone_before || !standalone_after {
+                    return Err(Error::ConfigInvalid {
+                        message: format!(
+                            "date-bucket reference \"${{{{ {expr} }}}}\" must stand alone in its \
+                             path segment — no literal prefix/suffix or adjacent references"
+                        ),
+                    });
+                }
+                for (idx, unit) in units.iter().enumerate() {
+                    if idx > 0 {
+                        segments.push(Vec::new());
+                    }
+                    segments.last_mut().unwrap().push(Part::Bucket {
+                        field: field.clone(),
+                        unit: *unit,
+                    });
+                }
+                continue;
+            }
 
             if is_field_name(&expr) {
                 let recursive = expr.ends_with("/**");
@@ -624,6 +859,223 @@ mod tests {
         assert_eq!(field_names("${{ (slug || legacyId) }}"), vec!["slug", "legacyId"]);
         // Reserved words / globals are excluded; `id` survives.
         assert_eq!(field_names("shard-${{ id % 4 }}/${{ id }}"), vec!["id"]);
+    }
+
+    // ── date-bucket references (spec: "Date-bucket references") ─────────────
+
+    fn dt(s: &str) -> Value {
+        Value::Datetime(s.parse().unwrap())
+    }
+
+    #[test]
+    fn bucket_renders_each_format() {
+        let r = table(&[("publishedAt", dt("2026-03-09T12:00:00Z")), ("slug", Value::String("hi".into()))]);
+        assert_eq!(render("${{ publishedAt: YYYY }}/${{ slug }}", &r).unwrap(), "2026/hi");
+        assert_eq!(render("${{ publishedAt: YYYY/MM }}/${{ slug }}", &r).unwrap(), "2026/03/hi");
+        assert_eq!(
+            render("${{ publishedAt: YYYY/MM/DD }}/${{ slug }}", &r).unwrap(),
+            "2026/03/09/hi"
+        );
+        // 2026-03-09 is a Monday in ISO week 11 of week-year 2026.
+        assert_eq!(render("${{ publishedAt: YYYY/WW }}/${{ slug }}", &r).unwrap(), "2026/11/hi");
+    }
+
+    #[test]
+    fn bucket_zero_pads_two_digit_parts() {
+        let r = table(&[("d", dt("2026-01-02"))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2026/01/02");
+        // Week 1 pads too (2026-01-02 is ISO 2026-W01).
+        assert_eq!(render("${{ d: YYYY/WW }}", &r).unwrap(), "2026/01");
+    }
+
+    #[test]
+    fn iso_week_year_is_not_the_calendar_year_at_boundaries() {
+        // January 1 belonging to week 53 of the PRIOR ISO year.
+        let r = table(&[("d", dt("2027-01-01"))]);
+        assert_eq!(render("${{ d: YYYY/WW }}", &r).unwrap(), "2026/53");
+        // ...while the calendar-year formats keep the calendar year.
+        assert_eq!(render("${{ d: YYYY }}", &r).unwrap(), "2027");
+
+        // Late December belonging to week 1 of the NEXT ISO year.
+        let r = table(&[("d", dt("2024-12-30"))]);
+        assert_eq!(render("${{ d: YYYY/WW }}", &r).unwrap(), "2025/01");
+        assert_eq!(render("${{ d: YYYY }}", &r).unwrap(), "2024");
+    }
+
+    #[test]
+    fn bucket_normalizes_offset_datetimes_to_utc() {
+        // 23:30 at -05:00 is 04:30 the NEXT day in UTC.
+        let r = table(&[("d", dt("2025-12-31T23:30:00-05:00"))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2026/01/01");
+        // And the other direction: 00:30+05:00 is the PREVIOUS day in UTC.
+        let r = table(&[("d", dt("2026-01-01T00:30:00+05:00"))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2025/12/31");
+    }
+
+    #[test]
+    fn bucket_takes_offsetless_values_at_face_value() {
+        // TOML local-datetime and local-date have no offset: no TZ math.
+        let r = table(&[("d", dt("2026-03-09T23:59:59"))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2026/03/09");
+        let r = table(&[("d", dt("2026-03-09"))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2026/03/09");
+    }
+
+    #[test]
+    fn bucket_accepts_iso_strings() {
+        let r = table(&[("d", Value::String("2026-03-09".into()))]);
+        assert_eq!(render("${{ d: YYYY/MM }}", &r).unwrap(), "2026/03");
+        // Offset string normalizes to UTC.
+        let r = table(&[("d", Value::String("2025-12-31T23:30:00-05:00".into()))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2026/01/01");
+        // Offset-less datetime string reads at face value.
+        let r = table(&[("d", Value::String("2026-03-09T23:59:59".into()))]);
+        assert_eq!(render("${{ d: YYYY/MM/DD }}", &r).unwrap(), "2026/03/09");
+    }
+
+    #[test]
+    fn bucket_may_be_the_entire_path() {
+        // Daily-rollup identity: the bucket IS the record key.
+        let r = table(&[("day", dt("2026-03-09"))]);
+        assert_eq!(render("${{ day: YYYY/MM/DD }}", &r).unwrap(), "2026/03/09");
+    }
+
+    #[test]
+    fn bucket_composes_anywhere_in_the_template() {
+        let r = table(&[
+            ("region", Value::String("us".into())),
+            ("d", dt("2026-03-09")),
+            ("slug", Value::String("x".into())),
+        ]);
+        assert_eq!(
+            render("posts/${{ region }}/${{ d: YYYY/MM }}/${{ slug }}", &r).unwrap(),
+            "posts/us/2026/03/x"
+        );
+    }
+
+    #[test]
+    fn bucket_dotted_field_reads_nested_tables() {
+        let mut meta = IndexMap::new();
+        meta.insert("publishedAt".to_string(), dt("2026-03-09"));
+        let r = table(&[("meta", Value::Table(meta)), ("slug", Value::String("x".into()))]);
+        assert_eq!(
+            render("${{ meta.publishedAt: YYYY/MM }}/${{ slug }}", &r).unwrap(),
+            "2026/03/x"
+        );
+    }
+
+    #[test]
+    fn bucket_missing_field_follows_the_missing_field_rule() {
+        let r = table(&[("slug", Value::String("x".into()))]);
+        let err = render("${{ d: YYYY/MM }}/${{ slug }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_render_failed");
+    }
+
+    #[test]
+    fn bucket_wrong_type_fails_render_with_a_naming_message() {
+        for v in [Value::Integer(42), Value::Boolean(true), Value::Float(1.5)] {
+            let r = table(&[("d", v), ("slug", Value::String("x".into()))]);
+            let err = render("${{ d: YYYY/MM }}/${{ slug }}", &r).unwrap_err();
+            assert_eq!(err.code(), "path_render_failed");
+            assert!(err.message().contains("\"d\""), "message names the field: {}", err.message());
+        }
+    }
+
+    #[test]
+    fn bucket_unparseable_string_fails_render() {
+        let r = table(&[("d", Value::String("not-a-date".into()))]);
+        let err = render("${{ d: YYYY }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_render_failed");
+        assert!(err.message().contains("not-a-date"));
+    }
+
+    #[test]
+    fn bucket_toml_local_time_fails_render() {
+        let r = table(&[("d", dt("07:32:00"))]);
+        let err = render("${{ d: YYYY }}", &r).unwrap_err();
+        assert_eq!(err.code(), "path_render_failed");
+        assert!(err.message().contains("local-time"));
+    }
+
+    #[test]
+    fn bucket_invalid_format_is_config_invalid_at_compile() {
+        let mut eng = Engine::new().unwrap();
+        for bad in ["YYYY-MM", "MM/DD", "YYYY/MM/DD/HH", "yyyy", "WW", ""] {
+            let src = format!("${{{{ d: {bad} }}}}/${{{{ slug }}}}");
+            let err = Template::compile(&src, &mut eng).unwrap_err();
+            assert_eq!(err.code(), "config_invalid", "format {bad:?}");
+            assert!(err.message().contains("YYYY/MM/DD"), "message lists valid formats");
+        }
+    }
+
+    #[test]
+    fn bucket_must_stand_alone_in_its_segment() {
+        let mut eng = Engine::new().unwrap();
+        for bad in [
+            "posts-${{ d: YYYY }}",             // literal prefix
+            "${{ d: YYYY }}.draft",             // literal suffix
+            "${{ d: YYYY }}${{ slug }}",        // adjacent reference
+            "${{ slug }}-${{ d: YYYY/MM }}",    // reference prefix
+        ] {
+            let err = Template::compile(bad, &mut eng).unwrap_err();
+            assert_eq!(err.code(), "config_invalid", "template {bad:?}");
+        }
+    }
+
+    #[test]
+    fn bucket_expands_component_count() {
+        let mut eng = Engine::new().unwrap();
+        let t = Template::compile("${{ d: YYYY/MM/DD }}/${{ slug }}", &mut eng).unwrap();
+        assert_eq!(t.component_count(), 4);
+        let t = Template::compile("${{ d: YYYY/WW }}", &mut eng).unwrap();
+        assert_eq!(t.component_count(), 2);
+    }
+
+    #[test]
+    fn get_field_names_includes_bucket_fields_once() {
+        assert_eq!(
+            field_names("${{ publishedAt: YYYY/MM/DD }}/${{ slug }}"),
+            vec!["publishedAt", "slug"]
+        );
+        // Dotted bucket contributes its base field, like an expression scan.
+        assert_eq!(
+            field_names("${{ meta.publishedAt: YYYY/MM }}/${{ slug }}"),
+            vec!["meta", "slug"]
+        );
+    }
+
+    #[test]
+    fn plan_query_renders_buckets_from_query_values_and_wildcards_otherwise() {
+        let mut eng = Engine::new().unwrap();
+        let t = Template::compile("${{ d: YYYY/MM }}/${{ slug }}", &mut eng).unwrap();
+
+        // Datetime query value → both bucket segments render.
+        let q = table(&[("d", dt("2026-03-09T12:00:00Z"))]);
+        let plan = t.plan_query(&q, &mut eng).unwrap();
+        let rendered: Vec<Option<&str>> = plan.iter().map(|p| p.rendered.as_deref()).collect();
+        assert_eq!(rendered, vec![Some("2026"), Some("03"), None]);
+
+        // ISO-string query value renders too.
+        let q = table(&[("d", Value::String("2026-03-09".into()))]);
+        let plan = t.plan_query(&q, &mut eng).unwrap();
+        assert_eq!(plan[0].rendered.as_deref(), Some("2026"));
+        assert_eq!(plan[1].rendered.as_deref(), Some("03"));
+
+        // Absent field → wildcard (None), not an error.
+        let q = table(&[("slug", Value::String("x".into()))]);
+        let plan = t.plan_query(&q, &mut eng).unwrap();
+        assert_eq!(plan[0].rendered, None);
+        assert_eq!(plan[1].rendered, None);
+        assert_eq!(plan[2].rendered.as_deref(), Some("x"));
+
+        // Wrong-typed / unparseable query value degrades to wildcard — the
+        // walk widens; the record-level filter still applies downstream.
+        for v in [Value::Integer(42), Value::String("not-a-date".into())] {
+            let q = table(&[("d", v)]);
+            let plan = t.plan_query(&q, &mut eng).unwrap();
+            assert_eq!(plan[0].rendered, None);
+            assert_eq!(plan[1].rendered, None);
+        }
     }
 
     #[test]

--- a/rust/gitsheets-core/src/query.rs
+++ b/rust/gitsheets-core/src/query.rs
@@ -38,10 +38,13 @@
 //! so an integer filter does not equal a float-stored field. This is the same
 //! bytes-authority int/float distinction the value type carries everywhere.
 //!
-//! *Datetime as a path/prune field* — a datetime field renders to `None` in the
-//! core path layer (see `path_template`), so a component keyed on a datetime is
-//! treated as un-renderable and the walk expands rather than prunes — fewer
-//! records pruned, identical final results.
+//! *Datetime as a path/prune field* — a datetime field renders to `None` for a
+//! plain `${{ field }}` reference (see `path_template`), so such a component
+//! keyed on a datetime is treated as un-renderable and the walk expands rather
+//! than prunes — fewer records pruned, identical final results. Datetime
+//! equality values DO enter the prune record (see [`prune_record`]) so that
+//! date-*bucket* components (`${{ field: YYYY/MM/DD }}`) — and expression
+//! components using UTC accessors — prune to the exact rendered path.
 
 use holo_tree::{Child, MutableTree, ObjectId};
 
@@ -137,17 +140,27 @@ fn predicate_error(field: &str, e: SnippetError) -> Error {
 
 /// The scalar equality fields of a filter, as a `Value::Table` — the partial
 /// "record" the template renders against for pruning. Only top-level scalar
-/// equality clauses contribute (predicates, nested filters, arrays, and
-/// datetimes render to nothing / un-renderable, so they widen the walk exactly
-/// as the host's `queryTree` does when it renders the full query object and a
+/// equality clauses contribute (predicates, nested filters, and arrays render
+/// to nothing / un-renderable, so they widen the walk exactly as the host's
+/// `queryTree` does when it renders the full query object and a
 /// function/object/array value stringifies to `undefined`).
+///
+/// Datetimes are included so a datetime-valued equality filter prunes a
+/// date-*bucket* component to its exact rendered path (spec:
+/// "Date-bucket references § Query traversal semantics"). A plain
+/// `${{ field }}` reference still treats a datetime as un-renderable
+/// (`field_to_string` → `None`), preserving the walk-widening behavior there.
 pub fn prune_record(filter: &Filter) -> Value {
     let mut map = indexmap::IndexMap::new();
     for (key, pred) in &filter.0 {
         if let FilterPred::Equals(v) = pred {
             if matches!(
                 v,
-                Value::String(_) | Value::Integer(_) | Value::Float(_) | Value::Boolean(_)
+                Value::String(_)
+                    | Value::Integer(_)
+                    | Value::Float(_)
+                    | Value::Boolean(_)
+                    | Value::Datetime(_)
             ) {
                 map.insert(key.clone(), v.clone());
             }
@@ -422,6 +435,57 @@ mod tests {
                 .unwrap();
         let paths: Vec<&str> = out.iter().map(|(p, _)| p.as_str()).collect();
         assert_eq!(paths, vec!["bob"]);
+    }
+
+    #[test]
+    fn date_bucket_prunes_when_field_supplied_and_wildcards_when_absent() {
+        // Bucketed template: one bucket token = two real tree levels.
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        let dt = |s: &str| Value::Datetime(s.parse().unwrap());
+        let items = vec![
+            ("2026/03/a".to_string(), rec(&[("publishedAt", dt("2026-03-09T12:00:00Z")), ("slug", s("a"))])),
+            ("2026/04/b".to_string(), rec(&[("publishedAt", dt("2026-04-01T00:00:00Z")), ("slug", s("b"))])),
+            ("2025/12/c".to_string(), rec(&[("publishedAt", dt("2025-12-31T09:00:00Z")), ("slug", s("c"))])),
+        ];
+        let hash = write_records(&repo, &mut tree, "posts", &items, TOML_EXTENSION)
+            .unwrap()
+            .tree_hash;
+        let mut tree = resolve_tree(&repo, &hash).unwrap();
+        let mut eng = Engine::new().unwrap();
+        let template =
+            Template::compile("${{ publishedAt: YYYY/MM }}/${{ slug }}", &mut eng).unwrap();
+
+        // Datetime equality filter reaches the bucket components via
+        // prune_record and descends the exact rendered bucket path.
+        let q = rec(&[("publishedAt", dt("2026-03-09T12:00:00Z"))]);
+        let paths =
+            query_candidate_paths(&repo, &mut tree, "posts", &template, &q, &mut eng, TOML_EXTENSION)
+                .unwrap();
+        assert_eq!(paths, vec!["2026/03/a"]);
+
+        // No bucket field in the query → bucket segments are wildcards.
+        let all = query_candidate_paths(
+            &repo,
+            &mut tree,
+            "posts",
+            &template,
+            &Value::Table(IndexMap::new()),
+            &mut eng,
+            TOML_EXTENSION,
+        )
+        .unwrap();
+        assert_eq!(all, vec!["2025/12/c", "2026/03/a", "2026/04/b"]);
+
+        // End-to-end: a datetime equality filter both prunes AND matches
+        // (core datetime equality is structural).
+        let mut filter = Filter::new();
+        filter.push("publishedAt", FilterPred::Equals(dt("2026-03-09T12:00:00Z")));
+        let out =
+            query_records(&repo, &mut tree, "posts", &template, &filter, &mut eng, TOML_EXTENSION)
+                .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0, "2026/03/a");
     }
 
     #[test]

--- a/rust/gitsheets-napi/test/_ref-path-template.mjs
+++ b/rust/gitsheets-napi/test/_ref-path-template.mjs
@@ -51,6 +51,103 @@ function stringifyValue(value) {
   return undefined;
 }
 
+// --- Date buckets (transcribed from the production renderer; spec:
+// specs/behaviors/path-templates.md § "Date-bucket references") ---
+
+const BUCKET_FORMATS = {
+  'YYYY': ['YYYY'],
+  'YYYY/MM': ['YYYY', 'MM'],
+  'YYYY/MM/DD': ['YYYY', 'MM', 'DD'],
+  'YYYY/WW': ['isoYYYY', 'WW'],
+};
+
+const BUCKET_FIELD_SEGMENT_RE = /^[a-zA-Z0-9_-]+$/;
+
+function splitBucketAttempt(source) {
+  const idx = source.indexOf(':');
+  if (idx === -1) return undefined;
+  const head = source.slice(0, idx).trim();
+  if (head === '') return undefined;
+  const field = head.split('.');
+  if (!field.every((seg) => BUCKET_FIELD_SEGMENT_RE.test(seg))) return undefined;
+  return { field, format: source.slice(idx + 1).trim() };
+}
+
+const BUCKET_DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BUCKET_DATETIME_RE =
+  /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?([Zz]|[+-]\d{2}:\d{2})?$/;
+
+function isRealDate(year, month, day) {
+  const t = new Date(Date.UTC(year, month - 1, day));
+  return t.getUTCFullYear() === year && t.getUTCMonth() === month - 1 && t.getUTCDate() === day;
+}
+
+// Strict-only (refRender renders full records): wrong type / unparseable
+// throws; absent field returns undefined (un-renderable).
+function bucketDate(record, field) {
+  let current = record;
+  for (const seg of field) {
+    if (current === null || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    current = current[seg];
+    if (current === undefined) return undefined;
+  }
+  const name = field.join('.');
+  const fail = (detail) => {
+    throw new RefPathError('path_render_failed', `date-bucket reference: ${detail}`);
+  };
+  if (current instanceof Date) {
+    if (Number.isNaN(current.getTime())) fail(`field "${name}" is an invalid Date`);
+    return { year: current.getUTCFullYear(), month: current.getUTCMonth() + 1, day: current.getUTCDate() };
+  }
+  if (typeof current === 'string') {
+    const dateOnly = BUCKET_DATE_ONLY_RE.exec(current);
+    if (dateOnly) {
+      const [, y, m, d] = dateOnly;
+      const year = Number(y), month = Number(m), day = Number(d);
+      if (!isRealDate(year, month, day)) fail(`field "${name}" value ${JSON.stringify(current)} is not a real date`);
+      return { year, month, day };
+    }
+    const dt = BUCKET_DATETIME_RE.exec(current);
+    if (dt) {
+      const [, y, m, d, hh, mm, ss, offset] = dt;
+      const year = Number(y), month = Number(m), day = Number(d);
+      if (!isRealDate(year, month, day) || Number(hh) > 23 || Number(mm) > 59 || Number(ss) > 60) {
+        fail(`field "${name}" value ${JSON.stringify(current)} is not a real date or time`);
+      }
+      if (offset === undefined) return { year, month, day };
+      const epoch = Date.parse(current);
+      if (Number.isNaN(epoch)) fail(`field "${name}" value ${JSON.stringify(current)} is not parseable`);
+      const at = new Date(epoch);
+      return { year: at.getUTCFullYear(), month: at.getUTCMonth() + 1, day: at.getUTCDate() };
+    }
+    fail(`field "${name}" value ${JSON.stringify(current)} is not an ISO 8601 date or datetime`);
+  }
+  fail(`field "${name}" has type ${Array.isArray(current) ? 'array' : typeof current}`);
+}
+
+function isoWeekOf(d) {
+  const t = new Date(Date.UTC(d.year, d.month - 1, d.day));
+  const dayNum = (t.getUTCDay() + 6) % 7;
+  t.setUTCDate(t.getUTCDate() - dayNum + 3);
+  const isoYear = t.getUTCFullYear();
+  const jan1 = Date.UTC(isoYear, 0, 1);
+  const week = Math.floor((t.getTime() - jan1) / 86_400_000 / 7) + 1;
+  return { year: isoYear, week };
+}
+
+const pad2 = (n) => String(n).padStart(2, '0');
+const pad4 = (n) => String(n).padStart(4, '0');
+
+function renderBucketUnit(date, unit) {
+  switch (unit) {
+    case 'YYYY': return pad4(date.year);
+    case 'MM': return pad2(date.month);
+    case 'DD': return pad2(date.day);
+    case 'isoYYYY': return pad4(isoWeekOf(date).year);
+    case 'WW': return pad2(isoWeekOf(date).week);
+  }
+}
+
 function parseTemplate(source) {
   const normalized = source.replace(/^\/+/, '').replace(/\/+$/, '');
   if (normalized === '') throw new RefPathError('path_render_failed', 'path template is empty');
@@ -77,6 +174,23 @@ function parseTemplate(source) {
       }
       exprSource = exprSource.trim();
       i += 2;
+      const bucket = splitBucketAttempt(exprSource);
+      if (bucket !== undefined) {
+        const units = BUCKET_FORMATS[bucket.format];
+        if (units === undefined) {
+          throw new RefPathError('config_invalid', `invalid date-bucket format ${JSON.stringify(bucket.format)}`);
+        }
+        const standaloneBefore = segments[segments.length - 1].length === 0;
+        const standaloneAfter = i >= normalized.length || normalized[i] === '/';
+        if (!standaloneBefore || !standaloneAfter) {
+          throw new RefPathError('config_invalid', 'date-bucket reference must stand alone in its path segment');
+        }
+        for (let u = 0; u < units.length; u++) {
+          if (u > 0) segments.push([]);
+          segments[segments.length - 1].push({ kind: 'bucket', field: bucket.field, unit: units[u] });
+        }
+        continue;
+      }
       if (FIELD_NAME_RE.test(exprSource)) {
         const recursive = exprSource.endsWith('/**');
         const name = recursive ? exprSource.slice(0, -3) : exprSource;
@@ -125,6 +239,10 @@ function renderPart(part, record) {
       return part.text;
     case 'field':
       return stringifyValue(record[part.name]);
+    case 'bucket': {
+      const date = bucketDate(record, part.field);
+      return date === undefined ? undefined : renderBucketUnit(date, part.unit);
+    }
     case 'expression':
       return stringifyValue(part.evaluate(record));
   }

--- a/rust/gitsheets-napi/test/path-template.mjs
+++ b/rust/gitsheets-napi/test/path-template.mjs
@@ -38,6 +38,25 @@ const CORPUS = [
   ['${{ (slug || legacyId) }}', { slug: 'realslug', legacyId: 'abc' }],
   // Recursive (field/**) component — value contains slashes.
   ['${{ contentPath/** }}', { contentPath: 'docs/guides/intro' }],
+  // Date-bucket references (UTC-deterministic, rendered natively on both
+  // sides — chrono in the core, UTC accessors in the reference renderer).
+  ['${{ publishedAt: YYYY }}/${{ slug }}', { publishedAt: new Date('2026-03-09T12:00:00Z'), slug: 'post' }],
+  ['${{ publishedAt: YYYY/MM }}/${{ slug }}', { publishedAt: new Date('2026-03-09T12:00:00Z'), slug: 'post' }],
+  ['${{ publishedAt: YYYY/MM/DD }}/${{ slug }}', { publishedAt: new Date('2026-03-09T12:00:00Z'), slug: 'post' }],
+  ['${{ publishedAt: YYYY/WW }}/${{ slug }}', { publishedAt: new Date('2026-03-09T12:00:00Z'), slug: 'post' }],
+  // Offset instant lands on the UTC date (next day) on both sides.
+  ['${{ d: YYYY/MM/DD }}', { d: new Date('2025-12-31T23:30:00-05:00') }],
+  // ISO week-based-year boundaries: Jan 1 in W53 of the prior ISO year,
+  // late December in W01 of the next.
+  ['${{ d: YYYY/WW }}', { d: new Date('2027-01-01T00:00:00Z') }],
+  ['${{ d: YYYY/WW }}', { d: new Date('2024-12-30T00:00:00Z') }],
+  // ISO 8601 string inputs: date-only, offset-less (face value), offset.
+  ['${{ d: YYYY/MM/DD }}', { d: '2026-03-09' }],
+  ['${{ d: YYYY/MM/DD }}', { d: '2026-03-09T23:59:59' }],
+  ['${{ d: YYYY/MM/DD }}', { d: '2025-12-31T23:30:00-05:00' }],
+  // Bucket as the entire path (daily-rollup identity) + dotted field.
+  ['${{ day: YYYY/MM/DD }}', { day: '2026-03-09' }],
+  ['${{ meta.publishedAt: YYYY/MM }}/${{ slug }}', { meta: { publishedAt: '2026-03-09' }, slug: 'post' }],
 ];
 
 test('renderPathsBatch matches the node:vm reference renderer across the corpus', () => {
@@ -100,4 +119,48 @@ test('getFullYear (local-time) parity is reported (TZ-sensitive)', () => {
   const [actual] = renderPathsBatch(template, [record]);
   console.log(`\n  getFullYear local-time parity: node:vm=${expected} boa=${actual} (TZ=${process.env.TZ ?? 'system'})`);
   assert.equal(actual, expected, 'boa local-time year matches node:vm in-process');
+});
+
+// --- Date-bucket cases beyond the render corpus ---
+
+test('date-bucket rendering is pinned to expected UTC values', () => {
+  // Belt and braces beyond ref parity: assert the exact expected paths so a
+  // shared bug in both implementations can't hide.
+  const cases = [
+    ['${{ d: YYYY/MM/DD }}', { d: new Date('2026-03-09T12:00:00Z') }, '2026/03/09'],
+    ['${{ d: YYYY/WW }}', { d: new Date('2027-01-01T00:00:00Z') }, '2026/53'],
+    ['${{ d: YYYY/WW }}', { d: new Date('2024-12-30T00:00:00Z') }, '2025/01'],
+    ['${{ d: YYYY/MM/DD }}', { d: new Date('2025-12-31T23:30:00-05:00') }, '2026/01/01'],
+    ['${{ d: YYYY/MM }}', { d: '2026-01-02' }, '2026/01'],
+  ];
+  for (const [template, record, expected] of cases) {
+    assert.deepEqual(renderPathsBatch(template, [record]), [expected], template);
+  }
+});
+
+test('an unknown date-bucket format fails identically (config_invalid)', () => {
+  for (const bad of ['YYYY-MM', 'MM/DD', 'YYYY/MM/DD/HH', 'yyyy']) {
+    const template = `\${{ d: ${bad} }}/\${{ slug }}`;
+    assert.throws(() => refRender(template, { d: '2026-03-09', slug: 'x' }), (e) => e.code === 'config_invalid');
+    assert.throws(() => renderPathsBatch(template, [{ d: '2026-03-09', slug: 'x' }]), (e) => e.code === 'config_invalid');
+  }
+});
+
+test('a non-standalone date bucket fails identically (config_invalid)', () => {
+  for (const template of ['posts-${{ d: YYYY }}', '${{ d: YYYY }}${{ slug }}']) {
+    assert.throws(() => refRender(template, { d: '2026-03-09', slug: 'x' }), (e) => e.code === 'config_invalid');
+    assert.throws(() => renderPathsBatch(template, [{ d: '2026-03-09', slug: 'x' }]), (e) => e.code === 'config_invalid');
+  }
+});
+
+test('a wrong-typed or unparseable bucket value fails identically (path_render_failed)', () => {
+  for (const d of [42, true, 'not-a-date', '2026-02-30']) {
+    assert.throws(() => refRender('${{ d: YYYY }}', { d }), (e) => e.code === 'path_render_failed');
+    assert.throws(() => renderPathsBatch('${{ d: YYYY }}', [{ d }]), (e) => e.code === 'path_render_failed');
+  }
+});
+
+test('a missing bucket field follows the missing-field rule identically', () => {
+  assert.throws(() => refRender('${{ d: YYYY/MM }}/${{ slug }}', { slug: 'x' }), (e) => e.code === 'path_render_failed');
+  assert.throws(() => renderPathsBatch('${{ d: YYYY/MM }}/${{ slug }}', [{ slug: 'x' }]), (e) => e.code === 'path_render_failed');
 });

--- a/rust/gitsheets-napi/test/record-query.mjs
+++ b/rust/gitsheets-napi/test/record-query.mjs
@@ -298,3 +298,39 @@ test('templateFieldNames matches the host Template.getFieldNames', () => {
   console.log('\n  getFieldNames parity (rust === host):');
   for (const c of log) console.log(`    OK  ${c.t}  ->  [${c.actual.join(', ')}]`);
 });
+
+// ── date-bucketed sheet: posts, template ${{ publishedAt: YYYY/MM }}/${{ slug }} ─
+
+test('recordQueryCandidates prunes a date-bucketed walk when the field is supplied', () => {
+  const { gitDir } = freshRepo();
+  const POSTS = [
+    { path: '2025/12/c', record: { publishedAt: new Date('2025-12-31T09:00:00Z'), slug: 'c' } },
+    { path: '2026/03/a', record: { publishedAt: new Date('2026-03-09T12:00:00Z'), slug: 'a' } },
+    { path: '2026/04/b', record: { publishedAt: new Date('2026-04-01T00:00:00Z'), slug: 'b' } },
+  ];
+  const tree = seed(gitDir, 'posts', POSTS);
+  const template = '${{ publishedAt: YYYY/MM }}/${{ slug }}';
+
+  // Bucketed field supplied → the walk descends the exact rendered partition.
+  const pruned = recordQueryCandidates(
+    gitDir, tree, 'posts', template,
+    { publishedAt: new Date('2026-03-09T12:00:00Z') },
+    '.toml',
+  );
+  assert.deepEqual(pruned, ['2026/03/a']);
+
+  // Absent → the bucket segments are wildcards.
+  const all = recordQueryCandidates(gitDir, tree, 'posts', template, {}, '.toml');
+  assert.deepEqual(all, ['2025/12/c', '2026/03/a', '2026/04/b']);
+
+  // A datetime equality filter both prunes AND matches end to end.
+  const out = recordQuery(
+    gitDir, tree, 'posts', template,
+    { publishedAt: new Date('2026-03-09T12:00:00Z') },
+    '.toml',
+  );
+  assert.deepEqual(out.map((r) => r.path), ['2026/03/a']);
+
+  // getFieldNames surfaces the bucket's field for query derivation.
+  assert.deepEqual(templateFieldNames(template), ['publishedAt', 'slug']);
+});

--- a/rust/gitsheets-py/tests/test_smoke.py
+++ b/rust/gitsheets-py/tests/test_smoke.py
@@ -390,3 +390,48 @@ def test_index_conflict_error_carries_paths():
     with pytest.raises(gitsheets.IndexError) as ei:
         gitsheets.simulate_core_error("index_unique_conflict")
     assert ei.value.conflicting_paths == ["people/by-email/a@b.com"]
+
+
+# ── date-bucket path keys ──────────────────────────────────────────────────────
+# specs/behaviors/path-templates.md "Date-bucket references": UTC-always,
+# closed format enum, ISO week-based year for YYYY/WW. The same core renders
+# these for every binding — the expected paths here are byte-identical to the
+# Node suite's (rust/gitsheets-napi/test/path-template.mjs).
+
+
+def test_date_bucket_renders_each_format_utc():
+    when = dt.datetime(2026, 3, 9, 12, 0, 0, tzinfo=dt.timezone.utc)
+    record = {"publishedAt": when, "slug": "post"}
+    assert gitsheets.render_paths_batch("${{ publishedAt: YYYY }}/${{ slug }}", [record]) == ["2026/post"]
+    assert gitsheets.render_paths_batch("${{ publishedAt: YYYY/MM }}/${{ slug }}", [record]) == ["2026/03/post"]
+    assert gitsheets.render_paths_batch("${{ publishedAt: YYYY/MM/DD }}/${{ slug }}", [record]) == [
+        "2026/03/09/post"
+    ]
+    assert gitsheets.render_paths_batch("${{ publishedAt: YYYY/WW }}/${{ slug }}", [record]) == ["2026/11/post"]
+
+
+def test_date_bucket_normalizes_offsets_to_utc_and_accepts_strings():
+    # 23:30 at -05:00 is 04:30 the NEXT day in UTC.
+    offset = dt.datetime(2025, 12, 31, 23, 30, 0, tzinfo=dt.timezone(dt.timedelta(hours=-5)))
+    assert gitsheets.render_paths_batch("${{ d: YYYY/MM/DD }}", [{"d": offset}]) == ["2026/01/01"]
+    # ISO 8601 strings work identically.
+    assert gitsheets.render_paths_batch("${{ d: YYYY/MM/DD }}", [{"d": "2025-12-31T23:30:00-05:00"}]) == [
+        "2026/01/01"
+    ]
+    assert gitsheets.render_paths_batch("${{ d: YYYY/MM }}", [{"d": "2026-01-02"}]) == ["2026/01"]
+
+
+def test_date_bucket_iso_week_year_boundaries():
+    # Jan 1 in W53 of the prior ISO year; late December in W01 of the next.
+    assert gitsheets.render_paths_batch("${{ d: YYYY/WW }}", [{"d": "2027-01-01"}]) == ["2026/53"]
+    assert gitsheets.render_paths_batch("${{ d: YYYY/WW }}", [{"d": "2024-12-30"}]) == ["2025/01"]
+
+
+def test_date_bucket_invalid_format_raises_config_error():
+    with pytest.raises(gitsheets.ConfigError):
+        gitsheets.render_paths_batch("${{ d: YYYY-MM }}/${{ slug }}", [{"d": "2026-03-09", "slug": "x"}])
+
+
+def test_date_bucket_wrong_type_raises_path_template_error():
+    with pytest.raises(gitsheets.PathTemplateError):
+        gitsheets.render_paths_batch("${{ d: YYYY }}", [{"d": 42}])

--- a/specs/behaviors/path-templates.md
+++ b/specs/behaviors/path-templates.md
@@ -11,12 +11,13 @@ Every sheet declares a **path template** that determines where each record's TOM
 
 ## Syntax
 
-The template is a slash-separated string of components. Each component is either literal text, a field reference, or a JS expression.
+The template is a slash-separated string of components. Each component is either literal text, a field reference, a date-bucket reference, or a JS expression.
 
 | Form | Example | Meaning |
 | --- | --- | --- |
 | Literal | `users/by-domain/` | Static path text |
 | Field reference | `${{ slug }}` | The value of `record.slug`, rendered to string |
+| Date bucket | `${{ publishedAt: YYYY/MM/DD }}` | UTC date buckets of the field — expands to one path segment per format part |
 | Expression | `${{ slug.toLowerCase() }}` | Arbitrary JS expression with record fields in scope |
 | Recursive | `${{ path/** }}` | The value of the field, which may itself contain `/` — used for nested-path fields |
 | Prefix/suffix | `user-${{ id }}.draft` | Literal prefix/suffix attached to an expression |
@@ -32,8 +33,8 @@ path = "${{ slug }}"
 # Composite key (two-level directory)
 path = "${{ domain }}/${{ username }}"
 
-# Sharded by date
-path = "${{ publishedAt.getFullYear() }}/${{ publishedAt.getMonth() }}/${{ slug }}"
+# Date-bucketed (three-level directory: 2026/03/09/my-post.toml)
+path = "${{ publishedAt: YYYY/MM/DD }}/${{ slug }}"
 
 # Multi-variable per segment (#105 fix)
 path = "${{ year }}/${{ status }}--${{ id }}"
@@ -41,6 +42,119 @@ path = "${{ year }}/${{ status }}--${{ id }}"
 # Nested path field (the field's value contains slashes)
 path = "${{ contentPath/** }}"
 ```
+
+## Date-bucket references
+
+A date-bucket reference partitions records by a date-typed field:
+
+```toml
+path = '${{ publishedAt: YYYY/MM/DD }}/${{ slug }}'   # day partitioning
+path = '${{ publishedAt: YYYY/MM }}/${{ slug }}'      # month partitioning
+path = '${{ publishedAt: YYYY/WW }}/${{ slug }}'      # ISO-week partitioning
+path = '${{ day: YYYY/MM/DD }}'                       # bucket as the whole path
+```
+
+### Grammar
+
+Inside `${{ }}`, content matching
+
+```text
+^\s*<identifier(.dotted)?>\s*:\s*<format>\s*$
+```
+
+is a date-bucket reference: a field name (optionally dot-separated for a nested
+field), a colon, and a format. Everything else keeps the existing
+field-reference / expression behavior. Bucket recognition runs **before** the
+expression fallback.
+
+**The format is a closed set — an enum, not a format language:**
+
+| Format | Segments produced | Example rendering |
+| --- | --- | --- |
+| `YYYY` | calendar year | `2026` |
+| `YYYY/MM` | calendar year / month | `2026/03` |
+| `YYYY/MM/DD` | calendar year / month / day | `2026/03/09` |
+| `YYYY/WW` | ISO week-based year / ISO week | `2026/11` |
+
+Anything else in the format position (e.g. `YYYY-MM`, `MM/DD`, `YYYY/MM/DD/HH`)
+throws `ConfigError` (`config_invalid`) at sheet-open. Needs beyond the closed
+set fall back to the JS-expression form.
+
+A bucket reference must stand alone in its path segment — no literal
+prefix/suffix and no other references in the same segment (`posts-${{ d: YYYY }}`
+is `ConfigError` (`config_invalid`)). One reference expanding into multiple
+real segments composes with prefixes only ambiguously, so it is rejected
+outright.
+
+### Rendering semantics
+
+1. **UTC always.** Bucket rendering never consults a timezone — this is a
+   determinism guarantee: the same record produces the same path on every
+   host. An offset datetime is converted to UTC before its date parts are
+   read; offset-less values (local datetime, local date, offset-less ISO
+   strings) are taken at face value. (This is the bug class the expression
+   form invites: `getFullYear()` renders host-timezone-dependent paths.
+   `getUTCFullYear()` avoids it, but nothing enforces that spelling.)
+2. **`YYYY/WW` is ISO-8601 week**, and its `YYYY` is the **ISO week-based
+   year**, not the calendar year. January 1 can belong to week 52/53 of the
+   prior ISO year: 2027-01-01 falls in ISO week 2026-W53, so
+   `${{ d: YYYY/WW }}` renders it as `2026/53`. Likewise a late-December date
+   can belong to week 1 of the next ISO year (2024-12-30 → `2025/01`).
+3. **Zero-padding**: `MM`, `DD`, and `WW` are always two digits; `YYYY` is
+   four.
+4. **Accepted field values**: TOML datetime, local-datetime, and local-date
+   values, and ISO 8601 strings (date-only, or datetime with or without
+   offset). Any other value type (number, boolean, array, table, TOML
+   local-time, unparseable string) fails the render with `PathTemplateError`
+   (`path_render_failed`) at write time. A **missing** field follows the
+   existing missing-field rule: the component is un-renderable — `render`
+   fails, and a query walk treats the segments as wildcards.
+5. **One token expands to multiple real path segments**: `YYYY/MM/DD` creates
+   three directory levels. A bucket token may appear anywhere in the template
+   — leading, between other components, or as the entire path
+   (`path = '${{ day: YYYY/MM/DD }}'` makes the bucket the record identity,
+   legitimate for daily-rollup records).
+
+### Query traversal semantics
+
+When a query's fields include the bucketed field (with a date-typed or ISO
+8601 string value), the walk descends the exact rendered bucket path — one
+subtree per bucket segment. When the field is absent from the query, the
+bucket segments are wildcards, exactly like un-renderable components today.
+A query value of any other type does not prune (the segments widen to
+wildcards); the record-level equality filter still applies downstream, so
+results are unchanged — only the walk is wider.
+
+**Range-pruned queries are explicitly out of scope** for this behavior:
+mapping date-*range* filters onto bounded subtree walks (skip whole years or
+months outside the range) is a natural follow-up that the declarative bucket
+form makes possible — an opaque JS expression could never be inverted this
+way. Tracked as a follow-up; see [#252](https://github.com/JarvusInnovations/gitsheets/issues/252).
+
+### Backward compatibility
+
+Recognizing the bucket form breaks no working config. Inside `${{ }}`,
+content like `publishedAt: YYYY/MM` previously fell through to the expression
+compiler, where it parses as a JS *labeled statement* dividing
+ReferenceErrors — invalid inside the renderer's `return (...)` wrapper, so it
+has **never rendered successfully for anyone**. The bucket grammar claims
+only that dead syntax space; every currently-working template parses exactly
+as before. The same reasoning covers the `ConfigError` for unknown formats:
+`${{ field: ANYTHING }}` was previously a guaranteed compile failure, so
+converting it into a clearer config-time error changes no working behavior.
+
+### Rejected alternative: a field-level `bucket` declaration
+
+A `[gitsheet.fields.<name>] bucket = 'YYYY/MM/DD'` config block (with the
+path template referencing the field plainly) was considered and rejected: the
+path template should tell the whole story of the tree layout. One plain-looking
+reference silently expanding to three directory levels via a side declaration
+hurts readability — the reader of `path` should see the shape of the tree.
+
+Related wart this supersedes for the bucket case: a bare `Date`-typed field
+referenced as `${{ field }}` renders via JS `.toString()` (host-formatted,
+timezone-dependent). That remains a wart for non-bucket references; bucket
+references are the supported way to put a date field in a path.
 
 ## Rendering
 
@@ -95,6 +209,11 @@ For each component of the path template, in order:
       - Walk the subtree as a flat blob map (recursive); apply queryMatches.
 ```
 
+A date-bucket segment behaves like a field reference in this algorithm: it has
+a value (and prunes) when the query supplies the bucketed field with a
+date-typed or ISO-string value, and is otherwise treated as un-renderable
+(walk all children). See "Date-bucket references § Query traversal semantics".
+
 ### Practical implication
 
 A sheet with `path = "${{ domain }}/${{ username }}"` and a query `{ domain: 'af.mil' }` reads only the `af.mil/` subtree. A query with no `domain` reads all subtrees but is still O(records). A query `{ domain: 'af.mil', username: 'GrandmaCOBOL' }` reads exactly one file.
@@ -130,3 +249,4 @@ Templates are parsed once per template string (process-wide cache by string). Re
 - [behaviors/attachments.md](attachments.md)
 - [GitHub #105](https://github.com/JarvusInnovations/gitsheets/issues/105) — multi-variable component bug
 - [GitHub #14](https://github.com/JarvusInnovations/gitsheets/issues/14) — invalid character handling
+- [GitHub #252](https://github.com/JarvusInnovations/gitsheets/issues/252) — declarative date-bucket path keys


### PR DESCRIPTION
Implements the declarative date-bucket path keys settled in #252, spec-first per `specs/README.md`.

## The feature

Path templates gain a declarative date-bucket reference alongside the existing field/expression forms:

```toml
path = '${{ publishedAt: YYYY/MM/DD }}/${{ slug }}'   # day partitioning
path = '${{ publishedAt: YYYY/MM }}/${{ slug }}'      # month partitioning
path = '${{ publishedAt: YYYY/WW }}/${{ slug }}'      # ISO-week partitioning
```

**Closed format enum** — `YYYY`, `YYYY/MM`, `YYYY/MM/DD`, `YYYY/WW`; anything else in the format position is `ConfigError('config_invalid')` at sheet-open. Fancier needs keep falling back to the JS-expression form.

## Settled semantics (specced in `specs/behaviors/path-templates.md` § "Date-bucket references")

- **UTC always** — bucket rendering never consults a timezone (native chrono in the core, UTC accessors host-side; never `new Date(string)` on offset-less strings). Same record → same path on every host.
- **`YYYY/WW` is ISO-8601 week** and its `YYYY` is the ISO **week-based year**: 2027-01-01 renders as `2026/53`; 2024-12-30 as `2025/01`. chrono's `iso_week()` in the core; the TS mirror is pinned to it by parity tests on boundary dates.
- **Zero-padding** — `MM`/`DD`/`WW` two digits, years four.
- **Accepted values** — TOML datetime / local-datetime / local-date and ISO 8601 strings (offset-full normalizes to UTC; offset-less reads at face value). Wrong types / unparseable strings fail render with `PathTemplateError`; a missing field follows the existing missing-field rule.
- **One token → multiple real segments** (`YYYY/MM/DD` = three directory levels), expanded at *parse* time so the query walk sees ordinary one-level components. A bucket may sit anywhere in the template, including as the entire path (daily-rollup identity). It must stand alone in its segment.
- **Query traversal** — a query supplying the bucketed field descends the exact rendered partition (datetime equality filters now enter the prune record); absent, the segments are wildcards. Wrong-typed query values widen the walk instead of erroring. **Range-pruned queries are out of scope** — noted in the spec as the follow-up this declarative form enables.
- **Backward compatible** — `field: YYYY/MM` inside `${{ }}` was a JS labeled statement inside the renderer's `return (...)` wrapper, i.e. a guaranteed compile failure; the bucket grammar claims only dead syntax space. Reasoning recorded in the spec, including the rejected `[gitsheet.fields.<name>] bucket = ...` alternative.

## Rider: workspace addon resolution fix

The 0.2.0 manifest-sync lockfile refresh had pinned a nested **registry** copy of `@gitsheets/core-napi` under `packages/gitsheets/node_modules`, so every core-routed vitest ran against the *published* binaries instead of the workspace addon CI builds from source — which would have masked this branch's core change entirely. Fixed via `npm uninstall`/`npm install` of the dep (lockfile-only diff; the range stays `^0.2.0`).

## Test evidence

| Suite | Result |
| --- | --- |
| `cargo test` (core) | 184 passed (18 new bucket cases: every format, padding, ISO week-year boundaries, offset→UTC, string vs datetime inputs, rejections, compile-time enum validation, walk prune/wildcard) |
| napi `node --test` | 113 passed (5 new: ref-renderer parity corpus incl. boundary dates, pinned UTC expectations, error parity) |
| package vitest (`gitsheets`) | 361 passed (18 new TS `Template` cases + 5 end-to-end: bucketed sheet upsert → `ls-tree`-verified UTC partition paths, pruned/wildcard queries, `pathForRecord`, daily-rollup, sheet-open rejection) |
| package vitest (`gitsheets-axi`) | 118 passed |
| `pytest` (gitsheets-py, incl. cross-binding parity) | 36 passed (5 new byte-parity bucket cases) |
| `npm run type-check` | clean |
| `cargo clippy -D warnings` (core) | clean |

Plan: `plans/date-bucket-path-keys.md`. Docs: `docs/path-templates.md` gains the bucket section.

Core change: per CLAUDE.md's Releases section, this requires a `core-napi-v*` release before the next `gitsheets` npm release.

closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5fwEknfSxpaGCVEME5D4h
