### PR TITLE
docs(specs): distribution tracks + Python binding surface; PyPI publication plan

### DIFF
--- a/plans/pypi-publication.md
+++ b/plans/pypi-publication.md
@@ -1,0 +1,48 @@
+---
+status: planned
+depends: []
+specs:
+  - specs/behaviors/distribution.md
+  - specs/api/python-binding.md
+issues: [255]
+---
+
+# Publish the Python binding to PyPI
+
+## Scope
+
+Take `rust/gitsheets-py` from builds-in-CI to `pip install gitsheets`: the `py-v*` publish workflow (abi3 wheel matrix + sdist, trusted publishing via a PyPI pending publisher), the version-match guard, a consumer-facing README, and the CLAUDE.md Releases third track. First tag rides when the release train un-pauses.
+
+## Implements
+
+- `specs/behaviors/distribution.md` (the `py-v*` track, wheel matrix, parity ordering rule, pending-publisher bootstrap)
+- `specs/api/python-binding.md` (the 0.x supported surface and its honestly-documented gaps)
+
+## Approach
+
+1. `python-publish.yml` (or fold into `rust-core.yml` family): `py-v*` tag trigger; maturin-action builds — manylinux x86_64 + aarch64 (native runners), musllinux x86_64, macOS x86_64 + arm64, Windows x86_64 — plus sdist; a guard step fails the run if `rust/gitsheets-py/Cargo.toml` version != tag; publish via `pypa/gh-action-pypi-publish` with OIDC.
+2. Configure the pending publisher on pypi.org for project `gitsheets` → this repo + this workflow (one-time, manual, Chris's PyPI account).
+3. README pass on `rust/gitsheets-py/README.md`: install, quick start (transact/upsert), the parity guarantee as the headline, the #240 gaps stated plainly, version/track note.
+4. CLAUDE.md Releases: add the `py-v*` track with its committed-version rule (deliberately different from the npm addon's tag-stamped rule — cite the spec).
+5. On release-train resume: set `Cargo.toml` version 0.1.0 (if not already), tag `py-v0.1.0` from a rust-core-green develop commit, watch the publish, verify `pip install gitsheets` cold.
+
+## Validation
+
+- [ ] Workflow builds all six wheels + sdist green on a dry-run (workflow_dispatch, publish skipped)
+- [ ] Version-mismatch guard proven (deliberate mismatch fails)
+- [ ] Pending publisher configured (manual step recorded here when done)
+- [ ] `py-v0.1.0` published; `pip install gitsheets` works on a clean machine; import + a transact round-trip succeeds
+- [ ] CLAUDE.md documents the track
+
+## Risks / unknowns
+
+- PyPI name squatting between now and first publish (name verified free 2026-07-12; the pending publisher can be configured immediately to reduce the window).
+- aarch64 manylinux runner availability/cost; fall back to QEMU cross-build via maturin-action if needed.
+
+## Notes
+
+_(populated at closeout)_
+
+## Follow-ups
+
+_(populated at closeout)_

--- a/specs/api/python-binding.md
+++ b/specs/api/python-binding.md
@@ -1,0 +1,26 @@
+# API: Python binding (`gitsheets` on PyPI)
+
+## Summary
+
+The Python binding (`rust/gitsheets-py`, pyo3) is a supported consumption surface of the same Rust core the npm package runs on. Its defining guarantee: **a write from Python and a write from Node produce byte-identical commits**, continuously proven by the cross-binding parity suite in CI. Layout is mixed: the compiled extension (`gitsheets._gitsheets`) wrapped by an idiomatic pure-Python surface (`python/gitsheets/`).
+
+## Supported surface (0.x)
+
+The 0.x releases are honestly scoped as a **transactional writer with parity-proven reads**:
+
+- `transact(...)` / `Transaction` — `open_sheet`, `upsert`, `delete`, `clear`, `will_change`, `parent_commit_hash`
+- Attachments — `set_attachment(s)`, `get_attachment(s)`, `delete_attachment(s)`
+- Reads through opened sheets at the transaction/opened tree
+- Validation: JSON Schema in-core (identical to Node); the consumer-validator hook is validator-agnostic (any callable; Pydantic works and is exercised in the test suite)
+
+## Known gaps (documented, tracked, not blockers for 0.x)
+
+Per [#240](https://github.com/JarvusInnovations/gitsheets/issues/240): no freshness model (`refresh`/auto-refresh after commit) and no streaming blob reads. No push daemon. These reach parity as #240 lands; the 0.x README states them plainly.
+
+## Versioning
+
+Version lives in `rust/gitsheets-py/Cargo.toml` (maturin reads it); releases follow the `py-v*` track per [behaviors/distribution.md](../behaviors/distribution.md). Pre-1.0 semver: breaking surface changes bump the minor.
+
+## Naming
+
+The PyPI package name is `gitsheets` (verified unregistered as of 2026-07-12; the first trusted-publish claims it via a pending publisher).

--- a/specs/behaviors/distribution.md
+++ b/specs/behaviors/distribution.md
@@ -1,0 +1,35 @@
+# Behavior: Distribution and release tracks
+
+## Rule
+
+Every published gitsheets artifact ships from this repo on a prefix-namespaced git-tag track with its own publish workflow, and every workflow authenticates via trusted publishing (OIDC) — no long-lived registry tokens anywhere. Tag prefixes never collide; a tag on one track must never trigger another track's workflow.
+
+## Applies To
+
+- `publish-npm.yml` (`v*`), `core-napi.yml` (`core-napi-v*`), and the Python publish workflow this spec introduces (`py-v*`)
+- CLAUDE.md's Releases section (the operator-facing summary of this spec)
+
+## The tracks
+
+| Artifact | Registry | Tag track | Version source |
+| --- | --- | --- | --- |
+| `gitsheets` (JS lib + CLI) | npm | `v*` via the develop→main Release-PR flow | Release PR title; stamped at publish |
+| `@gitsheets/core-napi` (+6 platform packages) | npm | `core-napi-v*` | **Tag-stamped at publish; never pre-committed.** Workspace manifests sync to the released version *after* publish |
+| `gitsheets` (Python) | PyPI | `py-v*` | **Committed in `rust/gitsheets-py/Cargo.toml`** (maturin reads it); the tag must match the committed version, and the workflow fails loudly on mismatch |
+
+The three version-source rules differ deliberately; each matches its toolchain's grain. The npm-addon rule and its rationale are recorded in `plans/core-napi-0.2.0-release.md` (learned from the v2.3.0 publish failure).
+
+## Python wheels
+
+- **abi3-py39**: one wheel per platform covers CPython >= 3.9. The wheel matrix is the same platform spread as `core-napi.yml`: manylinux x86_64 + aarch64, musllinux x86_64, macOS x86_64 + arm64, Windows x86_64 — built with `maturin-action`, natively where runners exist, plus an sdist.
+- **Ordering rule**: a `py-v*` release must be built from a commit whose `gitsheets-core` passes the cross-binding byte-parity suite against the *same commit's* Node binding — the parity guarantee is the product; a Python release that could disagree with npm's bytes is a defect. In practice: tag only commits where CI is green on `rust-core.yml`.
+- **Trusted publishing bootstrap**: unlike npm (which required packages to exist before configuring trusted publishers), PyPI supports **pending publishers** — the publisher is configured on pypi.org before the project exists, and the first workflow publish creates and claims the project name. No manual first upload.
+
+## Release sequencing across tracks
+
+When a batch touches `gitsheets-core`, releases order as: `core-napi-v*` → workspace manifest sync → `v*` (npm). The Python track is independent of the npm sequencing (it builds the core from source at the tagged commit) but follows the same parity gate.
+
+## Principles
+
+- Registry trust is workflow-shaped: OIDC everywhere, no tokens to leak or rotate.
+- A release's provenance is its git tag; nothing publishes from a branch tip.


### PR DESCRIPTION
Specs+plan for taking `rust/gitsheets-py` to PyPI (#255):

- **`specs/behaviors/distribution.md`** (new) — all three release tracks in one place with their deliberately-different version-source rules (Release-PR-stamped / tag-stamped / committed-in-Cargo.toml), the abi3 wheel matrix, the cross-binding parity gate as a release precondition, and the PyPI pending-publisher bootstrap (no manual first upload, unlike npm's flow).
- **`specs/api/python-binding.md`** (new) — the supported 0.x surface stated honestly: transactional writer with parity-proven reads; #240's freshness/streaming gaps documented rather than implied.
- **`plans/pypi-publication.md`** — `planned`; the build is one workflow + one manual pending-publisher step + a README pass, then `py-v0.1.0` rides the release-train un-pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)