### PR TITLE
feat: PyPI publication for the Python binding (py-v* track)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,10 @@
 #                             rust-cross image, which is x86_64-hosted)
 #   x86_64 musllinux_1_2    → ubuntu-latest   (container build; the musl wheel
 #                             can't install on the glibc host, so no smoke)
-#   x86_64 macOS            → macos-13        (Intel runner)
+#   x86_64 macOS            → macos-14        (cross-compiled on the Apple
+#                             Silicon runner, like core-napi.yml — Intel
+#                             macos-13 runners are retired/unschedulable, so
+#                             the x86_64 wheel builds cross and skips smoke)
 #   aarch64 macOS           → macos-14        (Apple Silicon runner)
 #   x86_64 Windows          → windows-latest
 #
@@ -111,9 +114,14 @@ jobs:
             manylinux: musllinux_1_2
             test: false # musl wheel can't install on the glibc host
           - platform: macos-x86_64
-            host: macos-13
+            # Cross-compiled on the Apple Silicon runner (core-napi.yml's
+            # pattern): GitHub's Intel macos-13 runners are retired — the job
+            # queues indefinitely. The arm64 host can't run the x86_64 wheel,
+            # so no smoke; the abi3 build logic is covered by the smoked
+            # platforms.
+            host: macos-14
             target: x86_64-apple-darwin
