### PR TITLE
docs(readme): use-case examples and four-surface getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,134 @@
 A git-backed document store for low-volume, high-touch, human-scale data.
 
 Records are TOML (or markdown-with-frontmatter) files in a git repository, laid
-out by a per-sheet path template. Every mutation is a commit, so the log is the
-audit trail. The engine is a shared **Rust core** with thin per-language
-bindings: this repo ships the Node binding (`gitsheets` on npm) and a Python
-binding, both running on the same core, so a write from either language produces
-byte-identical commits.
+out by a per-sheet path template. Every write is validated against your schema,
+serialized to a canonical form (the same data always produces the same bytes),
+and lands as a commit. The log is your audit trail, the diff is your review
+tool, and a `git clone` is a complete copy of everything. The engine is a
+shared Rust core with thin per-language bindings: the `gitsheets` npm package
+and a Python binding both produce byte-identical commits.
 
-The library and CLI live in [`packages/gitsheets`](packages/gitsheets); start
-there. The Rust core and its bindings live under [`rust/`](rust/).
+## The whole idea in one terminal
+
+```console
+$ cat .gitsheets/contacts.toml
+[gitsheet]
+root = 'contacts'
+path = '${{ handle }}'
+
+[gitsheet.schema]
+type = 'object'
+required = ['handle', 'name']
+
+$ npx -y gitsheets upsert contacts '{"handle": "ada", "name": "Ada Lovelace"}'
+
+$ git show HEAD --stat --oneline
+f3a91c2 contacts upsert ada
+ contacts/ada.toml | 2 ++
+```
+
+A record is a file. A change is a commit. Everything git can do with commits
+(blame, revert, branch, push, diff, sign) now applies to your data.
+
+## What people run on it
+
+- **An application datastore.** [codeforphilly.org's rebuild](https://github.com/CodeForPhilly/codeforphilly-ng)
+  uses gitsheets as its only public datastore: about 32,000 person records,
+  where every mutating HTTP request becomes one commit authored as the acting
+  user. The audit system is `git log`.
+- **Operational databanks.** Inventories and worklists that used to rot in
+  spreadsheets, tracked as schema-validated records where every decision is a
+  reviewable commit.
+- **AI evaluation corpora.** Agents and models write verdicts as records
+  (keyed by subject and evaluator), one commit per pass, and nothing acts on a
+  verdict until a human has read the diff. The schema rejects malformed model
+  output at write time.
+- **Mirrors of external systems.** Extract an API into records, fix and merge
+  data in git where diffs and review are free, then load only the deltas back.
+
+## Getting started
+
+### The library
+
+```console
+npm install gitsheets        # Node >= 20; prebuilt engine, no Rust toolchain
+```
+
+```typescript
+import { openRepo } from 'gitsheets';
+
+const repo = await openRepo({ gitDir: 'data/.git' });
+
+await repo.transact(
+  { message: 'contacts upsert ada', author: { name: 'Ada', email: 'ada@example.org' } },
+  async (tx) => {
+    await tx.sheet('contacts').upsert({ handle: 'ada', name: 'Ada Lovelace' });
+  },
+);
+```
+
+One handler, one commit, committed only on success. `openStore` layers typed
+sheets on top with Standard Schema validators (Zod, Valibot, ArkType), and a
+successful transaction auto-refreshes reads. See
+[the docs](https://jarvusinnovations.github.io/gitsheets/) for the API guide.
+
+### The CLI
+
+Works in any repo with a `.gitsheets/` config, no install required:
+
+```console
+npx -y gitsheets query contacts --filter name='Ada Lovelace'
+npx -y gitsheets read contacts ada
+npx -y gitsheets normalize contacts
+```
+
+Installed globally it also mounts as a git subcommand: `git sheet query …`.
+
+### For AI agents: gitsheets-axi
+
+`gitsheets-axi` is the same store behind a CLI designed for agents: compact
+token-efficient output, schemas surfaced with every listing, and bulk
+operations (upsert, patch, delete) that land as single reviewable commits.
+
+```console
+npx -y gitsheets-axi sheets            # what's here, with schemas
+npx -y gitsheets-axi query contacts --group-by name
+jq -c '.[]' import.json | npx -y gitsheets-axi upsert contacts   # one commit
+```
+
+An agent working in a gitsheets repo can be given real write access: the
+schema gates every write and the history makes every action reversible.
+
+### The agent skill
+
+For Claude Code and compatible harnesses, an installable skill teaches the
+agent the config grammar, the API, and the axi tool, with session hooks that
+surface your sheets at startup:
+
+```console
+npx skills add JarvusInnovations/gitsheets -y --skill gitsheets
+```
+
+### Python
+
+A Python binding ([`rust/gitsheets-py`](rust/gitsheets-py), pyo3) runs on the
+same core — a write from Python and a write from Node produce byte-identical
+commits, proven by cross-binding tests in CI. It builds from the repo today;
+PyPI publication is on the roadmap.
+
+## What it is not
+
+Every write is a commit, so sustained high write rates are the wrong fit. One
+process writes to a repo at a time. Queries are index-assisted scans with
+filters, grouping, and counts, not SQL joins. Large media belongs in object
+storage, not records. If a conventional database is serving you well, keep it.
 
 ## Spec-driven
 
-[`specs/`](specs/) is the source of truth. Start at [`specs/README.md`](specs/README.md).
-
-- [`specs/architecture.md`](specs/architecture.md) — stack and packaging
-- [`specs/rust-core.md`](specs/rust-core.md) — the Rust core + thin-binding architecture
-- [`specs/concepts.md`](specs/concepts.md) — Repository, Sheet, Record, Transaction, Store, Index
-- [`specs/api/`](specs/api/) — per-symbol API contracts
-- [`specs/behaviors/`](specs/behaviors/) — cross-cutting rules
+[`specs/`](specs/) is the source of truth for behavior; start at
+[`specs/README.md`](specs/README.md). The library and CLI live in
+[`packages/gitsheets`](packages/gitsheets); the Rust core and bindings live
+under [`rust/`](rust/).
 
 ## License
 

--- a/plans/readme-getting-started.md
+++ b/plans/readme-getting-started.md
@@ -1,0 +1,39 @@
+---
+status: done
+depends: []
+specs: []
+issues: []
+pr: 254
+---
+
+# README: use-case examples and four-surface getting started
+
+## Scope
+
+Rewrite the root README from an internal architecture note into the repo's public front door: brief use-case examples (the four production-proven patterns, generalized per the publication boundary; codeforphilly-ng named because public) and concise getting-started paths for all four consumption surfaces (library, CLI, gitsheets-axi, agent skill), plus the Python binding pointer.
+
+## Implements
+
+Docs only; API shapes verified against specs/api/transaction.md, specs/api/store.md, docs/cli.md.
+
+## Approach
+
+Structure: tagline (kept) → terminal walkthrough → use cases → getting started x4 → when not to use it → spec-driven pointer (condensed from prior README). Voice per the rollout drafts: plain, honest-limitations-visible, no promotional language.
+
+## Validation
+
+- [x] Every command/API line matches a shipped surface (tx.sheet(), upsert stdin, axi bootstrap, skills add)
+- [x] Publication boundary held: only public repos named
+- [ ] PR merged
+
+## Risks / unknowns
+
+None — docs only.
+
+## Notes
+
+The when-not-to-use section is deliberate positioning, not hedging: honest-fit framing is the rollout's credibility strategy.
+
+## Follow-ups
+
+- The packages/gitsheets npm README should eventually get a condensed version of the same getting-started (tracked informally; the rollout docs-TOC restructure covers it).


### PR DESCRIPTION
The root README becomes the repo's public front door, per the rollout content plan: one-terminal walkthrough, the four production-proven use-case patterns (codeforphilly-ng named — it's public; others generalized), concise getting-started for all four surfaces (library / CLI / gitsheets-axi / agent skill), the honest what-it-is-not section, and a truthful Python-binding status (builds from repo, PyPI on the roadmap — `pip install gitsheets` does not exist yet and is deliberately not promised).

Every command was verified against `docs/cli.md` shapes (`upsert <sheet> [input]` inline-JSON form, `--filter field=value` equality syntax).

🤖 Generated with [Claude Code](https://claude.com/claude-code)