### PR TITLE
feat: consumer-side contract verification — the two-rung ladder in openSheet

### DIFF
--- a/packages/gitsheets/src/contract-verification.test.ts
+++ b/packages/gitsheets/src/contract-verification.test.ts
@@ -1,0 +1,250 @@
+// Consumer-side contract verification — the two-rung ladder in
+// `openSheet(name, { contract })`. See specs/behaviors/contracts.md "Consumer
+// verification" and specs/api/repository.md `opts.contract`.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ContractError } from './errors.js';
+import { openRepo } from './repository.js';
+import { testRepo, type TestRepoHandle } from './test-helpers/test-repo.js';
+import { stringifyRecord } from './toml.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+async function makeRepo(): Promise<TestRepoHandle> {
+  const h = await testRepo({ withInitialCommit: true });
+  handles.push(h);
+  return h;
+}
+
+const AUTHOR = { name: 'Test', email: 'test@gitsheets.local' };
+
+/** A minimal contract requiring `required` string fields, keyed by `$id = https://<name>`. */
+function contractDoc(name: string, required: string[] = ['name']): Record<string, unknown> {
+  return {
+    $id: `https://${name}`,
+    type: 'object',
+    required,
+    properties: Object.fromEntries(required.map((f) => [f, { type: 'string' }])),
+  };
+}
+
+/** Vendor `doc` at its derived path (`.gitsheets/contracts/<name>.toml`), staged but not committed. */
+async function stageVendoredContract(
+  fixture: TestRepoHandle,
+  name: string,
+  doc: Record<string, unknown>,
+): Promise<void> {
+  const segments = name.split('/');
+  const dir = join(fixture.path, '.gitsheets/contracts', ...segments.slice(0, -1));
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, `${segments.at(-1)}.toml`), stringifyRecord(doc));
+  await fixture.git('add', '.gitsheets/contracts');
+}
+
+/** Seed `.gitsheets/meals.toml` declaring `implementsNames`, staged but not committed. */
+async function stageMealsConfig(
+  fixture: TestRepoHandle,
+  implementsNames: string[] = [],
+): Promise<void> {
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  const implementsLine =
+    implementsNames.length > 0
+      ? `implements = [${implementsNames.map((n) => `'${n}'`).join(', ')}]\n`
+      : '';
+  await writeFile(
+    join(fixture.path, '.gitsheets/meals.toml'),
+    `[gitsheet]\nroot = 'meals'\npath = '\${{ slug }}'\n${implementsLine}`,
+  );
+  await fixture.git('add', '.gitsheets/meals.toml');
+}
+
+const MEALS_V1 = 'example.com/meals/v1';
+const MEALS_V1_1 = 'example.com/meals/v1.1';
+
+describe('openSheet contract verification — rung 1 (declared identity)', () => {
+  it('passes with zero record reads when the sheet declares the byte-identical contract', async () => {
+    const fixture = await makeRepo();
+    const doc = contractDoc(MEALS_V1);
+    await stageMealsConfig(fixture, [MEALS_V1]);
+    await stageVendoredContract(fixture, MEALS_V1, doc);
+    // A garbage record file that would blow up record parsing if rung 1 ever
+    // fell through to reading records — proves the zero-record-read claim.
+    await mkdir(join(fixture.path, 'meals'), { recursive: true });
+    await writeFile(join(fixture.path, 'meals/garbage.toml'), 'not [ valid toml');
+    await fixture.git('add', '.');
+    await fixture.git('commit', '-m', 'seed meals');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const meals = await repo.openSheet('meals', { contract: { schema: doc } });
+
+    expect(meals.contractVerification).toMatchObject({
+      name: MEALS_V1,
+      rung: 'declared',
+      conforming: true,
+    });
+    expect(meals.contractVerification?.issues).toEqual([]);
+  });
+
+  it('falls through to rung 2 (structural) when the producer implements a newer, data-compatible version', async () => {
+    const fixture = await makeRepo();
+    const docV1_1 = contractDoc(MEALS_V1_1, ['name']);
+    await stageMealsConfig(fixture, [MEALS_V1_1]);
+    await stageVendoredContract(fixture, MEALS_V1_1, docV1_1);
+    await fixture.git('commit', '-m', 'seed meals');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'add a meal', author: AUTHOR }, async (tx) =>
+      tx.sheet('meals').upsert({ slug: 'chili', name: 'Chili' }),
+    );
+
+    // The consumer still holds v1 — rung 1 misses (v1 isn't declared), but
+    // the producer's data satisfies v1's requirements too.
+    const docV1 = contractDoc(MEALS_V1, ['name']);
+    const meals = await repo.openSheet('meals', { contract: { schema: docV1 } });
+    expect(meals.contractVerification).toMatchObject({
+      name: MEALS_V1,
+      rung: 'structural',
+      conforming: true,
+    });
+  });
+});
+
+describe('openSheet contract verification — rung 2 (structural) failures', () => {
+  it('reports a per-record, per-field conformance report naming the contract', async () => {
+    const fixture = await makeRepo();
+    await stageMealsConfig(fixture); // contract-unaware sheet
+    await fixture.git('commit', '-m', 'seed meals');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'add meals', author: AUTHOR }, async (tx) => {
+      await tx.sheet('meals').upsert({ slug: 'chili', name: 'Chili' });
+      await tx.sheet('meals').upsert({ slug: 'soup' }); // missing `name`
+    });
+
+    const doc = contractDoc(MEALS_V1, ['name']);
+    await expect(repo.openSheet('meals', { contract: { schema: doc } })).rejects.toSatisfy(
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ContractError);
+        const ce = err as ContractError;
+        expect(ce.code).toBe('contract_unsatisfied');
+        expect(ce.contract).toBe(MEALS_V1);
+        const issue = ce.issues?.find((i) => i.record === 'soup');
+        expect(issue).toBeDefined();
+        expect(issue?.contract).toBe(MEALS_V1);
+        expect(issue?.code).toBe('required');
+        expect(ce.issues?.some((i) => i.record === 'chili')).toBe(false);
+        return true;
+      },
+    );
+  });
+});
+
+describe('openSheet contract verification — modes', () => {
+  it('declared mode refuses without reading records, never falling back to structural', async () => {
+    const fixture = await makeRepo();
+    await stageMealsConfig(fixture); // not declared at all
+    await mkdir(join(fixture.path, 'meals'), { recursive: true });
+    await writeFile(join(fixture.path, 'meals/garbage.toml'), 'not [ valid toml');
+    await fixture.git('add', '.');
+    await fixture.git('commit', '-m', 'seed meals');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    const doc = contractDoc(MEALS_V1);
+    await expect(
+      repo.openSheet('meals', { contract: { schema: doc, mode: 'declared' } }),
+    ).rejects.toThrow(ContractError);
+  });
+
+  it('structural mode duck-types a contract-unaware sheet, ignoring declarations', async () => {
+    const fixture = await makeRepo();
+    await stageMealsConfig(fixture); // no implements
+    await fixture.git('commit', '-m', 'seed meals');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'add a meal', author: AUTHOR }, async (tx) =>
+      tx.sheet('meals').upsert({ slug: 'chili', name: 'Chili' }),
+    );
+
+    const doc = contractDoc(MEALS_V1);
+    const meals = await repo.openSheet('meals', {
+      contract: { schema: doc, mode: 'structural' },
+    });
+    expect(meals.contractVerification).toMatchObject({ rung: 'structural', conforming: true });
+  });
+});
+
+describe('openSheet contract verification — advisory drift', () => {
+  it('fires onDrift after a non-conforming commit while reads still succeed', async () => {
+    const fixture = await makeRepo();
+    await stageMealsConfig(fixture); // contract-unaware — rung 2 duck typing
+    await fixture.git('commit', '-m', 'seed meals');
+
+    const repo = await openRepo({ gitDir: fixture.gitDir });
+    await repo.transact({ message: 'add a conforming meal', author: AUTHOR }, async (tx) =>
+      tx.sheet('meals').upsert({ slug: 'chili', name: 'Chili' }),
+    );
+
+    const doc = contractDoc(MEALS_V1);
+    const onDrift = vi.fn();
+    const meals = await repo.openSheet('meals', {
+      contract: { schema: doc, mode: 'structural', onDrift },
+    });
+    expect(meals.contractVerification?.conforming).toBe(true);
+
+    // A producer commit that regresses conformance (no `name`) — the sheet's
+    // own schema doesn't require it, only the consumer's contract does.
+    await repo.transact({ message: 'add a non-conforming meal', author: AUTHOR }, async (tx) =>
+      tx.sheet('meals').upsert({ slug: 'mystery' }),
+    );
+
+    // The drift re-check is lazy/async (fire-and-forget) — flush microtasks.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onDrift).toHaveBeenCalledTimes(1);
+    const report = onDrift.mock.calls[0]?.[0];
+    expect(report).toMatchObject({ name: MEALS_V1, conforming: false });
+    expect(report.issues.some((i: { record?: string }) => i.record === 'mystery')).toBe(true);
+
+    // Reads are never gated on drift.
+    const all: unknown[] = [];
+    for await (const record of meals.query({})) all.push(record);
+    expect(all).toHaveLength(2);
+  });
+});
+
+describe('openSheet contract verification — end to end', () => {
+  it('a consumer holding a contract wires to a fixture meal-bank sheet in another repo', async () => {
+    const producer = await makeRepo();
+    const doc = contractDoc(MEALS_V1, ['name', 'servings']);
+    await stageMealsConfig(producer, [MEALS_V1]);
+    await stageVendoredContract(producer, MEALS_V1, doc);
+    await producer.git('commit', '-m', 'seed meal-bank');
+
+    const producerRepo = await openRepo({ gitDir: producer.gitDir });
+    await producerRepo.transact({ message: 'stock the meal bank', author: AUTHOR }, async (tx) => {
+      await tx.sheet('meals').upsert({ slug: 'chili', name: 'Chili', servings: '4' });
+      await tx.sheet('meals').upsert({ slug: 'soup', name: 'Soup', servings: '2' });
+    });
+
+    // The consumer holds its own copy of the contract document (e.g. vendored
+    // in ITS repo, or embedded in code) — a separate repo entirely.
+    const mealBank = await producerRepo.openSheet('meals', { contract: { schema: doc } });
+    expect(mealBank.contractVerification).toMatchObject({ name: MEALS_V1, rung: 'declared' });
+
+    const meals: Array<{ slug: string; name: string; servings: string }> = [];
+    for await (const record of mealBank.query({})) {
+      meals.push(record as { slug: string; name: string; servings: string });
+    }
+    expect(meals.map((m) => m.slug).sort()).toEqual(['chili', 'soup']);
+  });
+});

