### PR TITLE
ci(release): pin release-prepare to the v* tag track

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -18,3 +18,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-branch: main
+        # gitsheets shares one git tag space across three release tracks (v* for the
+        # JS package, core-napi-v*, py-v*). Restrict the JS Release PR's version
+        # computation to the v* track so a binding tag can't poison the title.
+        release-tag-match: 'v[0-9]*'


### PR DESCRIPTION
Preventive fix mirroring hologit: sets `release-tag-match: 'v[0-9]*'` (infra-components release-prepare r9) so the develop→main JS Release PR computes its version from the `v*` track only.

gitsheets now shares one git tag space across three tracks (`v*`, `core-napi-v*`, `py-v*`); without this, a `core-napi-v*`/`py-v*` tag reachable from main could mistitle a future Release PR the same way hologit's #504 was mistitled `holo-tree-v0.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4KHfjZQG7nS4c6R2pP2DJ