### PR TITLE
chore(napi): sync manifests to released core-napi 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       "link": true
     },
     "node_modules/@gitsheets/core-napi-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-arm64/-/core-napi-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-X9gFr9bMJ/faBmE3AepGARim0va3ONwGRVygdVOE4dSSruBzV+4SyjLrfqZ5NpX1Pg8K/XWkqxpnb1yaDdohIw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-arm64/-/core-napi-darwin-arm64-0.3.0.tgz",
+      "integrity": "sha512-WIzPjJdHfLqqKoK3YpuN2tI7kDC6Wa7yo9fXl3k+2y8m+FxwwvjpLg0QraDcbKwbCnkHRqw0L5iw7d7IxEpilg==",
       "cpu": [
         "arm64"
       ],
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-x64/-/core-napi-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-IuuM6ygcHZZNu6h/aHanHsQH+1VOndOUV1xAP9Kl77CF2vBvtR4/zLaR5SkLBkNtnjDDwodWasLBg97EZFrn/g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-x64/-/core-napi-darwin-x64-0.3.0.tgz",
+      "integrity": "sha512-smppb3w9Qwjvstuav/FdfFJdqzwswidvHryk7UdCO/HfOHXogl5b2EnKnHTjLdv7inU4RJatBQOGeB8tpbweGg==",
       "cpu": [
         "x64"
       ],
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-arm64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-arm64-gnu/-/core-napi-linux-arm64-gnu-0.2.0.tgz",
-      "integrity": "sha512-dYJeEv6zW6VpJOiiWkXGmIEy4VJdfaSzIPG+Din8Hlasv10UuvnnydxWjXAmW47zg6Q24cS5QAkKH7AE7itf9Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-arm64-gnu/-/core-napi-linux-arm64-gnu-0.3.0.tgz",
+      "integrity": "sha512-+PEY/scA6FKJpd5hJnmUrlQLG1q6dT4/8a8SuoUMIbUMdtY+enBG8kCHQ2Bdlu87lcC7CsZKmLHyIVFLz70bnw==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-gnu/-/core-napi-linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-PWyXvJfE2mEwbSRJD9krA6g+2b4FNIp8N3kou3K4Ce8Vhr6dzFWd9u6VRHMohFYfCP9IYZedN/HkO/nzTXhzHg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-gnu/-/core-napi-linux-x64-gnu-0.3.0.tgz",
+      "integrity": "sha512-bkUgFc/1jvLt1RT17/VatAILxG2yWHBuHLYYNe5ZRbo27nm5Jsy4DYjR2nOcet0pZcIgXAiN1cxT2cLGrq9D/A==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-x64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-musl/-/core-napi-linux-x64-musl-0.2.0.tgz",
-      "integrity": "sha512-w/uiJiEvXQKY0+O6tj7UbGgVSKrV40QZ9L52Z3gQsxA5eQREpaEhgo70TBGgvqbgOwXOp1EeXEnQArqakctKUQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-musl/-/core-napi-linux-x64-musl-0.3.0.tgz",
+      "integrity": "sha512-DRlvLrvrrHl4ZbchX0vIP/hxwk70WR6/SZrqqL7r3Yjg3AnDTA7nsYwXLRGkfxcPt1BLTMFqcUffiz4FchoiMQ==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-win32-x64-msvc/-/core-napi-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-oSQvdK+1zzAP8VYk/rjykyIC5TI+axLCvvASagpAPyL0CKEa3ZEaNeB51vie5yy4YuXnrqmEn/DJDY/LeL6cpg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-win32-x64-msvc/-/core-napi-win32-x64-msvc-0.3.0.tgz",
+      "integrity": "sha512-jfXfWznQt7YQnBWpOCfV3mwJylJf8/H0AN/BeB56O4co598Xk7gXahWYZ8yAHXQgND2jibmpcMDzdJqCMdxeDA==",
       "cpu": [
         "x64"
       ],
@@ -1804,7 +1804,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gitsheets/core-napi": "^0.2.0",
+        "@gitsheets/core-napi": "^0.3.0",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "rfc6902": "^5.2.0",
@@ -1850,7 +1850,7 @@
     },
     "rust/gitsheets-napi": {
       "name": "@gitsheets/core-napi",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -1863,12 +1863,12 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@gitsheets/core-napi-darwin-arm64": "0.2.0",
-        "@gitsheets/core-napi-darwin-x64": "0.2.0",
-        "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
-        "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
-        "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
-        "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
+        "@gitsheets/core-napi-darwin-arm64": "0.3.0",
+        "@gitsheets/core-napi-darwin-x64": "0.3.0",
+        "@gitsheets/core-napi-linux-arm64-gnu": "0.3.0",
+        "@gitsheets/core-napi-linux-x64-gnu": "0.3.0",
+        "@gitsheets/core-napi-linux-x64-musl": "0.3.0",
+        "@gitsheets/core-napi-win32-x64-msvc": "0.3.0"
       }
     }
   }

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
-    "@gitsheets/core-napi": "^0.2.0",
+    "@gitsheets/core-napi": "^0.3.0",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "rfc6902": "^5.2.0",

--- a/rust/gitsheets-napi/npm/darwin-arm64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-darwin-arm64",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "os": [
     "darwin"
   ],

--- a/rust/gitsheets-napi/npm/darwin-x64/package.json
+++ b/rust/gitsheets-napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-darwin-x64",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "os": [
     "darwin"
   ],

--- a/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-arm64-gnu",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-x64-gnu",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/linux-x64-musl/package.json
+++ b/rust/gitsheets-napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-linux-x64-musl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "os": [
     "linux"
   ],

--- a/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
+++ b/rust/gitsheets-napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi-win32-x64-msvc",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "os": [
     "win32"
   ],

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gitsheets/core-napi",
-  "version": "0.2.0",
-  "description": "Node.js native binding for gitsheets-core \u2014 the FFI marshalling boundary.",
+  "version": "0.3.0",
+  "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
   "main": "binding.cjs",
   "types": "index.d.ts",
   "license": "Apache-2.0",
@@ -33,12 +33,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@gitsheets/core-napi-linux-x64-gnu": "0.2.0",
-    "@gitsheets/core-napi-linux-arm64-gnu": "0.2.0",
-    "@gitsheets/core-napi-linux-x64-musl": "0.2.0",
-    "@gitsheets/core-napi-darwin-arm64": "0.2.0",
-    "@gitsheets/core-napi-darwin-x64": "0.2.0",
-    "@gitsheets/core-napi-win32-x64-msvc": "0.2.0"
+    "@gitsheets/core-napi-darwin-arm64": "0.3.0",
+    "@gitsheets/core-napi-darwin-x64": "0.3.0",
+    "@gitsheets/core-napi-linux-arm64-gnu": "0.3.0",
+    "@gitsheets/core-napi-linux-x64-gnu": "0.3.0",
+    "@gitsheets/core-napi-linux-x64-musl": "0.3.0",
+    "@gitsheets/core-napi-win32-x64-msvc": "0.3.0"
   },
   "scripts": {
     "artifacts": "napi artifacts",


### PR DESCRIPTION
Post-publish manifest/lockfile sync per the Releases sequence (core-napi 0.3.0 is live on npm; all 7 packages verified). Workspace lockfile resolves the published 0.3.0 platform binaries; the main package remains the workspace link (no nested registry copy — the v2.3.x gotcha checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