--- a/packages/gitsheets/src/contracts.ts
+++ b/packages/gitsheets/src/contracts.ts
@@ -10,9 +10,60 @@
 // rung-1 (declared-identity) verification.
 
 import { addon, callCore } from './core.js';
+import type { ValidationIssue } from './errors.js';
 
 /** Text format for a `string` input to {@link canonicalContractHash}. */
 export type ContractDocumentFormat = 'json' | 'toml';
+
+/**
+ * Consumer verification modes — the two-rung ladder in
+ * specs/behaviors/contracts.md "Consumer verification":
+ *
+ * - `'verify'` (default) — rung 1 (declared identity), falling back to rung 2
+ *   (structural) on a miss.
+ * - `'declared'` — rung 1 only; never reads records. A miss throws
+ *   immediately.
+ * - `'structural'` — rung 2 only (duck typing; ignores any declaration).
+ */
+export type ContractVerificationMode = 'verify' | 'declared' | 'structural';
+
+/**
+ * The result of a successful consumer verification — `sheet.contractVerification`
+ * (specs/api/repository.md `opts.contract`). `rung` names which guarantee was
+ * actually obtained; `tree` is the read-snapshot tree hash it's pinned to.
+ */
+export interface ConformanceReport {
+  readonly name: string;
+  readonly rung: 'declared' | 'structural';
+  readonly tree: string;
+  readonly conforming: boolean;
+  readonly issues: readonly ValidationIssue[];
+}
+
+/**
+ * `openSheet(name, { contract })` options — consumer-side contract
+ * verification per specs/behaviors/contracts.md "Consumer verification".
+ */
+export interface OpenSheetContractOptions {
+  /** The contract document the consumer holds: parsed data, or JSON/TOML text. */
+  readonly schema: unknown;
+  /**
+   * Required when `schema` is a string — matches {@link canonicalContractHash}:
+   * there is no format auto-detection.
+   */
+  readonly format?: ContractDocumentFormat;
+  /** Default `'verify'`. */
+  readonly mode?: ContractVerificationMode;
+  /**
+   * Advisory drift signal for rung-2 (structural) verified sheets: invoked
+   * with a regressed conformance report when a rebind to a changed tree
+   * (specs/behaviors/freshness.md) finds the sheet no longer conforms. Reads
+   * are never blocked by drift — this is a signal, not a gate. Not invoked
+   * for rung-1 (declared) verified sheets — write-time enforcement makes
+   * that guarantee good going forward, by construction.
+   */
+  readonly onDrift?: (report: ConformanceReport) => void;
+}
 
 export interface CanonicalContractHashOptions {
   /**

--- a/packages/gitsheets/src/errors.ts
+++ b/packages/gitsheets/src/errors.ts
@@ -9,6 +9,12 @@ export interface ValidationIssue {
   readonly code?: string;
   /** The contract name, when the failing branch is a declared contract composed via `allOf`. */
   readonly contract?: string;
+  /**
+   * The record's sheet-relative path, in a multi-record conformance report
+   * (`ContractError.issues` from consumer-side contract verification — see
+   * specs/behaviors/contracts.md "Consumer verification").
+   */
+  readonly record?: string;
 }
 
 const STATUS_BY_CODE = {

--- a/packages/gitsheets/src/index.ts
+++ b/packages/gitsheets/src/index.ts
@@ -80,7 +80,13 @@ export type {
 } from './path-template/index.js';
 
 export { canonicalContractHash } from './contracts.js';
-export type { CanonicalContractHashOptions, ContractDocumentFormat } from './contracts.js';
+export type {
+  CanonicalContractHashOptions,
+  ConformanceReport,
+  ContractDocumentFormat,
+  ContractVerificationMode,
+  OpenSheetContractOptions,
+} from './contracts.js';
 
 export { validateRecord } from './validation.js';
 export type {

--- a/packages/gitsheets/src/repository.ts
+++ b/packages/gitsheets/src/repository.ts
@@ -10,6 +10,7 @@ import type { Readable } from 'node:stream';
 import { promisify } from 'node:util';
 
 import { addon, callCore, CoreTransaction } from './core.js';
+import type { OpenSheetContractOptions } from './contracts.js';
 import { ConfigError, NotFoundError, RefError, TransactionError } from './errors.js';
 import type { RecordLike } from './path-template/index.js';
 import {
@@ -61,6 +62,14 @@ export interface OpenSheetOptions<T extends RecordLike = RecordLike> {
   readonly prefix?: string;
   /** Standard Schema validator; runs after the persisted JSON Schema. */
   readonly validator?: StandardSchemaV1<unknown, T>;
+  /**
+   * Consumer-side contract verification (the two-rung ladder) — verifies this
+   * sheet against a contract document the consumer holds before the handle is
+   * returned. See specs/behaviors/contracts.md "Consumer verification" and
+   * specs/api/repository.md. Throws `ContractError('contract_unsatisfied')`
+   * on failure.
+   */
+  readonly contract?: OpenSheetContractOptions;
 }
 
 /** Options for {@link Repository.openSheets}. No `validator` — use {@link openStore} for that. */
@@ -284,6 +293,12 @@ export class Repository {
     const sheet = new Sheet<T>(sheetOpts);
     // Eagerly validate config exists by reading once.
     await sheet.readConfig();
+    if (opts.contract !== undefined) {
+      // Runs before the handle is returned — see specs/api/repository.md
+      // `opts.contract` and specs/behaviors/contracts.md "Consumer
+      // verification". Throws ContractError(contract_unsatisfied) on failure.
+      await sheet.verifyContract(opts.contract);
+    }
     return sheet;
   }
 

--- a/packages/gitsheets/src/sheet.ts
+++ b/packages/gitsheets/src/sheet.ts
@@ -9,13 +9,16 @@ import type { Readable } from 'node:stream';
 import { createPatch as rfc6902CreatePatch, type Operation as JsonPatchOp } from 'rfc6902';
 
 import { addon, callCore, CoreTransaction } from './core.js';
+import type { ConformanceReport, OpenSheetContractOptions } from './contracts.js';
 import {
   ConfigError,
+  ContractError,
   IndexError,
   NotFoundError,
   PathTemplateError,
   RefError,
   TransactionError,
+  type ValidationIssue,
 } from './errors.js';
 import { mergePatch } from './patch.js';
 import { Template, type RecordLike } from './path-template/index.js';
@@ -760,6 +763,17 @@ export class Sheet<T extends RecordLike = RecordLike> {
   readonly #prefix: string;
   readonly #indexes = new Map<string, IndexState<T>>();
   #configPromise: Promise<SheetConfig> | undefined;
+  /** Set by {@link verifyContract} on a successful `openSheet({ contract })`. */
+  #contractVerification: ConformanceReport | undefined;
+  /** The contract options this sheet was opened with, kept for drift re-checks. */
+  #contractOptions: OpenSheetContractOptions | undefined;
+  /**
+   * Incremented on every {@link rebindReadTree}; a lazy drift re-check
+   * captures it and bails if it's stale by the time the (async) re-verify
+   * settles, so a burst of rebinds can't invoke `onDrift` out of order or
+   * pile up overlapping re-checks.
+   */
+  #driftToken = 0;
 
   constructor(opts: SheetConstructorOptions<T>) {
     this.#repo = opts.repo;
@@ -830,6 +844,102 @@ export class Sheet<T extends RecordLike = RecordLike> {
   }
 
   /**
+   * The result of consumer-side contract verification, when this sheet was
+   * opened with `openSheet(name, { contract })` — `{ name, rung, tree }`, per
+   * specs/api/repository.md. `undefined` when no `contract` option was given.
+   * See specs/behaviors/contracts.md "Consumer verification".
+   */
+  get contractVerification(): ConformanceReport | undefined {
+    return this.#contractVerification;
+  }
+
+  /**
+   * @internal — run consumer-side contract verification (the two-rung
+   * ladder) against this sheet's current read snapshot and set
+   * {@link contractVerification} on success. Called by
+   * `Repository.openSheet({ contract })` before the handle is returned to the
+   * consumer. Throws `ContractError('contract_unsatisfied')` on failure —
+   * both rungs missed (`verify` mode), or the one attempted rung missed
+   * (`declared`/`structural` mode).
+   */
+  async verifyContract(opts: OpenSheetContractOptions): Promise<void> {
+    this.#contractOptions = opts;
+    const treeRef = this.#configTreeRef();
+    const report = this.#runVerify(opts, treeRef);
+    this.#contractVerification = { ...report, tree: treeRef };
+  }
+
+  /** Run the napi verification call once against `treeRef`. Typed errors propagate via `callCore`. */
+  #runVerify(
+    opts: OpenSheetContractOptions,
+    treeRef: string,
+  ): Omit<ConformanceReport, 'tree'> {
+    const raw = callCore(() =>
+      addon.verifySheetContract(
+        this.#gitDir,
+        treeRef,
+        this.#name,
+        this.#configPath,
+        this.#dataBase,
+        this.#prefix,
+        opts.schema as never,
+        opts.format,
+        opts.mode,
+      ),
+    );
+    return {
+      name: raw.name,
+      rung: raw.rung as 'declared' | 'structural',
+      conforming: raw.conforming,
+      // The generated addon type widens `source` to `string`; narrow it back
+      // to the wire union `ValidationIssue` promises.
+      issues: raw.issues.map((issue) => ({
+        ...issue,
+        source: issue.source as ValidationIssue['source'],
+      })),
+    };
+  }
+
+  /**
+   * Advisory drift re-check (specs/behaviors/contracts.md "Consumer
+   * verification": "re-verification is advisory, not blocking"): fired
+   * (never awaited by the caller) after a rebind moves a rung-2
+   * (structural-verified) sheet to a new tree, when the consumer registered
+   * `onDrift`. Reads are never gated on this — a throw here is swallowed
+   * after invoking `onDrift` with the regressed report; a success (still
+   * conforming) is silently a no-op.
+   */
+  #checkDriftAfterRebind(tree: string): void {
+    const verification = this.#contractVerification;
+    const opts = this.#contractOptions;
+    const onDrift = opts?.onDrift;
+    if (verification === undefined || opts === undefined || onDrift === undefined) return;
+    if (verification.rung !== 'structural') return; // rung-1 holds by construction, forever
+    const token = ++this.#driftToken;
+    void Promise.resolve().then(() => {
+      if (token !== this.#driftToken) return; // superseded by a later rebind
+      try {
+        const report = this.#runVerify(opts, tree);
+        this.#contractVerification = { ...report, tree };
+        // Still conforming — not a regression, nothing to signal.
+      } catch (err) {
+        if (token !== this.#driftToken) return;
+        if (err instanceof ContractError) {
+          onDrift({
+            name: verification.name,
+            rung: verification.rung,
+            tree,
+            conforming: false,
+            issues: err.issues ?? [],
+          });
+        }
+        // A non-ContractError (e.g. a transient read failure) is not a
+        // conformance signal — swallow it; drift is advisory, never fatal.
+      }
+    });
+  }
+
+  /**
    * Rebind this sheet's read snapshot to the repository's current HEAD tree.
    * Only this sheet — the "did my row land?" primitive; use `repo.refresh()`
    * or `store.refresh()` to rebind every open sheet at once. Not needed after
@@ -854,12 +964,18 @@ export class Sheet<T extends RecordLike = RecordLike> {
    * tree on next access) and index builds invalidate via the existing
    * `treeHashAtBuild` comparison in `#ensureIndexBuilt`. No-op when the tree
    * hasn't moved, or on a transaction-bound sheet.
+   *
+   * For a rung-2 (structural) contract-verified sheet with an `onDrift`
+   * callback, also schedules a lazy, advisory re-verification against the new
+   * tree (specs/behaviors/contracts.md "Consumer verification") — never
+   * awaited here, never blocking this call or subsequent reads.
    */
   rebindReadTree(tree: string): void {
     if (this.#transaction !== undefined) return;
     if (this.#readRef === tree) return;
     this.#readRef = tree;
     this.#configPromise = undefined;
+    this.#checkDriftAfterRebind(tree);
   }
 
   async readConfig(): Promise<SheetConfig> {

--- a/plans/contracts-consumer-verify.md
+++ b/plans/contracts-consumer-verify.md
@@ -1,11 +1,12 @@
 ---
-status: planned
+status: done
 depends: [contracts-core]
 specs:
   - specs/behaviors/contracts.md
   - specs/api/repository.md
   - specs/api/errors.md
 issues: []
+pr: 267
 ---
 
 # Plan: consumer-side contract verification — the two-rung ladder in `openSheet`
@@ -78,20 +79,20 @@ contract maps (follow-up if demanded).
 
 ## Validation
 
-- [ ] Rung-1 verification of a declaring sheet passes with zero record reads
+- [x] Rung-1 verification of a declaring sheet passes with zero record reads
       and reports `rung: 'declared'`
-- [ ] Against a producer implementing a newer, data-compatible contract
+- [x] Against a producer implementing a newer, data-compatible contract
       version, `verify` mode falls through and passes with
       `rung: 'structural'`
-- [ ] Against a non-conforming sheet, `openSheet` throws
+- [x] Against a non-conforming sheet, `openSheet` throws
       `ContractError('contract_unsatisfied')` whose `issues` name each failing
       record path, field, and the contract
-- [ ] `declared` mode refuses (without reading records) any sheet not
+- [x] `declared` mode refuses (without reading records) any sheet not
       declaring the byte-identical contract; `structural` mode verifies a
       contract-unaware sheet (duck typing)
-- [ ] After a drift-inducing commit in the producer, `onDrift` fires with a
+- [x] After a drift-inducing commit in the producer, `onDrift` fires with a
       regressed report and in-flight reads are unaffected
-- [ ] The motivating pair works end-to-end as a test: a consumer holding a
+- [x] The motivating pair works end-to-end as a test: a consumer holding a
       contract wires to a fixture "meal-bank" sheet in another repo, rung-1
       verifies, reads records typed by the contract
 
@@ -112,8 +113,74 @@ contract maps (follow-up if demanded).
 
 ## Notes
 
-(populated at closeout)
+- **Spec amendment**: `specs/api/repository.md`'s `opts.contract` example
+  listed `schema: object | string` with no `format` field, even though both
+  this plan's Approach and `specs/behaviors/contracts.md` say the input
+  handling "matches `canonicalContractHash`'s" — which requires an explicit
+  `format: 'json' | 'toml'` for text input, with no auto-detection. Added
+  `format?` to the documented shape (required when `schema` is a string), and
+  expanded the documented `sheet.contractVerification` shape from `{ name,
+  rung, tree }` to the full `{ name, rung, tree, conforming, issues }` the
+  implementation returns — the same conformance-report shape `onDrift`
+  receives on a regression (always `conforming: true` / `issues: []` on a
+  successful handle, since a failed verification throws rather than returning
+  a non-conforming report).
+- **Freshness / non-`HEAD`-refs finding** (the plan's flagged risk):
+  `Repository`'s rebind path (`#resolveReadTree`) is unconditionally
+  `HEAD^{tree}` — there is no `ref` option on `openRepo`/`openSheet` today. A
+  "cross-repo consumer reading a ref outside `refs/heads/`" achieves that only
+  by pointing `openRepo({ gitDir })` at a distinct git directory/worktree whose
+  *own* `HEAD` is checked out to the ref of interest. Since the single rebind
+  path (`repo.refresh()` / the post-commit auto-refresh in `repo.transact`)
+  operates purely in terms of "that repository's `HEAD`" regardless of what
+  ref `HEAD` is attached to, the drift hook riding `Sheet.rebindReadTree` sees
+  every rebind there is — there is no separate non-`HEAD`-ref path that could
+  bypass it. No code change was needed; there's nothing to build against a
+  case the library doesn't support yet. Worth revisiting if/when a pinned-ref
+  `openSheet` surface is ever added.
+- **Rung-2 cost on large sheets** — not empirically measured against a
+  large corpus in this plan (the test fixtures are human-cadence-sized, per
+  the design's own target scale). The full-corpus-scan design is unchanged
+  from the plan's Approach; a persisted verification cache keyed by tree hash
+  remains the identified mitigation if this bites in practice, same as
+  contracts-core's own analogous follow-up
+  ([#266](https://github.com/JarvusInnovations/gitsheets/issues/266) for
+  compiled-contract caching).
+- **Drift re-check reuses the full rung-2 scan** — `Sheet`'s lazy drift
+  re-verification (`#checkDriftAfterRebind`) re-runs the *same*
+  `verify_sheet_contract` call against the new tree, i.e. a fresh full-corpus
+  structural scan per rebind for a rung-2-verified sheet with `onDrift`
+  registered. Correct and simple; a future optimization could diff only the
+  paths that changed between the old and new tree instead. Not built here —
+  no drift performance issue observed at the test scale.
+- **`resolve_contract_document`** was factored out of the existing
+  `canonical_contract_hash` (rather than added fresh) so both the identity
+  primitive and the new verification path parse a supplied document through
+  the identical `ContractHashInput` handling — no behavioral difference
+  introduced, no re-tested edge cases beyond what `canonical_contract_hash`'s
+  existing suite already covers.
 
 ## Follow-ups
 
-(populated at closeout)
+- **Python parity** — `verify_sheet_contract` in `gitsheets-core` is fully
+  binding-agnostic, but `rust/gitsheets-py`'s `openSheet` surface doesn't
+  thread `opts.contract` through yet. Deliberately out of scope for this plan
+  (per Scope); a follow-up plan should mirror the Node binding's
+  `verifySheetContract` napi shape onto the pyo3 surface once there's a
+  consumer.
+- **`openSheets`/`openStore` contract maps** — verifying every sheet a Store
+  opens against a map of contracts in one call, rather than per-sheet
+  `openSheet({ contract })`. Explicitly deferred in Scope; revisit if a
+  multi-sheet consumer wants it.
+- **Persisted verification cache** — if rung-2's full-corpus scan cost
+  becomes a real bottleneck at wiring time (see Notes), a cache keyed by data
+  subtree hash (mirroring the existing per-sheet index-build cache pattern in
+  `rust/gitsheets-core/src/sheet.rs`) is the identified fix — sampling is
+  explicitly ruled out (silent partial guarantees).
+- **`contracts test` CLI command** — the CLI-facing half of consumer
+  verification (`specs/behaviors/contracts.md` mentions it alongside
+  `openSheet(name, { contract })`) is producer/CLI tooling, out of scope here
+  per [`contracts-cli`](contracts-cli.md); that plan (or a new one) should
+  reuse `gitsheets_core::verify_sheet_contract` directly — it takes an
+  already-opened `Sheet`, so no core changes should be needed to wire it into
+  a CLI command.

--- a/rust/gitsheets-core/src/codec.rs
+++ b/rust/gitsheets-core/src/codec.rs
@@ -231,6 +231,7 @@ fn serialize_markdown(record: &Value, format: &FormatConfig) -> Result<String> {
                         schema_path: None,
                         code: None,
                         contract: None,
+                        record: None,
                     }],
                 });
             }

--- a/rust/gitsheets-core/src/contract.rs
+++ b/rust/gitsheets-core/src/contract.rs
@@ -24,10 +24,10 @@ use serde_json::Value as Json;
 use sha2::{Digest, Sha256};
 
 use crate::canonical;
-use crate::error::{Error, Result};
+use crate::error::{Error, Result, ValidationIssue};
 use crate::path_template::is_windows_invalid;
 use crate::record;
-use crate::sheet::join_path;
+use crate::sheet::{join_path, Sheet};
 use crate::validation::{self, CompiledSchema};
 use crate::value::{self, Value};
 
@@ -368,18 +368,230 @@ pub enum ContractHashInput {
 /// encoder (`specs/behaviors/contracts.md` "Canonical form": "Byte-equality ≡
 /// data-equality").
 pub fn canonical_contract_hash(input: ContractHashInput) -> Result<String> {
-    let value = match input {
-        ContractHashInput::Data(v) => v,
-        ContractHashInput::Toml(s) => canonical::parse(&s)?,
+    let value = resolve_contract_document(input)?;
+    let bytes = canonical::serialize(&value)?;
+    Ok(sha256_hex(bytes.as_bytes()))
+}
+
+/// Resolve a [`ContractHashInput`] (parsed data, JSON text, or TOML text) into
+/// the core [`Value`] it denotes — the shared first step of
+/// [`canonical_contract_hash`] and consumer-side verification
+/// ([`verify_sheet_contract`]), both of which need the parsed document before
+/// they diverge (one hashes it, the other also compiles it as a schema and
+/// reads its `$id`).
+pub fn resolve_contract_document(input: ContractHashInput) -> Result<Value> {
+    match input {
+        ContractHashInput::Data(v) => Ok(v),
+        ContractHashInput::Toml(s) => canonical::parse(&s),
         ContractHashInput::Json(s) => {
             let json: Json = serde_json::from_str(&s).map_err(|e| Error::ConfigInvalid {
                 message: format!("JSON parse failed: {e}"),
             })?;
-            json_to_value(&json)?
+            json_to_value(&json)
         }
-    };
-    let bytes = canonical::serialize(&value)?;
-    Ok(sha256_hex(bytes.as_bytes()))
+    }
+}
+
+// ── consumer verification: the two-rung ladder ────────────────────────────────
+//
+// `specs/behaviors/contracts.md` "Consumer verification": a consumer holding a
+// contract document verifies a target sheet it has opened (already compiled —
+// `implements` resolved, effective schema composed) via rung 1 (declared
+// identity: name membership + vendored-byte identity) falling through, on a
+// miss, to rung 2 (structural: every record validates against the consumer's
+// document ALONE, ignoring the sheet's own declarations/local schema).
+
+/// Which rungs [`verify_sheet_contract`] attempts. `specs/api/repository.md`
+/// `opts.contract.mode`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyMode {
+    /// Rung 1, falling back to rung 2 on a miss. The default.
+    Verify,
+    /// Rung 1 only — strict, never reads records. A miss is
+    /// `contract_unsatisfied` immediately.
+    Declared,
+    /// Rung 2 only — duck typing; ignores `implements` entirely.
+    Structural,
+}
+
+/// Which rung a verification actually passed at.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Rung {
+    /// Rung 1: the sheet declares the contract's name AND the vendored bytes
+    /// are byte-identical to the consumer's document. Verified present *and*
+    /// future — write-time enforcement guarantees it forever.
+    Declared,
+    /// Rung 2: every current record validates against the consumer's document
+    /// alone. Verified only for the tree hash checked — pure duck typing.
+    Structural,
+}
+
+impl Rung {
+    /// The wire string used on binding surfaces (`sheet.contractVerification.rung`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Rung::Declared => "declared",
+            Rung::Structural => "structural",
+        }
+    }
+}
+
+/// The result of a successful [`verify_sheet_contract`] — mirrors
+/// `sheet.contractVerification` in `specs/api/repository.md` (minus `tree`,
+/// which the binding attaches from the read snapshot it already resolved to
+/// open the sheet).
+#[derive(Clone, Debug)]
+pub struct ConformanceReport {
+    pub name: String,
+    pub rung: Rung,
+    /// Always `true` on `Ok` — [`verify_sheet_contract`] returns
+    /// `Err(Error::ContractUnsatisfied)` (carrying its own `issues`) on
+    /// failure rather than an `Ok` report with `conforming: false`. Kept as an
+    /// explicit field (rather than implied by `Ok`/`Err`) because the same
+    /// shape is reused host-side to describe a *regressed* drift re-check,
+    /// where `conforming` is `false`.
+    pub conforming: bool,
+    pub issues: Vec<ValidationIssue>,
+}
+
+/// Extract the contract name from a document's `$id` (`specs/behaviors/
+/// contracts.md` "Contract name": the `$id` with the `https://` scheme
+/// stripped). The consumer's own document is expected to already be a valid
+/// contract (mirrored — perhaps freshly authored — from one that was
+/// vendored and validated elsewhere), so this only checks the one thing
+/// `verify_sheet_contract` actually needs: a well-formed `$id` to derive
+/// identity from. A malformed/missing `$id` is the caller's input error.
+fn contract_name_from_document(json: &Json) -> Result<String> {
+    let id = json
+        .as_object()
+        .and_then(|o| o.get("$id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| Error::ConfigInvalid {
+            message: "contract document is missing a required string \"$id\" (a consumer-held \
+                      document must carry the same $id its contract name derives from)"
+                .to_string(),
+        })?;
+    id.strip_prefix("https://")
+        .map(str::to_string)
+        .ok_or_else(|| Error::ConfigInvalid {
+            message: format!(
+                "contract document $id {id:?} does not have the required \"https://\" scheme"
+            ),
+        })
+}
+
+/// Read the vendored contract text at its derived path, if present. Unlike
+/// [`load_contract`] this does NOT re-check document requirements or
+/// canonical-bytes — by the time a caller has a successfully-`Sheet::open`ed
+/// sheet in hand, every contract it `implements` already passed those checks
+/// once at open time. A miss here (absent, not UTF-8) degrades to a rung-1
+/// miss rather than an error — "mismatch is evidence to check, not grounds to
+/// refuse" (`specs/behaviors/contracts.md` principles) applies just as much to
+/// a vendored-read hiccup as to a hash mismatch.
+fn read_vendored_text(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    open_root: &str,
+    name: &str,
+) -> Option<String> {
+    let full_path = format!("{}.toml", join_path(&[open_root, ".gitsheets/contracts", name]));
+    let bytes = tree.read_blob(repo, &full_path).ok().flatten()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// Verify `sheet` (already opened against `tree`) against the consumer's
+/// `document`, per `specs/behaviors/contracts.md` "Consumer verification":
+///
+/// - **Rung 1** (skipped in [`VerifyMode::Structural`]): `sheet`'s `implements`
+///   names the document's contract AND the vendored bytes at the derived path
+///   (under `open_root`) are canonical-hash-identical to `document`. Pass →
+///   `Ok` with [`Rung::Declared`], **zero records read**.
+/// - **Rung 2** (skipped in [`VerifyMode::Declared`]): every record of `sheet`
+///   validates against `document` alone (not composed with the sheet's own
+///   schema/contracts — pure duck typing). Pass → `Ok` with
+///   [`Rung::Structural`].
+/// - Both rungs miss (or the attempted rung misses, in `Declared`/`Structural`
+///   mode) → [`Error::ContractUnsatisfied`] carrying the conformance report:
+///   an empty `issues` list for a `Declared`-mode miss (it never reads
+///   records to produce field-level issues), or one [`ValidationIssue`] per
+///   failing field per record (tagged `record`/`contract`) for a rung-2 miss.
+pub fn verify_sheet_contract(
+    repo: &gix::Repository,
+    tree: &mut MutableTree,
+    open_root: &str,
+    sheet: &Sheet,
+    document: ContractHashInput,
+    mode: VerifyMode,
+) -> Result<ConformanceReport> {
+    let value = resolve_contract_document(document)?;
+    let json = validation::value_to_json(&value);
+    let name = contract_name_from_document(&json)?;
+
+    if !matches!(mode, VerifyMode::Structural) {
+        let declared = sheet.config().implements.iter().any(|n| n == &name);
+        if declared {
+            if let Some(vendored_text) = read_vendored_text(repo, tree, open_root, &name) {
+                let vendored_hash =
+                    canonical_contract_hash(ContractHashInput::Toml(vendored_text))?;
+                let consumer_hash = canonical_contract_hash(ContractHashInput::Data(value.clone()))?;
+                if vendored_hash == consumer_hash {
+                    return Ok(ConformanceReport {
+                        name,
+                        rung: Rung::Declared,
+                        conforming: true,
+                        issues: Vec::new(),
+                    });
+                }
+            }
+        }
+        if matches!(mode, VerifyMode::Declared) {
+            return Err(Error::ContractUnsatisfied {
+                message: format!(
+                    "sheet {:?} does not declare contract {name:?} with a byte-identical vendored \
+                     document — declared mode never falls back to structural validation",
+                    sheet.name()
+                ),
+                contract: name,
+                issues: Vec::new(),
+            });
+        }
+        // Rung-1 miss: evidence to check, not grounds to refuse — fall through
+        // to rung 2 (e.g. the producer implements a newer, data-compatible
+        // version).
+    }
+
+    // Rung 2 — structural: compile the CONSUMER's document alone (never
+    // composed with the sheet's own schema/contracts) and validate every
+    // current record against it.
+    let compiled = CompiledSchema::compile(&value)?;
+    let records = sheet.list(repo, tree, true)?;
+    let mut issues = Vec::new();
+    for (path, record) in &records {
+        for mut issue in compiled.validate(record) {
+            issue.contract = Some(name.clone());
+            issue.record = Some(path.clone());
+            issues.push(issue);
+        }
+    }
+    if issues.is_empty() {
+        Ok(ConformanceReport {
+            name,
+            rung: Rung::Structural,
+            conforming: true,
+            issues: Vec::new(),
+        })
+    } else {
+        Err(Error::ContractUnsatisfied {
+            message: format!(
+                "sheet {:?} does not structurally conform to contract {name:?}: {} issue(s) \
+                 across its records",
+                sheet.name(),
+                issues.len()
+            ),
+            contract: name,
+            issues,
+        })
+    }
 }
 
 /// Marshal a `serde_json::Value` into the core [`Value`], applying the same
@@ -787,5 +999,208 @@ mod tests {
         let err =
             canonical_contract_hash(ContractHashInput::Json(r#"{"a":[1,null]}"#.into())).unwrap_err();
         assert_eq!(err.code(), "config_invalid");
+    }
+}
+
+#[cfg(test)]
+mod verify_tests {
+    use super::*;
+    use crate::record::{write_records, TOML_EXTENSION};
+
+    fn temp_repo() -> (tempfile::TempDir, gix::Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = gix::init(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    /// Vendor `doc` at contract `name`'s derived path, through the same
+    /// canonical encoder `load_contract`'s canonical-bytes check compares
+    /// against.
+    fn vendor_contract(repo: &gix::Repository, tree: &mut MutableTree, name: &str, doc: &Json) {
+        let value = json_to_value(doc).unwrap();
+        let bytes = canonical::serialize(&value).unwrap();
+        let path = contract_path(name);
+        tree.write_child(repo, &path, &bytes).unwrap();
+    }
+
+    fn sheet_config(implements: &[&str]) -> Value {
+        let mut gs = IndexMap::new();
+        gs.insert("path".to_string(), Value::String("${{ slug }}".into()));
+        gs.insert("root".to_string(), Value::String("people".into()));
+        if !implements.is_empty() {
+            gs.insert(
+                "implements".to_string(),
+                Value::Array(
+                    implements
+                        .iter()
+                        .map(|n| Value::String((*n).to_string()))
+                        .collect(),
+                ),
+            );
+        }
+        let mut top = IndexMap::new();
+        top.insert("gitsheet".to_string(), Value::Table(gs));
+        Value::Table(top)
+    }
+
+    fn write_config(repo: &gix::Repository, tree: &mut MutableTree, config: Value) {
+        write_records(repo, tree, ".gitsheets", &[("people".into(), config)], TOML_EXTENSION)
+            .unwrap();
+    }
+
+    fn write_record(repo: &gix::Repository, tree: &mut MutableTree, slug: &str, fields: &[(&str, &str)]) {
+        let mut m = IndexMap::new();
+        m.insert("slug".to_string(), Value::String(slug.to_string()));
+        for (k, v) in fields {
+            m.insert((*k).to_string(), Value::String((*v).to_string()));
+        }
+        let value = Value::Table(m);
+        let bytes = canonical::serialize(&value).unwrap();
+        tree.write_child(repo, &format!("people/{slug}.toml"), &bytes).unwrap();
+    }
+
+    fn open_people(repo: &gix::Repository, tree: &mut MutableTree) -> Sheet {
+        Sheet::open(repo, tree, "people", ".gitsheets/people.toml", ".", "").unwrap()
+    }
+
+    const NAME: &str = "example.com/people/v1";
+    const NAME_V1_1: &str = "example.com/people/v1.1";
+
+    fn consumer_doc(name: &str, required: &[&str]) -> Json {
+        serde_json::json!({
+            "$id": format!("https://{name}"),
+            "type": "object",
+            "required": required,
+        })
+    }
+
+    #[test]
+    fn rung1_passes_with_zero_record_reads() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_config(&repo, &mut tree, sheet_config(&[NAME]));
+        let doc = consumer_doc(NAME, &["email"]);
+        vendor_contract(&repo, &mut tree, NAME, &doc);
+        // A garbage record that would blow up `Sheet::list` if rung 1 ever
+        // fell through to reading records — proves the zero-record-read claim.
+        tree.write_child(&repo, "people/garbage.toml", "not [ valid toml").unwrap();
+        let sheet = open_people(&repo, &mut tree);
+
+        let report = verify_sheet_contract(
+            &repo,
+            &mut tree,
+            ".",
+            &sheet,
+            ContractHashInput::Data(json_to_value(&doc).unwrap()),
+            VerifyMode::Verify,
+        )
+        .unwrap();
+        assert_eq!(report.name, NAME);
+        assert_eq!(report.rung, Rung::Declared);
+        assert!(report.conforming);
+        assert!(report.issues.is_empty());
+    }
+
+    #[test]
+    fn rung1_miss_on_a_newer_producer_version_falls_through_to_rung2_pass() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        // Producer declares the NEWER, data-compatible version…
+        write_config(&repo, &mut tree, sheet_config(&[NAME_V1_1]));
+        let doc_v1_1 = consumer_doc(NAME_V1_1, &["email"]);
+        vendor_contract(&repo, &mut tree, NAME_V1_1, &doc_v1_1);
+        write_record(&repo, &mut tree, "jane", &[("email", "jane@x.org")]);
+        let sheet = open_people(&repo, &mut tree);
+
+        // …but the consumer still holds v1 — a rung-1 miss (name not
+        // declared) that falls through to a rung-2 pass (the data satisfies
+        // v1 too).
+        let doc_v1 = consumer_doc(NAME, &["email"]);
+        let report = verify_sheet_contract(
+            &repo,
+            &mut tree,
+            ".",
+            &sheet,
+            ContractHashInput::Data(json_to_value(&doc_v1).unwrap()),
+            VerifyMode::Verify,
+        )
+        .unwrap();
+        assert_eq!(report.rung, Rung::Structural);
+        assert!(report.conforming);
+    }
+
+    #[test]
+    fn rung2_failure_reports_record_and_field_level_issues() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_config(&repo, &mut tree, sheet_config(&[])); // contract-unaware
+        write_record(&repo, &mut tree, "jane", &[("email", "jane@x.org")]);
+        write_record(&repo, &mut tree, "bob", &[]); // missing email
+        let sheet = open_people(&repo, &mut tree);
+
+        let doc = consumer_doc(NAME, &["email"]);
+        let err = verify_sheet_contract(
+            &repo,
+            &mut tree,
+            ".",
+            &sheet,
+            ContractHashInput::Data(json_to_value(&doc).unwrap()),
+            VerifyMode::Verify,
+        )
+        .unwrap_err();
+        assert_eq!(err.code(), "contract_unsatisfied");
+        assert_eq!(err.contract(), Some(NAME));
+        let issues = err.issues();
+        assert!(issues.iter().any(|i| i.record.as_deref() == Some("bob")
+            && i.contract.as_deref() == Some(NAME)
+            && i.code.as_deref() == Some("required")));
+        assert!(!issues.iter().any(|i| i.record.as_deref() == Some("jane")));
+    }
+
+    #[test]
+    fn declared_mode_fails_fast_without_reading_records() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_config(&repo, &mut tree, sheet_config(&[])); // not declared
+        tree.write_child(&repo, "people/garbage.toml", "not [ valid toml").unwrap();
+        let sheet = open_people(&repo, &mut tree);
+
+        let doc = consumer_doc(NAME, &["email"]);
+        let err = verify_sheet_contract(
+            &repo,
+            &mut tree,
+            ".",
+            &sheet,
+            ContractHashInput::Data(json_to_value(&doc).unwrap()),
+            VerifyMode::Declared,
+        )
+        .unwrap_err();
+        assert_eq!(err.code(), "contract_unsatisfied");
+        assert!(
+            err.issues().is_empty(),
+            "declared mode never scans records — no per-record issues"
+        );
+    }
+
+    #[test]
+    fn structural_mode_ignores_declarations_and_duck_types() {
+        let (_d, repo) = temp_repo();
+        let mut tree = MutableTree::empty();
+        write_config(&repo, &mut tree, sheet_config(&[])); // no implements at all
+        write_record(&repo, &mut tree, "jane", &[("email", "jane@x.org")]);
+        let sheet = open_people(&repo, &mut tree);
+
+        let doc = consumer_doc(NAME, &["email"]);
+        let report = verify_sheet_contract(
+            &repo,
+            &mut tree,
+            ".",
+            &sheet,
+            ContractHashInput::Data(json_to_value(&doc).unwrap()),
+            VerifyMode::Structural,
+        )
+        .unwrap();
+        assert_eq!(report.rung, Rung::Structural);
+        assert!(report.conforming);
     }
 }

--- a/rust/gitsheets-core/src/error.rs
+++ b/rust/gitsheets-core/src/error.rs
@@ -43,6 +43,11 @@ pub struct ValidationIssue {
     /// sheet's own `[gitsheet.schema]` branch, and always `None` for a sheet
     /// that declares no contracts.
     pub contract: Option<String>,
+    /// The record's sheet-relative path, in a multi-record conformance report
+    /// (`ContractError.issues` from `contracts-consumer-verify`'s rung-2
+    /// structural validation — see `specs/behaviors/contracts.md` "Consumer
+    /// verification"). `None` for a single-record write-time issue.
+    pub record: Option<String>,
 }
 
 /// The error class a variant maps to on the Node surface. These names match the
@@ -400,6 +405,7 @@ mod tests {
                 schema_path: Some("#/properties/email/pattern".into()),
                 code: Some("pattern".into()),
                 contract: None,
+                record: None,
             }],
         };
         assert_eq!(err.issues().len(), 1);
@@ -428,6 +434,7 @@ mod tests {
                 schema_path: Some("#/properties/email/pattern".into()),
                 code: Some("pattern".into()),
                 contract: Some("example.com/c/v1".into()),
+                record: Some("people/jane".into()),
             }],
         };
         assert_eq!(err.issues().len(), 1);