-            test: true
+            test: false
           - platform: macos-arm64
             host: macos-14
             target: aarch64-apple-darwin

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,206 @@
+# Build + publish the `gitsheets` Python package (rust/gitsheets-py) to PyPI.
+#
+# This ships the pyo3 binding over gitsheets-core as abi3-py39 wheels — one
+# wheel per platform covers CPython >= 3.9 — plus an sdist, per
+# specs/behaviors/distribution.md. The wheel matrix mirrors core-napi.yml's
+# platform spread:
+#   x86_64 manylinux_2_28   → ubuntu-latest   (container build; native)
+#   aarch64 manylinux_2_28  → ubuntu-24.04-arm (Arm runner; native aarch64
+#                             manylinux container — NOT the default
+#                             rust-cross image, which is x86_64-hosted)
+#   x86_64 musllinux_1_2    → ubuntu-latest   (container build; the musl wheel
+#                             can't install on the glibc host, so no smoke)
+#   x86_64 macOS            → macos-13        (Intel runner)
+#   aarch64 macOS           → macos-14        (Apple Silicon runner)
+#   x86_64 Windows          → windows-latest
+#
+# VERSION RULE (specs/behaviors/distribution.md): the released version is
+# COMMITTED in rust/gitsheets-py/Cargo.toml (maturin reads it via pyproject's
+# dynamic version) — deliberately unlike the napi track, which tag-stamps at
+# publish. A `py-v*` tag must match the committed version exactly; the guard
+# job fails the whole run loudly on mismatch.
+#
+# Triggers:
+#   - push of a `py-v*` tag → build wheels + sdist, then publish to PyPI
+#   - workflow_dispatch     → dry-run: build + smoke everything, SKIP publish.
+#     The optional `guard-tag` input simulates a tag against the version guard
+#     (e.g. `py-v9.9.9` proves a mismatch fails the run).
+#
+# Publish auth: PyPI TRUSTED PUBLISHING (OIDC) — no token, matching the repo's
+# npm workflows. One-time bootstrap: PyPI supports PENDING publishers, so the
+# trusted publisher for project `gitsheets` (this repo + this workflow file +
+# environment `pypi`) is configured on pypi.org BEFORE the project exists; the
+# first tagged publish creates and claims the name. No manual first upload.
+#
+# Ordering rule: only tag commits where rust-core.yml is green — the
+# cross-binding byte-parity suite is the product guarantee, and a Python
+# release that could disagree with npm's bytes is a defect.
+name: python-publish
+
+on:
+  push:
+    tags:
+      - 'py-v*'
+  workflow_dispatch:
+    inputs:
+      guard-tag:
+        description: >-
+          Simulate a py-v* tag for the version guard (e.g. py-v0.1.0 to prove
+          a match passes, py-v9.9.9 to prove a mismatch fails the run). Leave
+          empty for a plain build-everything dry-run.
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: version guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fail loudly if the tag version != the committed crate version
+        env:
+          TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.guard-tag }}
+        run: |
+          CRATE_VERSION="$(python3 -c 'import tomllib; print(tomllib.load(open("rust/gitsheets-py/Cargo.toml", "rb"))["package"]["version"])')"
+          if [ -z "$TAG" ]; then
+            echo "Dry-run with no tag to check — committed version is ${CRATE_VERSION}."
+            exit 0
+          fi
+          TAG_VERSION="${TAG#py-v}"
+          if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error title=py-v tag/version mismatch::Tag ${TAG} expects version ${TAG_VERSION}, but rust/gitsheets-py/Cargo.toml commits ${CRATE_VERSION}. The Python track releases the COMMITTED version (specs/behaviors/distribution.md) — commit the bump to develop first, then tag py-v${CRATE_VERSION}."
+            exit 1
+          fi
+          echo "Tag ${TAG} matches committed version ${CRATE_VERSION}."
+
+  build:
+    name: build ${{ matrix.platform }}
+    needs: guard
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: manylinux-x86_64
+            host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            manylinux: '2_28'
+            test: true
+          - platform: manylinux-aarch64
+            host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            manylinux: '2_28'
+            # Native aarch64 manylinux container: maturin-action's default
+            # image for this target is the x86_64-hosted rust-cross image,
+            # which would need QEMU on an Arm runner.
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            test: true
+          - platform: musllinux-x86_64
+            host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            manylinux: musllinux_1_2
+            test: false # musl wheel can't install on the glibc host
+          - platform: macos-x86_64
+            host: macos-13
+            target: x86_64-apple-darwin
+            test: true
+          - platform: macos-arm64
+            host: macos-14
+            target: aarch64-apple-darwin
+            test: true
+          - platform: windows-x86_64
+            host: windows-latest
+            target: x86_64-pc-windows-msvc
+            test: true
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build wheel (abi3-py39)
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: rust/gitsheets-py
+          command: build
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          container: ${{ matrix.container }}
+          args: --release --locked --out dist
+          sccache: true
+
+      - name: Smoke test (install the wheel, run the binding suite)
+        if: ${{ matrix.test }}
+        shell: bash
+        run: |
+          python -m pip install pytest pydantic
+          python -m pip install --no-index --find-links rust/gitsheets-py/dist gitsheets
+          python -m pytest rust/gitsheets-py/tests/test_smoke.py -v
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-${{ matrix.platform }}
+          path: rust/gitsheets-py/dist/*.whl
+          if-no-files-found: error
+
+  sdist:
+    name: build sdist
+    needs: guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: rust/gitsheets-py
+          command: sdist
+          args: --out dist
+
+      - name: Smoke test (compile-from-source install, then import)
+        # Proves the sdist is complete — maturin must have packed the local
+        # path dependency (gitsheets-core) and the workspace Cargo.lock.
+        run: |
+          python -m pip install rust/gitsheets-py/dist/*.tar.gz
+          python -c "import gitsheets; print(gitsheets.serialize_records([{'ok': True}])[0])"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-sdist
+          path: rust/gitsheets-py/dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: publish gitsheets to PyPI
+    if: ${{ startsWith(github.ref, 'refs/tags/py-v') }}
+    needs: [build, sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gitsheets
+    permissions:
+      id-token: write # OIDC trusted publishing — job-scoped on purpose
+    steps:
+      - name: Collect wheels + sdist
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+
+      - name: List distributions for the run log
+        run: ls -l dist/
+
+      # Tokenless: OIDC trusted publishing (uploads from dist/ by default).
+      # Requires the pending/trusted publisher configured on pypi.org for
+      # project `gitsheets` → this repo, this workflow, environment `pypi`.
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,9 +22,12 @@
 #
 # Triggers:
 #   - push of a `py-v*` tag → build wheels + sdist, then publish to PyPI
+#   - pull_request touching the binding or this workflow → build + smoke
+#     everything (no publish), like core-napi.yml's PR builds
 #   - workflow_dispatch     → dry-run: build + smoke everything, SKIP publish.
 #     The optional `guard-tag` input simulates a tag against the version guard
-#     (e.g. `py-v9.9.9` proves a mismatch fails the run).
+#     (e.g. `py-v9.9.9` proves a mismatch fails the run). Note GitHub only
+#     accepts dispatches once the workflow exists on the default branch.
 #
 # Publish auth: PyPI TRUSTED PUBLISHING (OIDC) — no token, matching the repo's
 # npm workflows. One-time bootstrap: PyPI supports PENDING publishers, so the
@@ -41,6 +44,10 @@ on:
   push:
     tags:
       - 'py-v*'
+  pull_request:
+    paths:
+      - 'rust/gitsheets-py/**'
+      - '.github/workflows/python-publish.yml'
   workflow_dispatch:
     inputs:
       guard-tag:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,10 @@ See [specs/architecture.md](specs/architecture.md) for the full stack rationale.
 
 ## Releases
 
-Two npm release tracks ship from this repo on **separate, prefix-namespaced git-tag
-tracks** — keep them distinct, and mind the ordering rule:
+Three release tracks (two npm, one PyPI) ship from this repo on **separate,
+prefix-namespaced git-tag tracks** — keep them distinct, and mind the ordering rule.
+`specs/behaviors/distribution.md` is the source of truth for the tracks and their
+deliberately-different version-source rules:
 
 - **`gitsheets`** (the JS package) — released on **`v*`** tags via the develop→main
   Release-PR flow (`release-prepare`/`-validate`/`-publish` workflows; use the
@@ -86,6 +88,14 @@ tracks** — keep them distinct, and mind the ordering rule:
   **`core-napi-v*`** tags via `core-napi.yml`: native per-platform builds + npm
   trusted publishing (OIDC). Never tag the addon with a bare `v*` — that namespace
   belongs to the JS package.
+- **`gitsheets` on PyPI** (the Python binding) — released on **`py-v*`** tags via
+  `python-publish.yml`: abi3 wheels + sdist, PyPI trusted publishing (OIDC).
+  **The version is COMMITTED in `rust/gitsheets-py/Cargo.toml`** (maturin reads it)
+  and the tag must match it exactly — the workflow's guard job fails the run on
+  mismatch. This deliberately inverts the napi track's tag-stamped rule (see
+  `specs/behaviors/distribution.md`): bump the committed version on develop first,
+  then tag `py-v<that-version>` from a commit where `rust-core.yml` is green (the
+  cross-binding byte-parity gate). Never tag the binding with a bare `v*`.
 
 Rules learned the hard way (v2.3.0's failed publish — see
 `plans/core-napi-0.2.0-release.md`):
@@ -110,7 +120,9 @@ Rules learned the hard way (v2.3.0's failed publish — see
 
 Sequence for a batch that touches core: merge the feature PRs → tag `core-napi-v*`
 on develop → wait for the 7 packages to land on npm → PR the manifest/lockfile sync →
-merge → run the release-flow skill on the auto-opened `Release: v*` PR.
+merge → run the release-flow skill on the auto-opened `Release: v*` PR. The `py-v*`
+track is independent of this npm sequencing (it builds the core from source at the
+tagged commit) but shares the parity gate: only tag rust-core-green commits.
 
 ## Tooling
 

--- a/plans/pypi-publication.md
+++ b/plans/pypi-publication.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 depends: []
 specs:
   - specs/behaviors/distribution.md

--- a/plans/pypi-publication.md
+++ b/plans/pypi-publication.md
@@ -5,6 +5,9 @@ specs:
   - specs/behaviors/distribution.md
   - specs/api/python-binding.md
 issues: [255]
+awaits:
+  - "PyPI pending publisher for project `gitsheets` (repo JarvusInnovations/gitsheets, workflow python-publish.yml, environment pypi) — manual, maintainer's pypi.org account; then tag py-v0.1.0 from a rust-core-green develop commit"
+pr: 259
 ---
 
 # Publish the Python binding to PyPI
@@ -28,11 +31,27 @@ Take `rust/gitsheets-py` from builds-in-CI to `pip install gitsheets`: the `py-v
 
 ## Validation
 
-- [ ] Workflow builds all six wheels + sdist green on a dry-run (workflow_dispatch, publish skipped)
-- [ ] Version-mismatch guard proven (deliberate mismatch fails)
-- [ ] Pending publisher configured (manual step recorded here when done)
-- [ ] `py-v0.1.0` published; `pip install gitsheets` works on a clean machine; import + a transact round-trip succeeds
-- [ ] CLAUDE.md documents the track
+- [x] Workflow builds all six wheels + sdist green on a dry-run (publish skipped) —
+  PR #259's `python-publish` run
+  <https://github.com/JarvusInnovations/gitsheets/actions/runs/29218719524>. Wheels
+  are smoke-tested by installing them and running the binding suite (except musl —
+  can't install on the glibc host — and macOS x86_64, cross-compiled on the arm64
+  runner because Intel macos-13 runners are retired/unschedulable, matching
+  core-napi.yml's pattern); the sdist by a compile-from-source install. Note:
+  `workflow_dispatch` only registers once the file is on the default branch, so
+  the workflow also carries a `pull_request`-paths trigger (mirroring
+  core-napi.yml) — that is the dry-run used here; the `guard-tag` dispatch input
+  works post-merge.
+- [x] Version-mismatch guard proven (deliberate mismatch fails) — the guard script
+  run verbatim with `TAG=py-v9.9.9` exits 1 with a `::error` annotation while
+  `TAG=py-v0.1.0` and the no-tag dry-run pass (transcript in PR #259).
+- [ ] Pending publisher configured (manual step recorded here when done) —
+  pypi.org → publishing → project `gitsheets`, owner `JarvusInnovations`, repo
+  `gitsheets`, workflow `python-publish.yml`, environment `pypi`.
+- [ ] `py-v0.1.0` published; `pip install gitsheets` works on a clean machine;
+  import + a transact round-trip succeeds — awaits the pending publisher; then
+  tag `py-v0.1.0` on a rust-core-green develop commit.
+- [x] CLAUDE.md documents the track
 
 ## Risks / unknowns
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "gitsheets-py"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "gitsheets-core",

--- a/rust/gitsheets-py/Cargo.toml
+++ b/rust/gitsheets-py/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "gitsheets-py"
 description = "Python (pyo3) binding for gitsheets-core: marshals records between Python and the Rust core with full TOML type fidelity."
-version.workspace = true
+# Own version, NOT workspace-inherited: this is the released PyPI version.
+# maturin reads it (pyproject.toml declares `dynamic = ["version"]`), and a
+# `py-v*` release tag must match it exactly — python-publish.yml fails loudly
+# on mismatch. See specs/behaviors/distribution.md.
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/gitsheets-py/README.md
+++ b/rust/gitsheets-py/README.md
@@ -2,13 +2,71 @@
 
 The Python binding for [gitsheets](https://github.com/JarvusInnovations/gitsheets) —
 a git-backed document store for low-volume, high-touch, human-scale data.
+Records are canonical TOML files in a git tree; every write is a real git
+commit you can diff, review, revert, and sync like any other.
 
-It is a thin [pyo3](https://pyo3.rs) binding over the shared Rust
-`gitsheets-core` engine. Everything that determines on-disk bytes (canonical
-TOML, path-template rendering, JSON-Schema validation, the embedded JS engine,
-the Sheet/Transaction/Store state machine) lives in the core, so **a record
-written from Python and the same record written from the Node binding produce
-byte-identical trees, blobs, and commits.**
+**The guarantee that defines this package: a record written from Python and
+the same record written from the Node.js `gitsheets` package produce
+byte-identical trees, blobs, and commits.** The binding is a thin
+[pyo3](https://pyo3.rs) layer over the shared Rust `gitsheets-core` engine;
+everything that determines on-disk bytes (canonical TOML, path-template
+rendering, JSON-Schema validation, the embedded JS engine, the
+Sheet/Transaction/Store state machine) lives in the core, and a cross-binding
+parity suite proves the byte equivalence in CI on every change.
+
+## Install
+
+```bash
+pip install gitsheets
+```
+
+Prebuilt abi3 wheels (any CPython >= 3.9) ship for Linux x86_64 + aarch64
+(glibc), Linux x86_64 (musl), macOS x86_64 + arm64, and Windows x86_64. Other
+platforms install from the sdist, which needs a Rust toolchain.
+
+## Quick start
+
+A sheet is declared by a TOML config committed in the repo — here, one record
+file per person, keyed by `slug`, under `people/`:
+
+```bash
+mkdir crm && cd crm && git init -b main
+mkdir .gitsheets
+cat > .gitsheets/people.toml <<'EOF'
+[gitsheet]
+path = '${{ slug }}'
+root = 'people'
+EOF
+git add .gitsheets && git commit -m "declare the people sheet"
+```
+
+Write records inside a transaction — commit on success, discard on error:
+
+```python
+import time
+import gitsheets
+
+with gitsheets.transact(
+    ".git",                       # the repo's GIT_DIR
+    "people: add jane",           # commit message
+    int(time.time()),
+    author=("Jane Doe", "jane@example.org"),
+    branch="refs/heads/main",
+) as tx:
+    tx.open_sheet("people", ".gitsheets/people.toml")
+    tx.upsert("people", {"slug": "jane", "email": "jane@example.org"})
+
+print(tx.result["commit_hash"])
+```
+
+The round-trip is plain git — and the bytes are canonical, identical to what
+the Node binding would have written:
+
+```console
+$ git show main:people/jane.toml
+email = "jane@example.org"
+slug = "jane"
+```
 
 ## Type fidelity
 
@@ -46,6 +104,38 @@ with gitsheets.transact(git_dir, "add jane", time_seconds, author=("Jane", "jane
     tx.open_sheet("people", ".gitsheets/people.toml")
     tx.upsert("people", {"slug": "jane", "email": "jane@x.org"}, validate=Person.model_validate)
 ```
+
+JSON-Schema validation declared in the sheet config runs in-core, identically
+to the Node binding.
+
+## What 0.x is (and isn't)
+
+The 0.x releases are honestly scoped as a **transactional writer with
+parity-proven reads**: `transact`/`Transaction` (`open_sheet`, `upsert`,
+`delete`, `clear`, `will_change`), attachments
+(`set_attachment(s)`/`get_attachment(s)`/`delete_attachment(s)`), reads
+through opened sheets, and validation.
+
+Known gaps, tracked in
+[#240](https://github.com/JarvusInnovations/gitsheets/issues/240) and stated
+plainly rather than papered over:
+
+- **No freshness model** — no `refresh`/auto-refresh after commit; reads see
+  the tree a transaction opened, not later commits.
+- **No streaming blob reads** — attachments surface as blob hashes; there is
+  no streaming read API yet.
+- **No push daemon** — syncing the repo to remotes is yours to arrange.
+
+These reach parity with the Node binding as #240 lands.
+
+## Versioning and releases
+
+Releases ship from the
+[`py-v*` tag track](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/distribution.md):
+the released version is committed in `rust/gitsheets-py/Cargo.toml`, the tag
+must match it, and every release is built from a commit whose cross-binding
+byte-parity suite is green. Pre-1.0 semver: breaking surface changes bump the
+minor version.
 
 ## Development
 


### PR DESCRIPTION
Executes `plans/pypi-publication.md` steps 1–4: takes `rust/gitsheets-py` from builds-in-CI to one-tag-away from `pip install gitsheets`. Implements `specs/behaviors/distribution.md` (the `py-v*` track) and `specs/api/python-binding.md` (the honestly-scoped 0.x surface). The plan stays `in-progress` (with an `awaits:` blocker) until `py-v0.1.0` actually publishes.

## What's here

- **`.github/workflows/python-publish.yml`** — `py-v*` tag trigger + `workflow_dispatch` dry-run (with a `guard-tag` input to exercise the guard) + `pull_request`-paths dry-run builds (mirroring `core-napi.yml`; also needed because GitHub only registers `workflow_dispatch` once the file is on the default branch). Six abi3-py39 wheels via `PyO3/maturin-action@v1` + sdist; publish via `pypa/gh-action-pypi-publish@release/v1` with OIDC trusted publishing (job-scoped `id-token: write`, no tokens), skipped on non-tag runs.
- **Version guard** — a `guard` job fails the whole run loudly when a `py-v*` tag doesn't match the committed `rust/gitsheets-py/Cargo.toml` version (the track's committed-version rule, deliberately the inverse of the napi tag-stamped rule).
- **`rust/gitsheets-py/Cargo.toml`** — own `version = "0.1.0"` (no longer workspace-inherited; core/napi stay on the `0.0.0` placeholder), plus the matching `Cargo.lock` line.
- **`rust/gitsheets-py/README.md`** — the future PyPI project page: byte-parity guarantee as the headline, install + wheel coverage, a quick start verified end-to-end against a locally built wheel (output shown is byte-exact), the #240 gaps stated plainly, `py-v*` version/track note.
- **`CLAUDE.md`** — Releases section now documents all three tracks, citing `specs/behaviors/distribution.md`.

## Dry-run evidence (all wheels + sdist green, publish skipped)

Run: <https://github.com/JarvusInnovations/gitsheets/actions/runs/29218719524>

| Job | Result | Smoke |
| --- | --- | --- |
| version guard | ✅ pass | tag/version comparison (no-op on dry-runs) |
| build manylinux-x86_64 | ✅ pass | wheel installed, full binding suite |
| build manylinux-aarch64 (native `ubuntu-24.04-arm`) | ✅ pass | wheel installed, full binding suite |
| build musllinux-x86_64 | ✅ pass | build only (musl wheel can't install on the glibc host) |
| build macos-x86_64 (cross on `macos-14`) | ✅ pass | build only (arm64 host can't run the x86_64 wheel) |
| build macos-arm64 (`macos-14`) | ✅ pass | wheel installed, full binding suite |
| build windows-x86_64 | ✅ pass | wheel installed, full binding suite |
| build sdist | ✅ pass | compile-from-source `pip install` + import |
| publish gitsheets to PyPI | ⏭️ **skipped** (not a tag) | — |

Artifacts produced: `dist-manylinux-x86_64`, `dist-manylinux-aarch64`, `dist-musllinux-x86_64`, `dist-macos-x86_64`, `dist-macos-arm64`, `dist-windows-x86_64` (wheels, ~8–10 MB each), `dist-sdist`.

Note on the macOS x86_64 job: it originally targeted `macos-13`, which sat queued 45+ minutes — GitHub's Intel macOS runners are retired/effectively unschedulable, and that would hang every future release run too. Switched to `core-napi.yml`'s proven pattern: cross-compile `x86_64-apple-darwin` on the Apple Silicon runner.

## Version-guard proof

The guard script, run verbatim against this branch's checkout:

```console
=== case 1: matching tag py-v0.1.0 ===
Tag py-v0.1.0 matches committed version 0.1.0.
exit=0
=== case 2: mismatched tag py-v9.9.9 ===
::error title=py-v tag/version mismatch::Tag py-v9.9.9 expects version 9.9.9, but rust/gitsheets-py/Cargo.toml commits 0.1.0. The Python track releases the COMMITTED version (specs/behaviors/distribution.md) — commit the bump to develop first, then tag py-v0.1.0.
exit=1
=== case 3: no tag (dry-run) ===
Dry-run with no tag to check — committed version is 0.1.0.
exit=0
```

In CI the `build`/`sdist` jobs `needs: guard`, so a mismatched tag stops the entire run before any build. Once this merges, the `guard-tag` dispatch input re-proves it in CI: `gh workflow run python-publish.yml -f guard-tag=py-v9.9.9`.

## Remaining to release (manual, in order)

- [ ] **Configure the PyPI pending publisher** (maintainer's pypi.org account → Publishing → "Add a new pending publisher"): project name `gitsheets`, owner `JarvusInnovations`, repository `gitsheets`, workflow `python-publish.yml`, environment `pypi`. The first publish creates and claims the project name — do this soon to close the name-squatting window.
- [ ] **Tag the release** from a `rust-core.yml`-green develop commit that includes this PR: `git tag py-v0.1.0 && git push origin py-v0.1.0` (never a bare `v*`). The workflow builds everything and publishes; watch the run.
- [ ] **Verify cold**: `pip install gitsheets` on a clean machine; import + a transact round-trip.
- [ ] Check the last two validation boxes in `plans/pypi-publication.md`, record the pending-publisher step in the plan, flip it to `done`, and clear its `awaits:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ>
