### PR TITLE
specs+plans: schema contracts (implements, vendored canonical-TOML lock, two-rung consumer verification)

### DIFF
--- a/plans/contracts-cli.md
+++ b/plans/contracts-cli.md
@@ -1,0 +1,115 @@
+---
+status: planned
+depends: [contracts-core]
+specs:
+  - specs/behaviors/contracts.md
+  - specs/api/cli.md
+issues: []
+---
+
+# Plan: contracts CLI — adopt, verify, test, sync, export, prune
+
+## Scope
+
+The producer-facing (and CLI-consumer-facing) tooling for contracts: the
+`git sheet contracts` command group and the `.gitsheets/contracts/sources.toml`
+provenance sidecar. Everything rides `contracts-core`'s loader, requirement
+checks, and canonical-hash primitive.
+
+In scope:
+
+- `contracts adopt <source> [--sheet <name>]...` — fetch/read (local path or
+  HTTPS URL; JSON or TOML), enforce document requirements, canonicalize,
+  vendor at the derived path, record provenance; with `--sheet`, gate on
+  validating every existing record against the new effective schema
+- `contracts verify [<sheet>]...` — the offline CI gate, including the
+  closed-local-schema warning
+- `contracts test <sheet> --against <file-or-name>` — structural (rung-2)
+  check against an arbitrary document
+- `contracts sync [<name>]...` — re-fetch sources, report drift, never rewrite
+- `contracts export <name>` — interchange JSON to stdout
+- `contracts prune [--dry-run]`
+- `ContractError` exit code 67; error output per the existing CLI error shape
+
+Out of scope: git-native source shorthand and vanity-name resolution
+(`specs/deferred.md`); registry tooling; the library-consumer verification
+surface ([`contracts-consumer-verify`](contracts-consumer-verify.md));
+`gitsheets-axi` contract affordances (follow-up — see Risks).
+
+## Implements
+
+- `specs/behaviors/contracts.md` — the sources sidecar; adoption gating
+  (validate-existing-records); immutability posture of `sync`; prune as the
+  non-error path for orphans
+- `specs/api/cli.md` — the `git sheet contracts` command group; exit code 67
+
+## Approach
+
+1. Command group scaffold following the existing CLI command layout; all
+   writes confined to `.gitsheets/contracts/` — sheet configs are never
+   modified (print the exact `implements` line for the author to add after a
+   successful adopt).
+2. `adopt`: source read (fs / HTTPS via the existing fetch utility, one-shot,
+   no runtime network path added anywhere else); parse → requirement checks →
+   canonical encode → write derived path (mkdir -p semantics in-tree) →
+   upsert `sources.toml` entry (source + adopted timestamp). With `--sheet`:
+   build the would-be effective schema and validate every existing record,
+   streaming failures as per-record issues to stderr; refuse vendoring on any
+   failure so a red adopt leaves the tree untouched.
+3. `verify`: pure-offline walk — for each declaring sheet (or named subset):
+   resolution, requirement checks, canonical-bytes check, `$id`↔path, record
+   validation against effective schema; warn (stderr, exit 0) when a declaring
+   sheet's local schema sets `additionalProperties: false`; exit 67 on any
+   hard failure. This is the command CI adds.
+4. `test`: load the target document (file path, or vendored name), validate
+   the sheet's records against **that document alone** (not the effective
+   schema) — rung 2 exactly; per-record conformance report; exit 67 on
+   failure.
+5. `sync`: for each `sources.toml` entry (or named subset), re-fetch and
+   byte-compare against vendored; report match/drift; missing source entry →
+   listed as unsyncable, not an error. Never writes.
+6. `export`: canonical TOML → interchange JSON (stable key order from the
+   canonical form), stdout.
+7. `prune`: diff vendored documents against the union of all sheets'
+   `implements`; `--dry-run` lists; removal requires confirmation.
+8. Tests: end-to-end fixture repo exercising adopt (both source forms, JSON
+   and TOML input, refusal on non-conforming existing records), verify (each
+   failure class + the closed-local warning), test against a
+   contract-unaware sheet (duck-typing path), sync drift detection, export
+   round-trip (export → adopt yields byte-identical vendored file), prune.
+
+## Validation
+
+- [ ] `adopt` of the same document from JSON-over-HTTPS and a local TOML file
+      produces byte-identical vendored files and records both sources
+- [ ] `adopt --sheet` against a sheet with a non-conforming existing record
+      refuses, streams the per-record issues, and leaves the tree untouched
+- [ ] `verify` passes on a conforming fixture repo, fails (exit 67) on each
+      seeded defect class, and warns on a closed local schema without failing
+- [ ] `contracts test` passes against a contract-unaware sheet whose records
+      conform, and reports per-record issues against one whose records don't
+- [ ] `sync` reports drift when the upstream fixture changes and never
+      modifies the vendored file
+- [ ] `export <name> | contracts adopt -` round-trips to identical bytes
+- [ ] `prune --dry-run` lists exactly the undeclared vendored documents
+
+## Risks / unknowns
+
+- **HTTPS fetch surface** — the CLI gains its first network-touching command;
+  keep it one-shot in `adopt`/`sync` only, with no proxy of it into the
+  library runtime path. Timeout + clear error on failure.
+- **`sources.toml` merge conflicts** — two branches adopting different
+  contracts both touch the sidecar; entries are per-name tables so conflicts
+  are rare and mechanical, but document the resolution (union) in the file's
+  header comment.
+- **`gitsheets-axi` parity** — agents will want `contracts verify`/`test`
+  through the axi surface; deliberately a follow-up so this plan stays
+  bounded.
+
+## Notes
+
+(populated at closeout)
+
+## Follow-ups
+
+(populated at closeout)