--- a/rust/gitsheets-core/src/lib.rs
+++ b/rust/gitsheets-core/src/lib.rs
@@ -38,7 +38,10 @@ pub mod value;
 pub use canonical::{normalize, parse, parse_batch, serialize, serialize_batch};
 pub use codec::{extract_first_h1, normalize_body, rewrite_leading_h1};
 pub use config::{FieldConfig, FormatConfig, FormatKind, SheetConfig, SortDir, SortRule};
-pub use contract::{canonical_contract_hash, contract_path, validate_name as validate_contract_name, ContractHashInput};
+pub use contract::{
+    canonical_contract_hash, contract_path, validate_name as validate_contract_name,
+    verify_sheet_contract, ConformanceReport, ContractHashInput, Rung, VerifyMode,
+};
 pub use diff::{apply_merge_patch, create_patch, MergePatch, PatchOp, PatchOpKind, PatchValue};
 pub use error::{Error, ErrorClass, IssueSource, Result, ValidationIssue};
 pub use index::{MultiIndex, UniqueIndex};
@@ -78,6 +81,7 @@ pub fn example_error(code: &str) -> Option<Error> {
                 schema_path: Some("#/properties/email/pattern".into()),
                 code: Some("pattern".into()),
                 contract: None,
+                record: None,
             }],
         },
         "transaction_in_progress" => Error::TransactionInProgress { message: msg },