--- a/plans/contracts-consumer-verify.md
+++ b/plans/contracts-consumer-verify.md
@@ -1,0 +1,119 @@
+---
+status: planned
+depends: [contracts-core]
+specs:
+  - specs/behaviors/contracts.md
+  - specs/api/repository.md
+  - specs/api/errors.md
+issues: []
+---
+
+# Plan: consumer-side contract verification — the two-rung ladder in `openSheet`
+
+## Scope
+
+The library surface a consumer uses to wire itself to another repo's sheet with
+a checked interface: `openSheet(name, { contract })` implementing the two-rung
+verification ladder, the conformance report on failure, the
+`sheet.contractVerification` result surface, and advisory drift re-verification
+for structurally-verified sheets.
+
+In scope:
+
+- `contract` option on `openSheet` (`schema` as parsed data or JSON/TOML text;
+  `mode: 'verify' | 'declared' | 'structural'`; `onDrift`)
+- Rung 1: declaration check (name in `implements`) + canonical-hash identity
+  against the vendored document
+- Rung 2: structural validation of all records against the consumer's
+  document; `ContractError('contract_unsatisfied')` with per-record
+  `ValidationIssue`s (including `record` paths) on failure
+- `sheet.contractVerification` (`{ name, rung, tree }`)
+- Advisory re-verification on rebind to a changed tree (freshness path):
+  invoke `onDrift` with the report when a structural guarantee regresses;
+  never block reads
+- Node binding first; Python parity noted as follow-up
+
+Out of scope: producer tooling ([`contracts-cli`](contracts-cli.md)); any
+transport (the consumer opens whatever repo path/clone it already has —
+fetching remote repos is the consumer's business); `openSheets`/`openStore`
+contract maps (follow-up if demanded).
+
+## Implements
+
+- `specs/behaviors/contracts.md` — Consumer verification (the ladder, modes,
+  mismatch-degrades-to-evidence, advisory drift)
+- `specs/api/repository.md` — `openSheet` `opts.contract`,
+  `sheet.contractVerification`, the `ContractError` rows
+- `specs/api/errors.md` — `contract_unsatisfied` with the conformance report
+  in `issues` (`record` + `contract` fields populated)
+
+## Approach
+
+1. Core: `verify_sheet_contract(sheet, document, mode)` — canonicalize+hash
+   the consumer document (the `contracts-core` primitive); rung 1 = name
+   membership in the target's `implements` **and** hash equality with the
+   vendored bytes (both required: declaration proves future-write
+   enforcement, identity proves same-document); on miss and mode `verify`,
+   rung 2 = validate every record against the consumer document alone,
+   accumulating per-record issues.
+2. Report shape: `{ name, rung, tree, conforming, issues }` — `issues` empty
+   on success; on failure it is the payload of
+   `ContractError('contract_unsatisfied')`. Reuse the record-validation
+   machinery so issue quality matches write-time errors.
+3. Node binding: thread `opts.contract` through `openSheet`; run verification
+   before returning the handle; attach `contractVerification` to the `Sheet`.
+4. Drift: for rung-2-verified sheets, hook the existing rebind/freshness path
+   — when the sheet's bound tree hash changes, schedule a lazy re-validation;
+   if conformance regressed, invoke `onDrift(report)`. No `onDrift` → no
+   re-validation work (don't pay for an unobserved signal). Reads are never
+   gated on this.
+5. Tests: fixture producer repo (from the core plan's fixtures) exercising —
+   rung-1 pass (zero record reads — assert via instrumentation); rung-1 miss
+   on hash mismatch falling through to rung-2 pass (producer implements a
+   newer compatible version); rung-2 failure report quality (record paths +
+   contract name + field issues); `declared` mode never scanning records and
+   failing fast; `structural` mode ignoring declarations; drift callback
+   firing after a non-conforming commit lands in the producer fixture, with
+   reads still succeeding.
+
+## Validation
+
+- [ ] Rung-1 verification of a declaring sheet passes with zero record reads
+      and reports `rung: 'declared'`
+- [ ] Against a producer implementing a newer, data-compatible contract
+      version, `verify` mode falls through and passes with
+      `rung: 'structural'`
+- [ ] Against a non-conforming sheet, `openSheet` throws
+      `ContractError('contract_unsatisfied')` whose `issues` name each failing
+      record path, field, and the contract
+- [ ] `declared` mode refuses (without reading records) any sheet not
+      declaring the byte-identical contract; `structural` mode verifies a
+      contract-unaware sheet (duck typing)
+- [ ] After a drift-inducing commit in the producer, `onDrift` fires with a
+      regressed report and in-flight reads are unaffected
+- [ ] The motivating pair works end-to-end as a test: a consumer holding a
+      contract wires to a fixture "meal-bank" sheet in another repo, rung-1
+      verifies, reads records typed by the contract
+
+## Risks / unknowns
+
+- **Rung-2 cost on large sheets** — full-corpus validation at wiring time is
+  the honest guarantee, but on a large sheet it's a real scan. Acceptable at
+  contract-consumer scale (human-cadence sheets); if it bites, sampling is
+  explicitly *not* the fix (silent partial guarantees) — a persisted
+  verification cache keyed by tree hash is. Note in closeout if observed.
+- **Drift-hook interaction with freshness rebind semantics** — the rebind path
+  is `HEAD`-tree-oriented (see behaviors/freshness.md); verify the hook point
+  sees non-`HEAD` ref rebinds too, since cross-repo consumers commonly read
+  refs outside `refs/heads/`.
+- **Python parity** — the core function is binding-agnostic, but the Python
+  `openSheet` surface lags; record as a follow-up rather than widening this
+  plan.
+
+## Notes
+
+(populated at closeout)
+
+## Follow-ups
+
+(populated at closeout)

--- a/plans/contracts-core.md
+++ b/plans/contracts-core.md
@@ -1,0 +1,116 @@
+---
+status: planned
+depends: []
+specs:
+  - specs/behaviors/contracts.md
+  - specs/behaviors/validation.md
+  - specs/api/errors.md
+issues: []
+---
+
+# Plan: contracts core — declaration, vendored store, composed enforcement
+
+## Scope
+
+The core mechanics of schema contracts in the Rust engine, surfaced through every
+binding: the `implements` config key, the derived-path vendored contract store
+under `.gitsheets/contracts/`, contract-document requirement checks at compile,
+and `allOf` composition of declared contracts into write-time validation.
+
+In scope:
+
+- `implements` parsing/validation in sheet config
+- Contract name rules + name→path derivation (reusing path-segment character
+  validation)
+- Loading vendored contracts from the committed tree; canonical-bytes and
+  `$id`↔path consistency checks
+- Effective-schema composition (`allOf: [contracts…, local]`) in the existing
+  validation pipeline; contract attribution on `ValidationIssue`
+- `ContractError` (`contract_missing`, `contract_invalid`) across bindings
+- Canonical hashing of a contract document supplied as data or JSON/TOML text
+  (the identity primitive `contracts-cli` and `contracts-consumer-verify` both
+  build on)
+
+Out of scope: all CLI commands and the sources sidecar
+([`contracts-cli`](contracts-cli.md)); consumer verification
+([`contracts-consumer-verify`](contracts-consumer-verify.md)); everything in
+`specs/deferred.md`'s contract entries (source shorthand, registry, `$ref`
+closure, sheet-level assertions).
+
+## Implements
+
+- `specs/behaviors/contracts.md` — Concepts, names/derived path, document
+  requirements, canonical form, `implements` declaration, composition and
+  enforcement, the `contract_missing`/`contract_invalid` failure rows
+- `specs/behaviors/validation.md` — the amended layer-1 rule (effective schema
+  is `allOf` of contracts + local schema; issues name the contract)
+- `specs/api/errors.md` — `ContractError` class, `contract_missing` /
+  `contract_invalid` codes, `ValidationIssue.contract`
+
+## Approach
+
+1. Core: extend sheet-config parsing with `implements: Vec<String>`; validate
+   name rules (host-qualified, ≥1 `/`, path-segment character rules, no `.`/`..`,
+   no trailing slash). Reject invalid names as `ConfigError('config_invalid')`
+   (it's a config defect, not a contract defect).
+2. Core: contract loader — resolve each name to
+   `.gitsheets/contracts/<name>.toml` in the committed tree; absent →
+   `ContractError('contract_missing')`. Parse; enforce document requirements
+   (strict Draft-07 compile, `$id == 'https://' + name`, self-contained, open,
+   no null-bearing keywords, bytes are canonical — re-encode and compare) →
+   `ContractError('contract_invalid')` naming the violated rule.
+3. Core: build the effective schema per sheet as `allOf` of the N compiled
+   contracts + `[gitsheet.schema]`, compiled once and cached alongside the
+   existing per-sheet compiled schema. Tag validation issues that originate in
+   a contract branch with the contract name (`ValidationIssue.contract`).
+4. Core: expose `canonical_contract_hash(document)` — parse (JSON or TOML) →
+   canonical TOML encode → SHA-256 — as the shared identity primitive.
+5. Bindings: surface `ContractError` in Node and Python error marshalling with
+   stable codes; no new binding API beyond the error type (enforcement rides
+   the existing write path).
+6. Tests: name-rule table tests; each document-requirement rejection; deep +
+   root-level composition (contract-required field missing, contract + local
+   both failing, defaults from contract applying); multi-contract composition;
+   canonical-hash equality across JSON and TOML input of the same document;
+   cross-binding parity test that Node and Python compute identical hashes and
+   enforce identically (extend the existing parity suite).
+
+## Validation
+
+- [ ] A sheet declaring a vendored contract rejects a non-conforming write with
+      `ValidationError` whose issue names the contract; a conforming write with
+      extra local fields succeeds
+- [ ] `implements` naming an absent contract fails sheet-open with
+      `ContractError('contract_missing')`
+- [ ] Each document-requirement violation (bad `$id`, external `$ref`,
+      `additionalProperties: false`, null-bearing keyword, non-canonical bytes,
+      unknown keyword) fails with `ContractError('contract_invalid')` and a
+      message naming the rule
+- [ ] Two sheets declaring the same name compose the same single vendored
+      document
+- [ ] `canonical_contract_hash` yields identical hashes for the same document
+      supplied as JSON text, TOML text, and parsed data — in both Node and
+      Python
+- [ ] Existing validation/normalization test suites pass unchanged (sheets with
+      no `implements` are byte-for-byte unaffected)
+
+## Risks / unknowns
+
+- **Draft-07 `$id` handling in the `jsonschema` crate** — the crate may attempt
+  reference resolution against `$id` base URIs. Contracts are self-contained,
+  so resolution should never leave the document; verify no network/filesystem
+  resolver is reachable and disable external resolution outright.
+- **Canonical-bytes check cost** — re-encoding each vendored contract at
+  sheet-open to verify canonicality is O(contract size); fine at realistic
+  sizes, but cache by blob OID so repeated opens don't re-check.
+- **Openness detection depth** — `additionalProperties: false` must be rejected
+  at any nesting level, including inside `definitions`/`items`/`allOf`
+  branches. Needs a full-document walk, not a top-level check.
+
+## Notes
+
+(populated at closeout)
+
+## Follow-ups
+
+(populated at closeout)

--- a/specs/api/cli.md
+++ b/specs/api/cli.md
@@ -159,6 +159,39 @@ Scaffold `.gitsheets/<sheet>.toml` with defaults `root = <sheet>` and `path = '$
 git sheet init users --path='${{ slug }}' --schema=./schemas/user.schema.json
 ```
 
+### `git sheet contracts <subcommand>`
+
+Manage schema contracts ([behaviors/contracts.md](../behaviors/contracts.md)). All state these commands write lives under `.gitsheets/contracts/`; sheet configs are never rewritten by tooling — adding a name to `implements` is the author's edit.
+
+#### `git sheet contracts adopt <source> [--sheet <name>]...`
+
+Read a contract document from `<source>` (local file path or HTTPS URL; JSON or TOML), enforce the [document requirements](../behaviors/contracts.md#contract-document-requirements), canonicalize, and vendor it at its derived path. Records provenance in `.gitsheets/contracts/sources.toml`. With `--sheet`, also validates **every existing record** of each named sheet against the new effective schema and refuses adoption (per-record issues on stderr) until the data conforms — the author adds the name to `implements` only after adopt succeeds.
+
+```bash
+git sheet contracts adopt https://raw.githubusercontent.com/org/contracts/main/meals/v1.schema.json --sheet meal-bank
+git sheet contracts adopt ./meals-v1.schema.json
+```
+
+#### `git sheet contracts verify [<sheet>]...`
+
+Offline conformance gate (CI-friendly; no network). For the named sheets (default: all declaring sheets): every declared name resolves to a vendored document; each document satisfies the document requirements, is byte-canonical, and its `$id` matches its path; every record validates against the sheet's effective schema. Warns when a declaring sheet's local schema sets `additionalProperties: false`. Non-zero exit on any failure.
+
+#### `git sheet contracts test <sheet> --against <file-or-name>`
+
+Consumer-side structural check (rung 2 of [consumer verification](../behaviors/contracts.md#consumer-verification)) from the CLI: validate `<sheet>`'s records against an arbitrary contract document (a file, or the name of a vendored contract). Reports conformance per record; non-zero exit on failure. Works against sheets that declare nothing — duck typing.
+
+#### `git sheet contracts sync [<name>]...`
+
+Re-fetch each contract's recorded source and report drift between upstream and vendored bytes. **Never rewrites a vendored contract** — published versions are immutable; upstream drift is a finding to investigate, not a change to pull.
+
+#### `git sheet contracts export <name>`
+
+Emit the vendored contract as interchange JSON on stdout, for the wider JSON Schema toolchain.
+
+#### `git sheet contracts prune [--dry-run]`
+
+List (and with confirmation, remove) vendored documents no sheet declares.
+
 ## Exit codes
 
 | Code | Meaning |
@@ -170,6 +203,7 @@ git sheet init users --path='${{ slug }}' --schema=./schemas/user.schema.json
 | 64 | `ConfigError` |
 | 65 | `RefError` (not-found) |
 | 66 | `NotFoundError` |
+| 67 | `ContractError` |
 | 69 | `TransactionError` |
 | 70 | `IndexError` |
 

--- a/specs/api/errors.md
+++ b/specs/api/errors.md
@@ -22,6 +22,10 @@ export class IndexError extends GitsheetsError {
 export class RefError extends GitsheetsError {}
 export class PathTemplateError extends GitsheetsError {}
 export class NotFoundError extends GitsheetsError {}
+export class ContractError extends GitsheetsError {
+  readonly contract?: string;          // contract name, when one is in scope
+  readonly issues?: ValidationIssue[]; // conformance report on contract_unsatisfied
+}
 ```
 
 Every gitsheets exception extends `GitsheetsError`. Consumer catch blocks can typically use:
@@ -62,6 +66,9 @@ try {
 | `PathTemplateError` | `path_render_failed` | 422 | Template can't render against the record (missing fields, etc.) |
 | `PathTemplateError` | `path_invalid_chars` | 422 | Rendered path contains characters disallowed by the filesystem (Windows, etc.) |
 | `NotFoundError` | `record_not_found` | 404 | `delete` / `patch` / etc. against a path that doesn't exist |
+| `ContractError` | `contract_missing` | 500 | `implements` names a contract with no vendored document at its derived path |
+| `ContractError` | `contract_invalid` | 500 | Contract document violates [document requirements](../behaviors/contracts.md#contract-document-requirements) (compile, `$id`/path, canonical form, openness, self-containment, TOML data model) |
+| `ContractError` | `contract_unsatisfied` | 422 | Consumer verification failed both rungs (carries the conformance report in `issues`) |
 
 The `code` strings are stable. New scenarios get new codes; existing codes never change meaning.
 
@@ -74,6 +81,8 @@ interface ValidationIssue {
   source: 'json-schema' | 'standard-schema';
   schemaPath?: string;     // JSON Schema pointer when source === 'json-schema'
   code?: string;           // schema-keyword name (e.g., 'required', 'pattern')
+  contract?: string;       // contract name, when the failing schema branch is a declared contract (behaviors/contracts.md)
+  record?: string;         // record path, in multi-record conformance reports (ContractError.issues)
 }
 ```
 

--- a/specs/api/repository.md
+++ b/specs/api/repository.md
@@ -32,12 +32,25 @@ const users = await repo.openSheet('users', {
   root?: string,              // default: '.'
   prefix?: string,            // optional sub-prefix under the sheet's configured root
   validator?: StandardSchema, // optional Standard Schema validator
+  contract?: {                // consumer-side contract verification — behaviors/contracts.md
+    schema: object | string,  // the contract document the consumer holds (parsed data, or JSON/TOML text)
+    mode?: 'verify' | 'declared' | 'structural',   // default: 'verify'
+    onDrift?: (report: ConformanceReport) => void, // advisory drift signal (structural-verified sheets only)
+  },
 });
 ```
 
 `opts.prefix` scopes record reads/writes to `<configRoot>/<prefix>/<rendered-path>.<ext>`. Useful for multi-tenant sub-tree partitioning. The sheet's `.gitsheets/<name>.toml` config file is unaffected — only the record data tree is scoped. Mirrors the CLI `--prefix` global flag (env `GITSHEETS_PREFIX`). See [api/cli.md](cli.md#global-flags) for the CLI surface.
 
 Throws `ConfigError` if `.gitsheets/<name>.toml` doesn't exist under the resolved root.
+
+**`opts.contract`** verifies the sheet against a contract document the consumer holds, per the two-rung ladder in [behaviors/contracts.md](../behaviors/contracts.md#consumer-verification). The document is canonicalized and hashed by the core regardless of input form. Modes:
+
+- `'verify'` (default) — rung 1 (declared identity), falling back to rung 2 (structural validation of all records). Failure of both: `ContractError('contract_unsatisfied')` carrying the conformance report.
+- `'declared'` — rung 1 only; never reads records. Miss: `ContractError('contract_unsatisfied')`.
+- `'structural'` — rung 2 only (duck typing; ignores any declaration).
+
+`sheet.contractVerification` on the returned handle reports `{ name, rung: 'declared' | 'structural', tree }` — which guarantee you actually got, and the tree hash it's pinned to. For structural-verified sheets, a rebind to a changed tree ([behaviors/freshness.md](../behaviors/freshness.md)) triggers an advisory re-verification: `onDrift` is invoked with the report if conformance regressed. Reads are never blocked by drift — refusal belongs at wiring time only.
 
 ### `repo.openSheets(opts?)`
 
@@ -125,7 +138,6 @@ const result = await repo.withLock(async () => {
 - **Not reentrant — deliberately.** The lock has no hold-count. Calling `repo.withLock` inside a `withLock` callback, calling `repo.withLock` inside a `repo.transact` handler (the transaction already holds the lock), or calling `repo.transact` (or any permissive-mode mutation, which auto-opens a transaction) inside a `withLock` callback would self-deadlock — each is detected via async-context tracking and throws `TransactionError` (`lock_held`) instead of hanging.
 - The lock is **in-process, per-`Repository`-instance** — the same scope as the transaction mutex ([behaviors/transactions.md](../behaviors/transactions.md#single-writer-model)). It does not coordinate across processes or across two `Repository` instances opened on the same git dir.
 
-
 ### `repo.requireExplicitTransactions()`
 
 Opt into strict mode. After this is called on a `Repository`, calling `Sheet.upsert` / `delete` / `patch` outside a transaction throws `TransactionError` with `code: 'transaction_required'`.
@@ -187,6 +199,9 @@ When the handler stages no mutations, the transaction does **not** commit — `c
 | `TransactionError` | `parent_moved` | Optimistic concurrency: parent ref moved between transaction start and commit |
 | `ConfigError` | `config_missing` | `.gitsheets/<name>.toml` not found in `openSheet` |
 | `ConfigError` | `config_invalid` | Sheet config TOML is malformed |
+| `ContractError` | `contract_missing` | `implements` names a contract with no vendored document in the committed tree |
+| `ContractError` | `contract_invalid` | Vendored contract violates document requirements (compile, `$id`/path, canonical form, openness, self-containment) |
+| `ContractError` | `contract_unsatisfied` | `openSheet` with `opts.contract` failed verification (carries conformance report) |
 
 ## Examples
 

--- a/specs/behaviors/contracts.md
+++ b/specs/behaviors/contracts.md
@@ -1,0 +1,295 @@
+# Behavior: Contracts
+
+## Rule
+
+A sheet may declare that it **implements** one or more named, versioned schema
+contracts. A contract is a JSON Schema document, vendored into the repo in
+canonical TOML form, that is **composed into the sheet's write-time validation**
+— so every record the sheet ever commits conforms to every contract it declares,
+by construction. A consumer wiring itself to another repo's sheet can verify
+conformance mechanically: fast-path by content identity (the vendored bytes hash
+to the same document the consumer holds), fallback by structural validation of
+the records themselves.
+
+Contracts make cross-system sheet consumption a **checked interface instead of a
+hopeful convention**: the producer's conformance is enforced where writes happen,
+the consumer's expectations are verified where wiring happens, and drift becomes
+a commit-time failure in the repo that caused it — never a mid-read surprise in
+the repo that didn't.
+
+## Applies To
+
+- [`.gitsheets/<sheet>.toml`](../concepts.md#sheet) — the `implements` key
+- `.gitsheets/contracts/` — the vendored contract store
+- [behaviors/validation.md](validation.md) — contract composition in the write pipeline
+- [api/repository.md](../api/repository.md) — `openSheet(name, { contract })` consumer verification
+- [api/cli.md](../api/cli.md) — the `contracts` command group
+- [api/errors.md](../api/errors.md) — `ContractError`
+
+## Concepts
+
+- **Contract document** — a self-contained JSON Schema (Draft-07, same dialect
+  as `[gitsheet.schema]`) with a required `$id`. It describes the shape and
+  semantics of records; its `title`/`description` annotations are the semantic
+  payload (units, meanings — what structural checking can't see).
+- **Contract name** — the document's `$id` with the URL scheme stripped:
+  `$id = 'https://gitsheets.io/meals/v1'` → name `gitsheets.io/meals/v1`. Names
+  are host-qualified paths; the name is the identity humans and configs use.
+- **Contract identity** — the SHA-256 of the document's **canonical TOML bytes**
+  (equivalently: the git blob OID of the vendored file). Two parties hold the
+  same contract iff their canonical bytes are identical. Identity is of the
+  document, not the semantics — no schema-equivalence reasoning exists anywhere
+  in this design, by principle (see below).
+- **Vendored contract** — the canonical-TOML rendering of a contract document,
+  committed at its derived path under `.gitsheets/contracts/`. The vendored
+  bytes are simultaneously the **lock state** and the **enforced artifact**:
+  what validation compiles is what identity hashes. There is no separately
+  recorded integrity hash to drift from reality.
+
+## Contract names and the derived path
+
+A contract name must:
+
+- contain at least one `/` (host-qualified: `<host>/<path...>`)
+- use only lowercase host characters and path segments that satisfy the same
+  character rules as rendered [path-template](path-templates.md) segments
+  (no Windows-invalid characters, no control characters, no `.` / `..`
+  segments, no trailing slash)
+
+The vendored path is derived mechanically — no manifest, no lookup:
+
+```text
+.gitsheets/contracts/<name>.toml
+```
+
+e.g. `gitsheets.io/meals/v1` → `.gitsheets/contracts/gitsheets.io/meals/v1.toml`.
+
+Because names always contain a `/`, vendored documents always live in
+subdirectories — top-level files in `.gitsheets/contracts/` (the `sources.toml`
+sidecar) can never collide with a contract.
+
+The document's `$id` must equal `https://` + name. At compile time the core
+verifies the vendored document's internal `$id` matches the path it lives at;
+mismatch is `ContractError('contract_invalid')`. The contracts directory is
+therefore self-describing.
+
+The `$id` is an identifier, not a dereference: nothing at runtime, adopt time,
+or verify time ever fetches it. It may happen to resolve on the web; the system
+never depends on that.
+
+## Contract document requirements
+
+Enforced when a document is adopted (CLI) and re-checked when it is compiled
+(core). Violation is `ContractError('contract_invalid')` with a message naming
+the rule:
+
+1. **Draft-07, strictly compiled** — the same dialect and compiler as
+   `[gitsheet.schema]`. Unknown keywords fail compilation. `$data` is disabled.
+2. **Self-contained** — no external `$ref` (no other document, no URL).
+   Internal `$ref` into own `definitions` is allowed. Closure vendoring is
+   deferred (see [deferred.md](../deferred.md)).
+3. **Open for extension** — the document must not use
+   `additionalProperties: false` (at any level). Draft-07 has no
+   `unevaluatedProperties`, so a closed contract would silently break `allOf`
+   composition with sheet-local schemas and sibling contracts. Openness is a
+   hard requirement, not a style preference.
+4. **TOML data model only** — no null-bearing keywords (`type: 'null'`
+   including inside type arrays, `const: null`, `enum` containing null,
+   `default: null`). This is alignment, not compromise: contracts describe
+   gitsheets records, records are TOML, and TOML has no null — a null branch
+   could never match anything.
+5. **Required `$id`** conforming to the name rules above.
+
+## Canonical form
+
+The vendored file is produced by the core's canonical TOML encoder — the same
+deep-key-sorted, deterministically-rendered pipeline that writes records (see
+[normalization.md](normalization.md)). Consequences, all load-bearing:
+
+- **Byte-equality ≡ data-equality.** Two parties comparing contracts may hash
+  bytes, compare git blob OIDs, or parse-and-deep-equal — all three agree.
+- **Cross-binding identity for free** — the encoder is the shared Rust core, so
+  Node and Python consumers compute identical identities from the same data.
+- **Array order is part of identity.** The encoder sorts keys, never arrays
+  (array order can be semantic in JSON Schema). Two independently-authored,
+  semantically-equal documents with differently-ordered `required` arrays are
+  *different contracts*. This never arises in practice because contracts
+  propagate by copy, not by re-authoring — but it is the specified behavior,
+  not a bug.
+- **The vendored copy is byte-virgin.** No tool may inject provenance, comments,
+  or metadata into it — that would fork its identity from every other party's
+  copy. Provenance lives in the sidecar (below); annotations that would mutate
+  a published document (deprecation, succession) are a registry concern and are
+  deferred — **published contract versions are immutable, absolutely**. A
+  changed contract is a new name (`…/v2`), never edited bytes under an old one.
+
+Adoption accepts interchange JSON or TOML input and canonicalizes on vendor;
+`contracts export` emits interchange JSON for the wider JSON Schema toolchain.
+The identity-bearing form is always the TOML bytes.
+
+## Declaration: `implements`
+
+```toml
+[gitsheet]
+root = 'meals'
+path = '${{ slug }}'
+implements = ['gitsheets.io/meals/v1']
+```
+
+- `implements` is an array of contract names — **pure intent, wholly
+  human/agent-authored**. Tooling never rewrites the sheet config; all
+  tool-managed state lives under `.gitsheets/contracts/`.
+- Each name must resolve to a vendored document at its derived path **in the
+  committed tree** (the same commit-first rule as sheet configs themselves).
+  A declared name with no vendored document is
+  `ContractError('contract_missing')` at sheet-open.
+- The same name may be declared by any number of sheets in the repo; they all
+  compose the same single vendored document. One name → one document per repo:
+  sheets cannot skew on the content of a shared contract, structurally.
+
+## Composition and enforcement
+
+When a sheet declares contracts, its effective write-time JSON Schema is:
+
+```text
+allOf: [ <vendored contract 1>, …, <vendored contract N>, <[gitsheet.schema]> ]
+```
+
+evaluated as layer 1 of the validation pipeline (before Standard Schema — see
+[validation.md](validation.md)). Consequences:
+
+- Every write to the sheet conforms to every declared contract, **by
+  construction**. There is no conformance *checking* step for producers —
+  enforcement happens where enforcement already happens.
+- `ValidationError` issues arising from a contract branch identify the
+  contract by name in the issue (alongside the existing `path` / `message` /
+  `source` fields), so a failing write says *which* obligation it violated.
+- Contract `default:` values apply on write exactly as `[gitsheet.schema]`
+  defaults do.
+- A sheet-local `[gitsheet.schema]` that sets `additionalProperties: false`
+  without enumerating every contract property will reject contract-conforming
+  records — a self-inflicted composition footgun. It is legal (the local schema
+  is the producer's own), but `contracts verify` warns on it.
+- **There is no static satisfiability check** across contracts + local schema.
+  Detecting that an `allOf` is unsatisfiable is schema-subtyping territory —
+  explicitly out of scope, permanently. The practical gate is adoption's
+  validate-existing-records pass (below) and ordinary write-time failure.
+
+## The sources sidecar
+
+`.gitsheets/contracts/sources.toml` — tool-managed provenance, one entry per
+contract name:
+
+```toml
+['gitsheets.io/meals/v1']
+source = 'https://raw.githubusercontent.com/JarvusInnovations/claude-assist/main/contracts/meals/v1.schema.json'
+adopted = 2026-07-18T00:00:00Z
+```
+
+- **Non-load-bearing.** Nothing at runtime reads it; validation and identity
+  depend only on the vendored bytes. An entry may be absent (contract adopted
+  from a local file, offline) with no loss of function.
+- Used by `contracts sync` to re-fetch and report upstream drift, and by humans
+  to answer "where did this come from".
+- v1 source forms: a local file path or an HTTPS URL, fetched once at
+  adopt/sync time — never at runtime. Git-native source refs
+  (`owner/repo/path@ref` shorthand) and vanity-name resolution are deferred
+  (see [deferred.md](../deferred.md)).
+
+## Consumer verification
+
+A consumer holding a contract document verifies a target sheet via a two-rung
+ladder (surfaced as `openSheet(name, { contract })` — see
+[api/repository.md](../api/repository.md) — and as `contracts test` in the CLI):
+
+1. **Rung 1 — declared identity.** The sheet's config declares the contract's
+   name in `implements`, **and** the vendored document at the derived path is
+   byte-identical (canonical-hash-equal) to the consumer's copy. Both halves
+   are required: the declaration proves the contract is composed into write
+   enforcement (future records conform); byte-identity proves it is the *same*
+   contract (this contract, not a namesake). Pass → verified, present and
+   future, zero records read.
+2. **Rung 2 — structural.** Every record of the sheet validates against the
+   consumer's document. Pass → verified for the current tree only. This rung
+   is what makes contract-unaware sheets consumable — pure duck typing against
+   any sheet ever written.
+
+- **A rung-1 miss is evidence-checking, not rejection**: a hash mismatch (the
+  producer implements a newer or different version) falls through to rung 2,
+  because the producer's data may well still satisfy the consumer's document.
+- Rung-2 failure throws `ContractError('contract_unsatisfied')` carrying a
+  conformance report: per-record, per-field `ValidationIssue`s — diff-quality,
+  at wiring time, in the party that chose the wiring.
+- A rung-2-verified sheet's guarantee is pinned to the tree hash that was
+  validated. On rebind to a changed tree (see
+  [freshness.md](freshness.md)), re-verification is **advisory, not
+  blocking**: the consumer may register a drift callback, but reads are never
+  blocked mid-flight — a producer's bad commit must not become a consumer
+  outage. Refusal belongs at wiring/boot time; drift after that is a signal.
+
+Verification modes: `verify` (rung 1, fall back to rung 2 — the default),
+`declared` (rung 1 only — strict, never scans records), `structural` (rung 2
+only). Exact API shape in [api/repository.md](../api/repository.md).
+
+## Evolution
+
+- **Additive revision** — publish a new immutable name (`…/v1.1` adding
+  optional fields). A producer adopts it *alongside* the old one:
+  `implements = ['gitsheets.io/meals/v1', 'gitsheets.io/meals/v1.1']`. `allOf`
+  composition makes multi-conformance enforcement-by-construction — a type
+  implementing two interfaces, with no entailment reasoning anywhere. Old
+  consumers rung-1 match v1, new consumers rung-1 match v1.1, simultaneously,
+  indefinitely. Dropping the old declaration is the producer's choice, made
+  when its known consumers have moved — or never; carrying both is nearly free.
+- **Adoption is gated on existing data.** `contracts adopt` validates every
+  existing record of each newly-declaring sheet against the new effective
+  schema and refuses to write the declaration until the data conforms. Adopting
+  a contract is a commit that cannot lie.
+- **Breaking revision** — a new name (`…/v2`) whose constraints conflict with
+  the old. Preferred migration is the **bridge**: design v2 rename-by-addition
+  so records can satisfy v1 and v2 simultaneously during the transition, then
+  drop v1 and the legacy fields together later. The **hard cutover**
+  alternative (switch `implements` to v2 alone) makes old consumers fail
+  precisely and early: rung 1 misses, rung 2 reports exactly which fields went
+  missing — at their next wiring/boot, not mid-read.
+- **Succession/deprecation signaling** (`supersededBy`-style metadata) cannot
+  live in the document — published versions are immutable, and annotating one
+  would fork its identity. It is a registry-layer concern, deferred.
+
+## Failure modes
+
+| Condition | Error | When |
+| --- | --- | --- |
+| `implements` names a contract with no vendored document | `ContractError('contract_missing')` | sheet-open |
+| Vendored/adopted document violates document requirements (compile failure, `$id`/path mismatch, non-canonical bytes, external `$ref`, null-bearing keyword, closed) | `ContractError('contract_invalid')` | sheet-open / adopt |
+| Record fails a contract branch on write | `ValidationError('validation_failed')` (issue names the contract) | write |
+| Consumer verification fails both rungs | `ContractError('contract_unsatisfied')` (carries conformance report) | `openSheet` with `contract` / `contracts test` |
+| Vendored document no sheet declares | not an error — `contracts prune` lists/removes | CLI |
+
+## Principles
+
+**Local** — the decisive trade-offs this design is built on:
+
+- **The lock is the artifact.** When the artifact is committed, a separately
+  recorded hash is a cache that can lie. The vendored bytes are what validation
+  compiles *and* what identity hashes — one source of truth, no divergence
+  possible. Trust computations over declarations.
+- **Identity is content, not location.** A contract's identity is its canonical
+  bytes; names are human handles and sources are provenance. Any party may
+  fetch from anywhere — hosts can change, registries can vanish — and identity
+  is unaffected.
+- **Conformance by construction beats conformance proofs.** Never compare
+  schemas to schemas (subtyping is a tar pit up to undecidability). Compose the
+  contract into write validation and the question disappears for producers;
+  hash the bytes and it disappears for consumers; validate records and it
+  disappears for strangers.
+- **Producer-local growth must cost zero coordination.** Adding a local field
+  to a sheet that implements contracts requires nothing from anyone. Any design
+  change that violates this is wrong.
+- **Mismatch is evidence to check, not grounds to refuse.** Every fast-path
+  miss degrades to a structural check; refusal happens only on structural
+  failure, and only at wiring time — never mid-read.
+
+**Inherited** — see [validation.md](validation.md) on persisted-vs-consumer
+validation layering and [normalization.md](normalization.md) on canonical bytes;
+this behavior is deliberately a composition of those two existing guarantees.

--- a/specs/behaviors/validation.md
+++ b/specs/behaviors/validation.md
@@ -4,14 +4,15 @@
 
 Records are validated on every write through two stacked layers, in order:
 
-1. **JSON Schema** — declared in `.gitsheets/<sheet>.toml`, **persisted with the data**. Framework-agnostic. The shape contract the repo carries.
+1. **JSON Schema** — declared in `.gitsheets/<sheet>.toml`, **persisted with the data**. Framework-agnostic. The shape contract the repo carries. When the sheet declares contracts ([behaviors/contracts.md](contracts.md)), the effective schema at this layer is `allOf: [<each vendored contract>, <[gitsheet.schema]>]` — contract conformance is enforced here, by construction, on every write.
 2. **Standard Schema** _(optional, consumer-supplied)_ — runs after JSON Schema, **lives in consumer code**. Adds branded types, refinements, transforms.
 
-A failure at either layer throws `ValidationError`. Validation runs synchronously inside `Sheet.upsert` / `Sheet.patch`, before any tree mutation.
+A failure at either layer throws `ValidationError`. Validation runs synchronously inside `Sheet.upsert` / `Sheet.patch`, before any tree mutation. Issues arising from a contract branch of the `allOf` identify the contract by name, so a failing write says which obligation it violated.
 
 ## Applies To
 
-- [`.gitsheets/<sheet>.toml`](../concepts.md#sheet) — `[gitsheet.schema]` block
+- [`.gitsheets/<sheet>.toml`](../concepts.md#sheet) — `[gitsheet.schema]` block, `implements` key
+- [behaviors/contracts.md](contracts.md) — contract composition at the JSON Schema layer
 - [api/sheet.md](../api/sheet.md) — `upsert`, `patch`
 - [api/repository.md](../api/repository.md) — `openSheet(name, { validator? })`
 - [api/store.md](../api/store.md) — `openStore(repo, { validators? })`
@@ -113,7 +114,7 @@ gitsheets' exported `StandardSchemaV1<Input, Output>` type (and every result/iss
 ## Order
 
 1. Record arrives at `Sheet.upsert(record)` (or `Sheet.patch(query, partial)` after the merge step).
-2. JSON Schema validation. On failure: `ValidationError` with all JSON Schema issues. No transform.
+2. JSON Schema validation — the effective schema (declared contracts composed via `allOf` with `[gitsheet.schema]`; see [behaviors/contracts.md](contracts.md)). On failure: `ValidationError` with all JSON Schema issues. No transform.
 3. Standard Schema validation (if configured). On failure: `ValidationError` with all Standard Schema issues. Record may be transformed.
 4. Canonical normalization (see [behaviors/normalization.md](normalization.md)).
 5. Path render + write.

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -94,10 +94,14 @@ An optional, library-side background task that pushes new commits to a configure
 
 Two layers run on every write, in order:
 
-1. **JSON Schema** (persisted in `.gitsheets/<sheet>.toml`) — the shape contract that travels with the repo.
+1. **JSON Schema** (persisted in `.gitsheets/<sheet>.toml`) — the shape contract that travels with the repo. When the sheet declares contracts, they compose into this layer via `allOf`.
 2. **Standard Schema** (consumer-supplied, optional) — richer validation: branded types, refinements, transforms.
 
 See [behaviors/validation.md](behaviors/validation.md).
+
+## Contract
+
+A named, versioned, immutable JSON Schema document that a sheet **implements** — vendored into the repo in canonical TOML form under `.gitsheets/contracts/` and composed into the sheet's write-time validation, so conformance is enforced by construction. A consumer holding the same document can verify a sheet mechanically: by content identity (fast, guarantees future writes) or by structural validation of records (works against any sheet, guarantees the present). The unit of cross-system sheet interoperability. See [behaviors/contracts.md](behaviors/contracts.md).
 
 ## Canonical normalization
 

--- a/specs/deferred.md
+++ b/specs/deferred.md
@@ -24,6 +24,26 @@ When in doubt about whether an entry belongs in `deferred.md`, the litmus test i
 - **What:** Accept and emit YAML in CLI ingest / export, alongside the existing JSON / TOML / CSV.
 - **Why deferred:** Long-standing backlog request with no concrete current consumer.
 
+### Contract source shorthand + vanity-name resolution
+
+- **What:** Richer `contracts adopt`/`sync` source forms beyond v1's local-path and HTTPS URL: git-native refs with a host-defaulted shorthand (`owner/repo/path@ref`, GitHub Actions-style), and vanity-name resolution (a name like `gitsheets.io/meals/v1` dereferencing to a backing source, Go-modules-style). Pure resolution sugar — identity, pinning, and enforcement are already location-free ([behaviors/contracts.md](behaviors/contracts.md)).
+- **Why deferred:** The kernel works with vendored files and raw URLs alone; the shorthand grammar can arrive later without breaking anything since it desugars to the same (source, bytes) pair.
+
+### Contract registry as a gitsheet + succession metadata
+
+- **What:** A contract registry that is itself a gitsheets repo — contracts as records in a built-in contracts sheet (validated on write by a meta-contract: `$id` present, self-contained, open), served read-only over git transport. Succession/deprecation signaling (`supersededBy`) lives here — it cannot live in contract documents, which are immutable ([behaviors/contracts.md](behaviors/contracts.md#canonical-form)).
+- **Why deferred:** Speculative until multiple independent producers/consumers exist; the motivating consumer pair works with consumer-authored, repo-hosted contracts.
+
+### Contract `$ref` closure vendoring
+
+- **What:** Allow contract documents to `$ref` other contracts, with adoption vendoring the transitive closure and identity accounting for resolution.
+- **Why deferred:** v1 requires contracts to be self-contained — closure identity semantics are subtle, and no consumer needs composition-by-reference yet.
+
+### Contract assertions beyond record shape
+
+- **What:** Contracts asserting sheet-level semantics — path-template/key structure (a consumer doing keyed lookups depends on `${{ slug }}` semantics), required indexes.
+- **Why deferred:** Record schema covers the motivating cases; key-semantics assertions are where scope creep would live. Needs concrete consumer demand first.
+
 ### Persisted indexes
 
 - **What:** Allow secondary indices (currently in-memory only) to materialize to disk under a `.gitsheets/.indexes/` tree, so consumers don't pay rebuild cost across restarts.


### PR DESCRIPTION
## What

Specs and plans for **schema contracts** — cross-system sheet consumption as a checked interface. No implementation in this PR; the three-plan DAG is scoped to proceed once these are accepted.

**New spec: `specs/behaviors/contracts.md`.** A sheet declares `implements = ['gitsheets.io/meals/v1']`; the contract document is vendored in **canonical TOML** at a path derived from its name under `.gitsheets/contracts/`. The design's load-bearing choices:

- **The lock is the artifact.** The vendored bytes are what validation compiles *and* what identity hashes — no separately recorded integrity hash that could disagree with reality. Git content-addresses it for free (identity ≡ blob OID).
- **Conformance by construction, never subtyping proofs.** Declared contracts compose into write-time validation as `allOf(contracts…, local schema)` — every record a declaring sheet ever commits conforms; drift is a commit-time failure in the producer. No schema-vs-schema comparison exists anywhere in the design.
- **Canonical TOML as identity.** The core's existing same-data-same-bytes encoder makes byte-equality ≡ data-equality, cross-binding, with zero new canonicalization machinery. Contracts are restricted to the TOML data model — which is alignment, not compromise, since they describe TOML-resident records (a `null` branch could never match anything).
- **Two-rung consumer ladder.** Rung 1: declared name + byte-identical vendored document → present *and* future guaranteed, zero records read. Rung 2 (fallback, and the duck-typing path for contract-unaware sheets): structural validation of records → present guaranteed. A rung-1 miss degrades to evidence-checking, not rejection; refusal happens only at wiring time, never mid-read.
- **Evolution without entailment reasoning**: additive revisions ship as new immutable names adopted *alongside* the old (`implements` is a list; multi-conformance is enforced by the same `allOf`); breaking revisions migrate by bridge (rename-by-addition) or hard cutover with precise early failure. Published versions are immutable absolutely — succession metadata is a registry concern, deferred.

**Amendments**: `validation.md` (layer-1 composition), `repository.md` (`openSheet` `contract` option, modes, `contractVerification`), `cli.md` (`git sheet contracts adopt/verify/test/sync/export/prune`, exit 67), `errors.md` (`ContractError` + codes, `ValidationIssue.contract`/`.record`), `concepts.md` (Contract entry), `deferred.md` (source shorthand + vanity resolution, registry-as-gitsheet, `$ref` closure, sheet-level assertions).

**Plans** (`specops next` parses clean):

```
contracts-core  ──►  contracts-cli
            └────►  contracts-consumer-verify
```

## Why

One system consuming a ref'd gitsheet from another currently rests on hopeful convention — the consumer's expectations live implicitly in its code, and drift surfaces as late runtime confusion in the party that didn't cause it. Motivating pair: a generic toolkit module reading a domain sheet from a private repo via instance configuration (repo path + sheet name). Contracts make the consumer's expectations a first-class, named, verifiable artifact, while keeping producer-local growth at zero coordination cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1