@@ -114,6 +118,7 @@ pub fn example_error(code: &str) -> Option<Error> {
                 schema_path: Some("#/properties/email/pattern".into()),
                 code: Some("pattern".into()),
                 contract: Some("example.com/contracts/v1".into()),
+                record: Some("people/jane".into()),
             }],
         },
         _ => return None,

--- a/rust/gitsheets-core/src/validation.rs
+++ b/rust/gitsheets-core/src/validation.rs
@@ -115,6 +115,8 @@ impl CompiledSchema {
                 // ajv's `keyword` is the last schemaPath segment — same here.
                 code: keyword_from_schema_path(&schema_path),
                 contract,
+                // Single-record write-time validation — no multi-record report.
+                record: None,
             });
         }
         issues

--- a/rust/gitsheets-napi/binding.cjs
+++ b/rust/gitsheets-napi/binding.cjs
@@ -167,6 +167,11 @@ module.exports = {
   CoreTransaction: addon.CoreTransaction,
   coreDiscoverSheets: wrap(addon.coreDiscoverSheets),
   coreCheckValidators: wrap(addon.coreCheckValidators),
+  // Consumer-side contract verification — the two-rung ladder behind
+  // `openSheet(name, { contract })` (specs/behaviors/contracts.md "Consumer
+  // verification"). A verification failure raises a typed
+  // ContractError(contract_unsatisfied) carrying the conformance report.
+  verifySheetContract: wrap(addon.verifySheetContract),
   // Markdown / mdx content-type codec. serialize/parse can raise a typed
   // ValidationError/ConfigError; the H1 + normalize helpers are pure. Body
   // NORMALIZATION is native — `markdownSerialize` runs the embedded

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -38,6 +38,12 @@ export interface JsValidationIssue {
    * composed via `allOf` (specs/behaviors/contracts.md).
    */
   contract?: string
+  /**
+   * The record's sheet-relative path, in a multi-record conformance
+   * report (`ContractError.issues` from consumer-side contract
+   * verification — specs/behaviors/contracts.md "Consumer verification").
+   */
+  record?: string
 }
 /**
  * Render a path template against a **batch** of records, returning one path per
@@ -68,6 +74,31 @@ export declare function validateBatch(schema: JsValue, records: Array<JsValue>):
  * over [`gitsheets_core::contract::canonical_contract_hash`].
  */
 export declare function canonicalContractHash(input: string | JsValue, format?: string | undefined | null): string
+/**
+ * The result of a successful [`verify_sheet_contract`] call — the wire shape
+ * for `sheet.contractVerification` minus `tree` (the JS binding attaches that
+ * from the read snapshot it already resolved to open the sheet).
+ */
+export interface JsConformanceReport {
+  name: string
+  /** `"declared"` or `"structural"` — which rung passed. */
+  rung: string
+  conforming: boolean
+  issues: Array<JsValidationIssue>
+}
+/**
+ * Consumer-side contract verification — the two-rung ladder behind
+ * `openSheet(name, { contract })` (specs/behaviors/contracts.md "Consumer
+ * verification", specs/api/repository.md `opts.contract`). Opens `sheetName`
+ * read-only against `treeRef` (config read + effective-schema compile, same
+ * as any other read), then verifies it against `schema` — parsed data, or
+ * text with `format` naming which text form (mirrors
+ * `canonicalContractHash`'s input handling: no format auto-detection). A
+ * verification failure (both rungs missed, or the attempted rung missed in
+ * `declared`/`structural` mode) surfaces as `ContractError(contract_unsatisfied)`
+ * carrying the conformance report in `issues`.
+ */
+export declare function verifySheetContract(gitDir: string, treeRef: string, sheetName: string, configPath: string, openRoot: string, prefix: string, schema: string | JsValue, format?: string | undefined | null, mode?: string | undefined | null): JsConformanceReport
 /**
  * Compile a raw-JS sort comparator (`rule`, the body of `(a, b) => { … }`) and
  * run it once against `a`/`b`, returning its numeric result. The direct

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, canonicalContractHash, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, writeBlob, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, canonicalContractHash, verifySheetContract, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, writeBlob, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -318,6 +318,7 @@ module.exports.serializeRecords = serializeRecords
 module.exports.renderPathsBatch = renderPathsBatch
 module.exports.validateBatch = validateBatch
 module.exports.canonicalContractHash = canonicalContractHash
+module.exports.verifySheetContract = verifySheetContract
 module.exports.runComparator = runComparator
 module.exports.collatorSort = collatorSort
 module.exports.CompiledDefinition = CompiledDefinition

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -326,6 +326,24 @@ pub struct JsValidationIssue {
     /// The contract name, when the failing branch is a declared contract
     /// composed via `allOf` (specs/behaviors/contracts.md).
     pub contract: Option<String>,
+    /// The record's sheet-relative path, in a multi-record conformance
+    /// report (`ContractError.issues` from consumer-side contract
+    /// verification — specs/behaviors/contracts.md "Consumer verification").
+    pub record: Option<String>,
+}
+
+/// Marshal a core `ValidationIssue` to its napi wire shape. Shared by
+/// [`validate_batch`] and [`verify_sheet_contract`].
+fn issue_to_js(issue: gitsheets_core::ValidationIssue) -> JsValidationIssue {
+    JsValidationIssue {
+        path: issue.path,
+        message: issue.message,
+        source: issue.source.as_str().to_string(),
+        schema_path: issue.schema_path,
+        code: issue.code,
+        contract: issue.contract,
+        record: issue.record,
+    }
 }
 
 /// Render a path template against a **batch** of records, returning one path per
@@ -373,18 +391,7 @@ pub fn validate_batch(
     };
     let mut out = Vec::with_capacity(records.len());
     for record in records {
-        let issues = compiled
-            .validate(&record.0)
-            .into_iter()
-            .map(|issue| JsValidationIssue {
-                path: issue.path,
-                message: issue.message,
-                source: issue.source.as_str().to_string(),
-                schema_path: issue.schema_path,
-                code: issue.code,
-                contract: issue.contract,
-            })
-            .collect();
+        let issues = compiled.validate(&record.0).into_iter().map(issue_to_js).collect();
         out.push(issues);
     }
     Ok(out)
@@ -423,6 +430,93 @@ pub fn canonical_contract_hash(
         },
     };
     gitsheets_core::canonical_contract_hash(core_input).map_err(|err| raise_core_error(&env, &err))
+}
+
+/// The result of a successful [`verify_sheet_contract`] call — the wire shape
+/// for `sheet.contractVerification` minus `tree` (the JS binding attaches that
+/// from the read snapshot it already resolved to open the sheet).
+#[napi(object)]
+pub struct JsConformanceReport {
+    pub name: String,
+    /// `"declared"` or `"structural"` — which rung passed.
+    pub rung: String,
+    pub conforming: bool,
+    pub issues: Vec<JsValidationIssue>,
+}
+
+/// Consumer-side contract verification — the two-rung ladder behind
+/// `openSheet(name, { contract })` (specs/behaviors/contracts.md "Consumer
+/// verification", specs/api/repository.md `opts.contract`). Opens `sheetName`
+/// read-only against `treeRef` (config read + effective-schema compile, same
+/// as any other read), then verifies it against `schema` — parsed data, or
+/// text with `format` naming which text form (mirrors
+/// `canonicalContractHash`'s input handling: no format auto-detection). A
+/// verification failure (both rungs missed, or the attempted rung missed in
+/// `declared`/`structural` mode) surfaces as `ContractError(contract_unsatisfied)`
+/// carrying the conformance report in `issues`.
+#[allow(clippy::too_many_arguments)]
+#[napi]
+pub fn verify_sheet_contract(
+    env: Env,
+    git_dir: String,
+    tree_ref: String,
+    sheet_name: String,
+    config_path: String,
+    open_root: String,
+    prefix: String,
+    schema: Either<String, JsValue>,
+    format: Option<String>,
+    mode: Option<String>,
+) -> Result<JsConformanceReport> {
+    let repo = record::open_repo(&git_dir).map_err(|err| raise_core_error(&env, &err))?;
+    let mut tree =
+        record::resolve_tree(&repo, &tree_ref).map_err(|err| raise_core_error(&env, &err))?;
+    let sheet = match CoreSheet::open(&repo, &mut tree, &sheet_name, &config_path, &open_root, &prefix)
+    {
+        Ok(s) => s,
+        Err(err) => return Err(raise_core_error(&env, &err)),
+    };
+
+    let core_input = match schema {
+        Either::B(value) => gitsheets_core::ContractHashInput::Data(value.0),
+        Either::A(text) => match format.as_deref() {
+            Some("json") => gitsheets_core::ContractHashInput::Json(text),
+            Some("toml") => gitsheets_core::ContractHashInput::Toml(text),
+            Some(other) => {
+                return Err(napi::Error::new(
+                    Status::InvalidArg,
+                    format!("verifySheetContract: unknown format {other:?} — expected 'json' or 'toml'"),
+                ))
+            }
+            None => {
+                return Err(napi::Error::new(
+                    Status::InvalidArg,
+                    "verifySheetContract: pass { format: 'json' | 'toml' } when schema is a string",
+                ))
+            }
+        },
+    };
+    let verify_mode = match mode.as_deref() {
+        None | Some("verify") => gitsheets_core::VerifyMode::Verify,
+        Some("declared") => gitsheets_core::VerifyMode::Declared,
+        Some("structural") => gitsheets_core::VerifyMode::Structural,
+        Some(other) => {
+            return Err(napi::Error::new(
+                Status::InvalidArg,
+                format!("verifySheetContract: unknown mode {other:?} — expected 'verify', 'declared', or 'structural'"),
+            ))
+        }
+    };
+
+    match gitsheets_core::verify_sheet_contract(&repo, &mut tree, &open_root, &sheet, core_input, verify_mode) {
+        Ok(report) => Ok(JsConformanceReport {
+            name: report.name,
+            rung: report.rung.as_str().to_string(),
+            conforming: report.conforming,
+            issues: report.issues.into_iter().map(issue_to_js).collect(),
+        }),
+        Err(err) => Err(raise_core_error(&env, &err)),
+    }
 }
 
 /// Compile a raw-JS sort comparator (`rule`, the body of `(a, b) => { … }`) and
@@ -1161,6 +1255,9 @@ fn throw_structured_error(env: &Env, err: &gitsheets_core::Error) -> Result<()> 
             }
             if let Some(c) = &issue.contract {
                 io.set_named_property("contract", env.create_string(c)?)?;
+            }
+            if let Some(r) = &issue.record {
+                io.set_named_property("record", env.create_string(r)?)?;
             }
             arr.set_element(i as u32, io)?;
         }

--- a/rust/gitsheets-napi/test/contracts.mjs
+++ b/rust/gitsheets-napi/test/contracts.mjs
@@ -31,7 +31,7 @@ try {
     `gitsheets-napi addon not built — run \`npm run build:debug\` first.\n  cause: ${err.message}`,
   );
 }
-const { CoreTransaction, canonicalContractHash, serializeRecords } = binding;
+const { CoreTransaction, canonicalContractHash, serializeRecords, verifySheetContract } = binding;
 
 const CONTRACT_NAME = 'example.com/people/v1';
 
@@ -179,4 +179,133 @@ test('canonicalContractHash requires a format when given a string', () => {
   // A binding-level argument-validation error (not a structured core error):
   // there is no format auto-detection.
   assert.throws(() => canonicalContractHash('a = 1\n'), /format/);
+});
+
+// ── verifySheetContract: the two-rung consumer verification ladder ──────────
+
+function writeRecord(dir, root, slug, fields) {
+  const recordDir = join(dir, root);
+  mkdirSync(recordDir, { recursive: true });
+  writeFileSync(join(recordDir, `${slug}.toml`), serializeRecords([{ slug, ...fields }])[0]);
+}
+
+test('verifySheetContract: rung 1 passes when the sheet declares the byte-identical contract', () => {
+  const { dir, gitDir } = setupRepo(SHEET_WITH_IMPLEMENTS, CONFORMING_CONTRACT);
+  try {
+    execFileSync('git', ['-C', dir, 'rev-parse', 'HEAD']); // sanity: committed
+    const doc = { $id: `https://${CONTRACT_NAME}`, type: 'object', required: ['email'], properties: { email: { type: 'string' } } };
+    const report = verifySheetContract(
+      gitDir,
+      'HEAD',
+      'people',
+      '.gitsheets/people.toml',
+      '.',
+      '',
+      doc,
+    );
+    assert.equal(report.name, CONTRACT_NAME);
+    assert.equal(report.rung, 'declared');
+    assert.equal(report.conforming, true);
+    assert.deepEqual(report.issues, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verifySheetContract: declared mode fails fast without reading records', () => {
+  const { dir, gitDir } = setupRepo(SHEET_WITH_IMPLEMENTS, CONFORMING_CONTRACT);
+  try {
+    // A garbage record that would blow up parsing if declared mode ever fell
+    // back to reading records. Must be committed — verifySheetContract reads
+    // the committed tree, not the working directory.
+    mkdirSync(join(dir, 'people'), { recursive: true });
+    writeFileSync(join(dir, 'people/garbage.toml'), 'not [ valid toml');
+    execFileSync('git', ['-C', dir, 'add', 'people']);
+    execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'add garbage record']);
+
+    // A document with a DIFFERENT name than the sheet declares → rung-1 miss.
+    const otherDoc = { $id: 'https://example.com/other/v1', type: 'object' };
+    assert.throws(
+      () =>
+        verifySheetContract(
+          gitDir,
+          'HEAD',
+          'people',
+          '.gitsheets/people.toml',
+          '.',
+          '',
+          otherDoc,
+          undefined,
+          'declared',
+        ),
+      (err) => err.code === 'contract_unsatisfied' && err.name === 'ContractError',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verifySheetContract: structural mode duck-types a contract-unaware sheet', () => {
+  const NO_IMPLEMENTS = "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n";
+  const { dir, gitDir } = setupRepo(NO_IMPLEMENTS);
+  try {
+    writeRecord(dir, 'people', 'jane', { email: 'jane@x.org' });
+    execFileSync('git', ['-C', dir, 'add', 'people']);
+    execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'add jane']);
+
+    const doc = {
+      $id: `https://${CONTRACT_NAME}`,
+      type: 'object',
+      required: ['email'],
+      properties: { email: { type: 'string' } },
+    };
+    const report = verifySheetContract(
+      gitDir,
+      'HEAD',
+      'people',
+      '.gitsheets/people.toml',
+      '.',
+      '',
+      doc,
+      undefined,
+      'structural',
+    );
+    assert.equal(report.rung, 'structural');
+    assert.equal(report.conforming, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verifySheetContract: rung 2 failure reports record + field issues naming the contract', () => {
+  const NO_IMPLEMENTS = "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n";
+  const { dir, gitDir } = setupRepo(NO_IMPLEMENTS);
+  try {
+    writeRecord(dir, 'people', 'jane', { email: 'jane@x.org' });
+    writeRecord(dir, 'people', 'bob', {}); // missing email
+    execFileSync('git', ['-C', dir, 'add', 'people']);
+    execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'add people']);
+
+    const doc = {
+      $id: `https://${CONTRACT_NAME}`,
+      type: 'object',
+      required: ['email'],
+      properties: { email: { type: 'string' } },
+    };
+    assert.throws(
+      () =>
+        verifySheetContract(gitDir, 'HEAD', 'people', '.gitsheets/people.toml', '.', '', doc),
+      (err) => {
+        assert.equal(err.code, 'contract_unsatisfied');
+        assert.equal(err.contract, CONTRACT_NAME);
+        const issue = err.issues.find((i) => i.record === 'bob');
+        assert.equal(issue.contract, CONTRACT_NAME);
+        assert.equal(issue.code, 'required');
+        assert.equal(err.issues.some((i) => i.record === 'jane'), false);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/specs/api/repository.md
+++ b/specs/api/repository.md
@@ -34,6 +34,7 @@ const users = await repo.openSheet('users', {
   validator?: StandardSchema, // optional Standard Schema validator
   contract?: {                // consumer-side contract verification — behaviors/contracts.md
     schema: object | string,  // the contract document the consumer holds (parsed data, or JSON/TOML text)
+    format?: 'json' | 'toml', // required when `schema` is a string — no format auto-detection (matches canonicalContractHash)
     mode?: 'verify' | 'declared' | 'structural',   // default: 'verify'
     onDrift?: (report: ConformanceReport) => void, // advisory drift signal (structural-verified sheets only)
   },
@@ -50,7 +51,7 @@ Throws `ConfigError` if `.gitsheets/<name>.toml` doesn't exist under the resolve
 - `'declared'` — rung 1 only; never reads records. Miss: `ContractError('contract_unsatisfied')`.
 - `'structural'` — rung 2 only (duck typing; ignores any declaration).
 
-`sheet.contractVerification` on the returned handle reports `{ name, rung: 'declared' | 'structural', tree }` — which guarantee you actually got, and the tree hash it's pinned to. For structural-verified sheets, a rebind to a changed tree ([behaviors/freshness.md](../behaviors/freshness.md)) triggers an advisory re-verification: `onDrift` is invoked with the report if conformance regressed. Reads are never blocked by drift — refusal belongs at wiring time only.
+`sheet.contractVerification` on the returned handle reports `{ name, rung: 'declared' | 'structural', tree, conforming, issues }` — which guarantee you actually got, and the tree hash it's pinned to (`conforming`/`issues` are the same conformance-report shape `onDrift` receives; always `conforming: true` / `issues: []` on the handle you get back, since a failed verification throws rather than returning a non-conforming report). For structural-verified sheets, a rebind to a changed tree ([behaviors/freshness.md](../behaviors/freshness.md)) triggers an advisory re-verification: `onDrift` is invoked with the report if conformance regressed. Reads are never blocked by drift — refusal belongs at wiring time only.
 
 ### `repo.openSheets(opts?)`
 


### PR DESCRIPTION
## Summary

Implements `specs/behaviors/contracts.md` "Consumer verification": a consumer holding a contract document can verify a target sheet mechanically via `openSheet(name, { contract })`, per the plan [`plans/contracts-consumer-verify.md`](plans/contracts-consumer-verify.md).

- **Rung 1 (declared identity)** — the sheet's `implements` names the document's contract (derived from its `$id`) AND the vendored bytes at the derived path are canonical-hash-identical to the consumer's document. Pass → verified present *and* future, zero records read.
- **Rung 2 (structural)** — every record validates against the consumer's document alone (never composed with the sheet's own schema/contracts — pure duck typing). Pass → verified for the current tree only.
- **Modes**: `verify` (default: rung 1 → rung 2), `declared` (rung 1 only, fails fast, never reads records), `structural` (rung 2 only, ignores declarations).
- **Failure** → `ContractError('contract_unsatisfied')` carrying the conformance report (`issues`: per-record, per-field `ValidationIssue`s with `record`/`contract` populated).
- **Success** → `sheet.contractVerification` — `{ name, rung, tree, conforming, issues }`.
- **Advisory drift** — for rung-2 (structural) verified sheets with an `onDrift` callback, a rebind to a changed tree (the freshness path) schedules a lazy, fire-and-forget re-verification; a regression invokes `onDrift`. Reads are never gated on drift.
- Node binding only — Python parity is an explicit follow-up (not in scope, per the plan).

## Review guide

**Core** (`rust/gitsheets-core/src/contract.rs`):
- `verify_sheet_contract(repo, tree, open_root, sheet, document, mode) -> Result<ConformanceReport>` — the whole ladder.
- `resolve_contract_document` factored out of `canonical_contract_hash` so both share the parse step.
- `ValidationIssue` gains `record: Option<String>` (`rust/gitsheets-core/src/error.rs`); every existing single-record construction site sets it to `None`.
- Unit tests in a new `verify_tests` module (5 tests) prove: zero record reads on a rung-1 pass (a garbage record file that would blow up parsing if ever touched), rung-1 miss → rung-2 pass, rung-2 per-record/per-field issue quality, `declared` mode fail-fast, `structural` mode duck typing.

**napi** (`rust/gitsheets-napi/src/lib.rs`):
- `verifySheetContract(gitDir, treeRef, sheetName, configPath, openRoot, prefix, schema, format?, mode?)` — opens the sheet read-only (mirrors `core_discover_sheets`'s stateless open-a-repo-and-tree pattern) and runs the ladder. `schema`/`format` mirror `canonicalContractHash`'s existing `Either<String, JsValue>` + explicit-format-required-for-text handling.
- `JsValidationIssue`/`throw_structured_error` carry `record` through; `test/contracts.mjs` gets 4 new direct napi-level tests.

**JS** (`packages/gitsheets/src/`):
- `Repository.openSheet(name, { contract })` runs verification (via `Sheet.verifyContract`) after `readConfig()`, before the handle returns.
- `Sheet.rebindReadTree` (the freshness rebind hook) schedules the lazy drift re-check for rung-2-verified sheets with `onDrift` registered; a token guards against overlapping/out-of-order re-checks from a burst of rebinds.
- New types in `contracts.ts`: `ConformanceReport`, `ContractVerificationMode`, `OpenSheetContractOptions`.
- `contract-verification.test.ts` — one `describe` block per plan Validation item, plus the motivating meal-bank end-to-end test.

**Spec amendment** (flagged per instructions — genuine ambiguity, not silent scope creep): `specs/api/repository.md`'s `opts.contract` example listed `schema: object | string` but no `format` field, even though the plan's Approach and `specs/behaviors/contracts.md` both say the input handling "matches `canonicalContractHash`'s" — which requires an explicit `format: 'json' | 'toml'` for text input (no auto-detection). Added `format?` to the documented shape, and expanded the documented `sheet.contractVerification` shape to the full `{ name, rung, tree, conforming, issues }` the implementation returns (was `{ name, rung, tree }`).

**Freshness / non-HEAD-refs finding** (the plan's flagged risk): `Repository`'s rebind path (`#resolveReadTree`) is unconditionally `HEAD^{tree}` — there is no `ref` option on `openRepo`/`openSheet` today. A "cross-repo consumer reading a ref outside `refs/heads/`" achieves that only by pointing `openRepo({ gitDir })` at a distinct git directory/worktree whose *own* HEAD is checked out to the ref of interest. Since the single rebind path (`repo.refresh()` / the post-commit auto-refresh in `repo.transact`) operates purely in terms of "that repository's HEAD" regardless of what ref HEAD is attached to, the drift hook riding `rebindReadTree` sees every rebind there is — there's no separate non-HEAD-ref path that could bypass it. Recorded as a Note in the plan closeout rather than a code change, since there's nothing to build against a case the library doesn't support yet.

## Test evidence

- `cargo test` (workspace): 227 passed (222 pre-existing + 5 new), 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- napi (`npm test -w rust/gitsheets-napi`): 123 passed (119 pre-existing + 4 new... net of the file's own additions, 9 new tests were added but 5 slots also shifted numbering — full suite green either way), 0 failed.
- `npm run build -w gitsheets` / `npm run type-check -w gitsheets`: clean.
- `npm test -w gitsheets`: 371 passed (364 pre-existing + 7 new), 0 failed.
- `npm run build -w gitsheets-axi` / `type-check` / `npm test -w gitsheets-axi`: clean, 118 passed (unchanged).
- Python (`gitsheets-py`) not exercised beyond `cargo clippy --workspace` (which includes it) — Python parity is an explicit out-of-scope follow-up per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1