### PR TITLE
feat(cli): git sheet contracts — adopt, verify, test, sync, export, prune

### DIFF
--- a/packages/gitsheets/src/cli/cli-contracts.test.ts
+++ b/packages/gitsheets/src/cli/cli-contracts.test.ts
@@ -1,0 +1,536 @@
+// CLI `contracts` command group — adopt, verify, test, sync, export, prune.
+// See specs/api/cli.md ("git sheet contracts") and specs/behaviors/contracts.md.
+
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { main } from './index.js';
+import { stringifyRecord } from '../toml.js';
+import { testRepo, type TestRepoHandle } from '../test-helpers/test-repo.js';
+
+const exec = promisify(execFile);
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+  vi.unstubAllGlobals();
+});
+
+function captureStreams(): { restore: () => { stdout: string; stderr: string } } {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  process.stdout.write = ((c: string | Uint8Array): boolean => {
+    outChunks.push(typeof c === 'string' ? c : Buffer.from(c).toString('utf8'));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: string | Uint8Array): boolean => {
+    errChunks.push(typeof c === 'string' ? c : Buffer.from(c).toString('utf8'));
+    return true;
+  }) as typeof process.stderr.write;
+  return {
+    restore: () => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+      return { stdout: outChunks.join(''), stderr: errChunks.join('') };
+    },
+  };
+}
+
+/** Feed `text` to `process.stdin` for the duration of `fn`, then restore. */
+async function withStdin<T>(text: string, fn: () => Promise<T>): Promise<T> {
+  const original = process.stdin;
+  const fake = Readable.from([Buffer.from(text, 'utf8')]);
+  Object.defineProperty(process, 'stdin', { value: fake, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'stdin', { value: original, configurable: true });
+  }
+}
+
+async function blobAt(fixture: TestRepoHandle, ref: string, path: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['cat-file', 'blob', `${ref}:${path}`], { cwd: fixture.path });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+async function headHash(fixture: TestRepoHandle): Promise<string> {
+  const { stdout } = await fixture.git('rev-parse', 'HEAD');
+  return stdout.trim();
+}
+
+const CONTRACT_NAME = 'test.local/meals/v1';
+const CONTRACT_DOC = {
+  $id: `https://${CONTRACT_NAME}`,
+  type: 'object',
+  required: ['name'],
+  properties: { name: { type: 'string', minLength: 1 } },
+};
+
+function canonicalContractText(): string {
+  return stringifyRecord(CONTRACT_DOC as Record<string, unknown>);
+}
+
+const MEALS_CONFIG = `[gitsheet]
+root = 'meals'
+path = '\${{ slug }}'
+implements = ['${CONTRACT_NAME}']
+`;
+
+const MEALS_CONFIG_NO_CONTRACT = `[gitsheet]
+root = 'meals'
+path = '\${{ slug }}'
+`;
+
+/** A repo with a `meals` sheet declaring CONTRACT_NAME, the contract already vendored, and one conforming record. */
+async function seedConformingRepo(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+  await writeFile(
+    join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals', 'v1.toml'),
+    canonicalContractText(),
+  );
+  await fixture.git('add', '.gitsheets');
+  await fixture.git('commit', '-m', 'seed meals sheet + contract');
+
+  const cap = captureStreams();
+  const code = await main(['--git-dir', fixture.gitDir, 'upsert', 'meals', '{"slug":"soup","name":"Soup"}']);
+  cap.restore();
+  expect(code).toBe(0);
+  // `upsert` commits via direct git-object writes (`repo.transact`), bypassing
+  // the working tree/index entirely. Sync both to the new HEAD so a caller's
+  // subsequent manual `git add` + commit doesn't silently drop the upserted
+  // record from history (it would otherwise stage the STALE pre-upsert tree).
+  await fixture.git('reset', '--hard', 'HEAD');
+  return fixture;
+}
+
+describe('CLI contracts adopt', () => {
+  it('adopts a JSON local file, vendors it canonically, records provenance, and prints the implements hint', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+
+    const docPath = join(fixture.path, 'meals-v1.schema.json');
+    await writeFile(docPath, JSON.stringify(CONTRACT_DOC));
+
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'adopt', docPath]);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+    expect(stdout).toContain(`adopted ${CONTRACT_NAME}`);
+    expect(stdout).toContain(`implements = ['${CONTRACT_NAME}']`);
+
+    const vendored = await blobAt(
+      fixture,
+      'HEAD',
+      '.gitsheets/contracts/test.local/meals/v1.toml',
+    );
+    expect(vendored).toBe(canonicalContractText());
+
+    const sources = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/sources.toml');
+    expect(sources).toContain(docPath);
+  });
+
+  it('adopting the same document from a local TOML file produces byte-identical vendored bytes', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+
+    const docPath = join(fixture.path, 'meals-v1.schema.toml');
+    await writeFile(docPath, canonicalContractText());
+
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'adopt', docPath]);
+    expect(code).toBe(0);
+
+    const vendored = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+    expect(vendored).toBe(canonicalContractText());
+  });
+
+  it('adopts over HTTPS (fetch mocked — see plan Risks: no real network in unit tests)', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+
+    const url = 'https://contracts.example.com/meals/v1.schema.json';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify(CONTRACT_DOC),
+      })),
+    );
+
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'adopt', url]);
+    expect(code).toBe(0);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const vendored = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+    expect(vendored).toBe(canonicalContractText());
+    const sources = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/sources.toml');
+    expect(sources).toContain(url);
+  });
+
+  it('--sheet refuses adoption when an existing record fails the new effective schema, leaving the tree untouched', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'seed meals sheet');
+
+    // Existing record has no `name` — the candidate contract requires it.
+    let code = await main([
+      '--git-dir',
+      fixture.gitDir,
+      'upsert',
+      'meals',
+      '{"slug":"soup"}',
+    ]);
+    expect(code).toBe(0);
+
+    const before = await headHash(fixture);
+    const docPath = join(fixture.path, 'meals-v1.schema.json');
+    await writeFile(docPath, JSON.stringify(CONTRACT_DOC));
+
+    const cap = captureStreams();
+    code = await main([
+      '--git-dir',
+      fixture.gitDir,
+      'contracts',
+      'adopt',
+      docPath,
+      '--sheet',
+      'meals',
+    ]);
+    const { stderr } = cap.restore();
+    expect(code).toBe(67);
+    expect(stderr).toContain('soup');
+    expect(stderr).toContain('name');
+
+    const after = await headHash(fixture);
+    expect(after).toBe(before); // tree untouched
+    const vendored = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+    expect(vendored).toBeNull();
+  });
+});
+
+describe('CLI contracts verify', () => {
+  it('passes on a conforming fixture repo', async () => {
+    const fixture = await seedConformingRepo();
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'verify']);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+    expect(stdout).toContain('ok');
+  });
+
+  it('fails (exit 67) when a declared contract has no vendored document (contract_missing)', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'declares a contract with nothing vendored');
+
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'verify']);
+    const { stderr } = cap.restore();
+    expect(code).toBe(67);
+    expect(stderr).toContain(CONTRACT_NAME);
+  });
+
+  it('fails (exit 67) when the vendored document is not canonical (contract_invalid)', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+    // Deliberately non-canonical: keys out of sorted order.
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals', 'v1.toml'),
+      `type = 'object'\n'$id' = 'https://${CONTRACT_NAME}'\nrequired = ['name']\n`,
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'non-canonical vendored contract');
+
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'verify']);
+    const { stderr } = cap.restore();
+    expect(code).toBe(67);
+    expect(stderr).toContain('canonical');
+  });
+
+  it('fails (exit 67) when an existing record violates the effective schema', async () => {
+    // Contract enforcement composes into every WRITE, so a non-conforming
+    // record can never be upserted once a sheet declares the contract — the
+    // scenario `verify` exists to catch is a sheet config hand-edited to add
+    // `implements` (a plain author edit, never tooling-managed) AFTER
+    // records were written under a laxer (or absent) local schema.
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'seed meals sheet, no contract yet');
+    let code = await main(['--git-dir', fixture.gitDir, 'upsert', 'meals', '{"slug":"bad","name":""}']);
+    expect(code).toBe(0);
+    // See seedConformingRepo's comment: sync the working tree/index to HEAD
+    // before manually staging further changes, or this upsert's record would
+    // be silently dropped from the next hand-built commit.
+    await fixture.git('reset', '--hard', 'HEAD');
+
+    // Now the author hand-edits the config to declare the contract, and the
+    // contract gets vendored — without ever running `adopt --sheet`.
+    await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals', 'v1.toml'),
+      canonicalContractText(),
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'declare the contract after the fact');
+
+    const cap = captureStreams();
+    code = await main(['--git-dir', fixture.gitDir, 'contracts', 'verify']);
+    const { stderr } = cap.restore();
+    expect(code).toBe(67);
+    expect(stderr).toContain('bad');
+  });
+
+  it('warns (stderr, exit 0) when a declaring sheet closes its local schema with additionalProperties: false', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals'), { recursive: true });
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'meals.toml'),
+      `[gitsheet]
+root = 'meals'
+path = '\${{ slug }}'
+implements = ['${CONTRACT_NAME}']
+
+[gitsheet.schema]
+type = 'object'
+additionalProperties = false
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+
+[gitsheet.schema.properties.name]
+type = 'string'
+`,
+    );
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals', 'v1.toml'),
+      canonicalContractText(),
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'closed local schema');
+    let code = await main(['--git-dir', fixture.gitDir, 'upsert', 'meals', '{"slug":"soup","name":"Soup"}']);
+    expect(code).toBe(0);
+
+    const cap = captureStreams();
+    code = await main(['--git-dir', fixture.gitDir, 'contracts', 'verify']);
+    const { stdout, stderr } = cap.restore();
+    expect(code).toBe(0);
+    expect(stderr).toContain('additionalProperties');
+    expect(stdout).toContain('ok');
+  });
+});
+
+describe('CLI contracts test', () => {
+  it('passes against a contract-unaware sheet whose records conform', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'seed meals sheet, no contracts');
+    let code = await main(['--git-dir', fixture.gitDir, 'upsert', 'meals', '{"slug":"soup","name":"Soup"}']);
+    expect(code).toBe(0);
+
+    const docPath = join(fixture.path, 'meals-v1.schema.json');
+    await writeFile(docPath, JSON.stringify(CONTRACT_DOC));
+
+    const cap = captureStreams();
+    code = await main(['--git-dir', fixture.gitDir, 'contracts', 'test', 'meals', '--against', docPath]);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+    expect(stdout).toContain('ok soup');
+  });
+
+  it('reports per-record issues (exit 67) against a sheet whose records do not conform', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'seed meals sheet, no contracts');
+    let code = await main(['--git-dir', fixture.gitDir, 'upsert', 'meals', '{"slug":"soup"}']); // no name
+    expect(code).toBe(0);
+
+    const docPath = join(fixture.path, 'meals-v1.schema.json');
+    await writeFile(docPath, JSON.stringify(CONTRACT_DOC));
+
+    const cap = captureStreams();
+    code = await main(['--git-dir', fixture.gitDir, 'contracts', 'test', 'meals', '--against', docPath]);
+    const { stderr } = cap.restore();
+    expect(code).toBe(67);
+    expect(stderr).toContain('soup');
+  });
+});
+
+describe('CLI contracts sync', () => {
+  it('reports drift when the upstream fixture changes, and never modifies the vendored file', async () => {
+    const fixture = await seedConformingRepo();
+    const url = 'https://contracts.example.com/meals/v1.schema.json';
+
+    // Record provenance manually (this fixture's contract was vendored by
+    // hand in seedConformingRepo, not via `adopt`, so it has no sources.toml
+    // entry yet) — mirrors what a prior real `adopt <url>` would have left.
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'sources.toml'),
+      `['${CONTRACT_NAME}']\nsource = '${url}'\nadopted = 2026-01-01T00:00:00Z\n`,
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'record provenance');
+
+    const before = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+
+    // First sync: upstream matches vendored bytes exactly.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify(CONTRACT_DOC) })),
+    );
+    let cap = captureStreams();
+    let code = await main(['--git-dir', fixture.gitDir, 'contracts', 'sync']);
+    let out = cap.restore();
+    expect(code).toBe(0);
+    expect(out.stdout).toContain(`match ${CONTRACT_NAME}`);
+    vi.unstubAllGlobals();
+
+    // Upstream has since changed — sync must report drift, not rewrite.
+    const drifted = { ...CONTRACT_DOC, required: ['name', 'servedAt'] };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify(drifted) })),
+    );
+    cap = captureStreams();
+    code = await main(['--git-dir', fixture.gitDir, 'contracts', 'sync']);
+    out = cap.restore();
+    expect(code).toBe(0);
+    expect(out.stdout).toContain(`drift ${CONTRACT_NAME}`);
+
+    const after = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+    expect(after).toBe(before); // never rewritten
+  });
+
+  it('lists an entry with no recorded source as unsyncable (an adopt-from-stdin has none)', async () => {
+    const fixture = await seedConformingRepo();
+    // A contract adopted from stdin ('-') never gets a sources.toml entry
+    // (readContractsAdopt's documented no-loss-of-function case) — simulate
+    // the sidecar entry an operator might still hand-add without a source.
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'sources.toml'),
+      `['${CONTRACT_NAME}']\nadopted = 2026-01-01T00:00:00Z\n`,
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'sidecar entry with no source');
+
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'sync']);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+    expect(stdout).toContain(`unsyncable ${CONTRACT_NAME}`);
+  });
+});
+
+describe('CLI contracts export', () => {
+  it('round-trips through `adopt -` to identical vendored bytes', async () => {
+    const fixture = await seedConformingRepo();
+
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'export', CONTRACT_NAME]);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+
+    const before = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+
+    // A second, throwaway repo re-adopts the exported JSON via stdin.
+    const fixture2 = await testRepo({ withInitialCommit: true });
+    handles.push(fixture2);
+    const code2 = await withStdin(stdout, () =>
+      main(['--git-dir', fixture2.gitDir, 'contracts', 'adopt', '-']),
+    );
+    expect(code2).toBe(0);
+
+    const after = await blobAt(fixture2, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+    expect(after).toBe(before);
+  });
+});
+
+describe('CLI contracts prune', () => {
+  it('--dry-run lists exactly the undeclared vendored documents and removes nothing', async () => {
+    const fixture = await seedConformingRepo();
+    // An orphan: vendored, but no sheet declares it.
+    await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'orphans'), { recursive: true });
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'orphans', 'v1.toml'),
+      stringifyRecord({ $id: 'https://test.local/orphans/v1', type: 'object' }),
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'add an orphan contract');
+
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'prune', '--dry-run']);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+    expect(stdout).toContain('would remove test.local/orphans/v1');
+    expect(stdout).not.toContain(CONTRACT_NAME); // the declared one is not listed
+
+    const stillThere = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/orphans/v1.toml');
+    expect(stillThere).not.toBeNull();
+  });
+
+  it('removes orphans with --yes (bypassing the confirmation prompt)', async () => {
+    const fixture = await seedConformingRepo();
+    await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'orphans'), { recursive: true });
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'orphans', 'v1.toml'),
+      stringifyRecord({ $id: 'https://test.local/orphans/v1', type: 'object' }),
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'add an orphan contract');
+
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'prune', '--yes']);
+    expect(code).toBe(0);
+
+    const gone = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/orphans/v1.toml');
+    expect(gone).toBeNull();
+    const stillDeclared = await blobAt(fixture, 'HEAD', '.gitsheets/contracts/test.local/meals/v1.toml');
+    expect(stillDeclared).not.toBeNull();
+  });
+
+  it('nothing to prune when every vendored document is declared', async () => {
+    const fixture = await seedConformingRepo();
+    const cap = captureStreams();
+    const code = await main(['--git-dir', fixture.gitDir, 'contracts', 'prune', '--dry-run']);
+    const { stdout } = cap.restore();
+    expect(code).toBe(0);
+    expect(stdout).toContain('nothing to prune');
+  });
+});

--- a/packages/gitsheets/src/cli/contracts.ts
+++ b/packages/gitsheets/src/cli/contracts.ts
@@ -1,0 +1,692 @@
+// `git sheet contracts <subcommand>` — adopt, verify, test, sync, export,
+// prune. See specs/api/cli.md ("git sheet contracts <subcommand>") and
+// specs/behaviors/contracts.md.
+//
+// Every command here is a thin CLI orchestration layer over the primitives
+// `gitsheets-core::contract` already provides (name validation, the derived
+// vendored path, the document-requirement walk, and the vendored-tree
+// loader — each surfaced as a minimal napi wrapper: `validateContractName`,
+// `contractPath`, `checkContractDocument`, `contractLoad`). The one thing
+// assembled host-side is the "effective schema" `allOf` array — a documented,
+// mechanical formula (specs/behaviors/contracts.md "Composition and
+// enforcement"), not a re-implementation of any core logic — which is then
+// validated through the existing `addon.validateBatch`, exactly as
+// `[gitsheet.schema]` alone already is elsewhere in this CLI.
+//
+// All writes these commands make are confined to `.gitsheets/contracts/` —
+// sheet configs are never rewritten by tooling (see `printImplementsHint`).
+
+import { readFile, stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+import type { Argv } from 'yargs';
+
+import { addon, callCore } from '../core.js';
+import { ConfigError, ContractError } from '../errors.js';
+import type { ValidationIssue } from '../errors.js';
+import { openRepo } from '../repository.js';
+import type { RecordLike } from '../path-template/index.js';
+import { parseToml, stringifyRecord } from '../toml.js';
+import type { JSONSchema } from '../validation.js';
+import { buildTxOpts, type GlobalArgs } from './shared.js';
+
+const exec = promisify(execFile);
+
+const RECORD_PATH_SYMBOL = Symbol.for('gitsheets-path');
+
+// --- Shared arg shape ---------------------------------------------------------
+
+type ContractsArgs = GlobalArgs;
+
+interface AdoptArgs extends ContractsArgs {
+  source: string;
+  sheet?: string[];
+}
+
+interface VerifyArgs extends ContractsArgs {
+  sheets?: string[];
+}
+
+interface TestArgs extends ContractsArgs {
+  sheet: string;
+  against: string;
+}
+
+interface SyncArgs extends ContractsArgs {
+  names?: string[];
+}
+
+interface ExportArgs extends ContractsArgs {
+  name: string;
+}
+
+interface PruneArgs extends ContractsArgs {
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+// --- Path helpers --------------------------------------------------------------
+
+/** Prefix `relPath` with `root` when `root` isn't the repo root. */
+function scopedPath(root: string, relPath: string): string {
+  const cleanRoot = root.replace(/^\/+|\/+$/g, '');
+  if (!cleanRoot || cleanRoot === '.') return relPath;
+  return `${cleanRoot}/${relPath}`;
+}
+
+function sheetOpenOpts(root: string): { root?: string } {
+  return root && root !== '.' && root !== '/' ? { root } : {};
+}
+
+/** `git cat-file blob <ref>:<path>` — null when the path doesn't exist at `ref`. */
+async function readBlobText(gitDir: string, ref: string, path: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['cat-file', 'blob', `${ref}:${path}`], {
+      cwd: gitDir,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+/** The `implements` array declared by `<root>/.gitsheets/<sheet>.toml` at `ref` ([] if absent/unparseable). */
+async function readImplements(
+  gitDir: string,
+  ref: string,
+  root: string,
+  sheet: string,
+): Promise<string[]> {
+  const configPath = scopedPath(root, `.gitsheets/${sheet}.toml`);
+  const text = await readBlobText(gitDir, ref, configPath);
+  if (text === null) return [];
+  let parsed: RecordLike;
+  try {
+    parsed = parseToml(text) as RecordLike;
+  } catch {
+    return [];
+  }
+  const gitsheet = (parsed['gitsheet'] as RecordLike) ?? {};
+  const raw = gitsheet['implements'];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((x): x is string => typeof x === 'string');
+}
+
+function recordPathOf(record: RecordLike): string | undefined {
+  const p = (record as Record<symbol, unknown>)[RECORD_PATH_SYMBOL];
+  return typeof p === 'string' ? p : undefined;
+}
+
+// --- Document I/O + parsing ----------------------------------------------------
+
+type DocFormat = 'json' | 'toml';
+
+function sniffFormat(text: string): DocFormat {
+  return text.trimStart().startsWith('{') ? 'json' : 'toml';
+}
+
+function formatFromExtension(path: string): DocFormat | undefined {
+  if (path.endsWith('.toml')) return 'toml';
+  if (path.endsWith('.json')) return 'json';
+  return undefined;
+}
+
+/** Read `source` — an `https://` URL (one-shot fetch, 15s timeout), a local file path, or `-` for stdin. */
+async function readSource(source: string): Promise<{ text: string; format: DocFormat }> {
+  if (source === '-') {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer));
+    }
+    const text = Buffer.concat(chunks).toString('utf8');
+    return { text, format: sniffFormat(text) };
+  }
+  if (/^https:\/\//i.test(source)) {
+    let res: Response;
+    try {
+      res = await fetch(source, { signal: AbortSignal.timeout(15_000) });
+    } catch (err) {
+      throw new ConfigError(
+        'config_invalid',
+        `contracts: could not fetch ${source}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+    if (!res.ok) {
+      throw new ConfigError(
+        'config_invalid',
+        `contracts: fetch ${source} failed: ${res.status} ${res.statusText}`,
+      );
+    }
+    const text = await res.text();
+    return { text, format: formatFromExtension(source) ?? sniffFormat(text) };
+  }
+  const text = await readFile(source, 'utf8');
+  return { text, format: formatFromExtension(source) ?? sniffFormat(text) };
+}
+
+function parseDocument(text: string, format: DocFormat): RecordLike {
+  if (format === 'json') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      throw new ConfigError(
+        'config_invalid',
+        `contracts: failed to parse document as JSON: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new ConfigError('config_invalid', 'contracts: document must be a JSON/TOML table');
+    }
+    return parsed as RecordLike;
+  }
+  try {
+    return parseToml(text);
+  } catch (err) {
+    throw new ConfigError(
+      'config_invalid',
+      `contracts: failed to parse document as TOML: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+}
+
+/** Load a vendored contract's JSON via the core's `load_contract` (byte-canonical + document-requirement + $id↔path checks, all enforced there). */
+function loadVendoredContract(
+  gitDir: string,
+  ref: string,
+  root: string,
+  name: string,
+): JSONSchema {
+  const text = callCore(() => addon.contractLoad(gitDir, ref, root, name));
+  return JSON.parse(text) as JSONSchema;
+}
+
+/** Resolve `<file-or-name>` per `contracts test --against`: an existing file path, else a vendored contract name. */
+async function resolveAgainstSchema(
+  gitDir: string,
+  ref: string,
+  root: string,
+  against: string,
+): Promise<JSONSchema> {
+  let isFile = false;
+  try {
+    isFile = (await stat(against)).isFile();
+  } catch {
+    isFile = false;
+  }
+  if (isFile) {
+    const text = await readFile(against, 'utf8');
+    const format = formatFromExtension(against) ?? sniffFormat(text);
+    return parseDocument(text, format) as JSONSchema;
+  }
+  return loadVendoredContract(gitDir, ref, root, against);
+}
+
+/** Recursively scan a JSON Schema object for `additionalProperties: false` at any depth (advisory only — see `contracts verify`'s closed-local-schema warning). */
+function schemaHasClosedAdditionalProperties(schema: unknown): boolean {
+  if (Array.isArray(schema)) return schema.some(schemaHasClosedAdditionalProperties);
+  if (schema !== null && typeof schema === 'object') {
+    for (const [key, value] of Object.entries(schema as RecordLike)) {
+      if (key === 'additionalProperties' && value === false) return true;
+      if (schemaHasClosedAdditionalProperties(value)) return true;
+    }
+  }
+  return false;
+}
+
+/** Validate `records` against `schema`, streaming per-record issues to stderr under `label`. Returns whether any record failed. */
+function streamValidateBatch(
+  schema: JSONSchema,
+  records: RecordLike[],
+  label: (record: RecordLike, index: number) => string,
+  prefix: string,
+): boolean {
+  if (records.length === 0) return false;
+  const issuesPerRecord = callCore(() => addon.validateBatch(schema, records)) as ValidationIssue[][];
+  let anyFailed = false;
+  issuesPerRecord.forEach((issues, i) => {
+    if (issues.length === 0) return;
+    anyFailed = true;
+    for (const issue of issues) {
+      process.stderr.write(
+        `gitsheets: ${prefix}: ${label(records[i]!, i)}: ${issue.path.join('.') || '<root>'}: ` +
+          `${issue.message}${issue.contract ? ` [${issue.contract}]` : ''}\n`,
+      );
+    }
+  });
+  return anyFailed;
+}
+
+function printImplementsHint(name: string): void {
+  process.stdout.write(
+    `add to the declaring sheet's config (tooling never edits sheet configs):\n` +
+      `  implements = ['${name}']\n`,
+  );
+}
+
+// --- adopt ----------------------------------------------------------------------
+
+async function runContractsAdopt(argv: AdoptArgs): Promise<void> {
+  const repo = await openRepo(argv.gitDir ? { gitDir: argv.gitDir } : {});
+  const ref = argv.ref ?? 'HEAD';
+  const root = argv.root ?? '.';
+
+  // yargs-parser mangles a bare `-` positional into `''` (the same quirk
+  // `upsert`'s `[input]` sidesteps by also accepting `undefined`) — normalize
+  // both back to the `-` stdin sentinel `readSource`/the sources.toml
+  // provenance logic below actually check for.
+  const source = argv.source === '' ? '-' : argv.source;
+  const { text, format } = await readSource(source);
+  const document = parseDocument(text, format);
+
+  const id = document['$id'];
+  if (typeof id !== 'string' || !id.startsWith('https://')) {
+    throw new ConfigError(
+      'config_invalid',
+      "contracts adopt: document is missing a required $id ('https://<host-qualified-name>')",
+    );
+  }
+  const name = id.slice('https://'.length);
+  callCore(() => addon.validateContractName(name));
+  // Check the document requirements against the ORIGINAL source text (not the
+  // already-parsed `document`) — a JSON-sourced candidate's literal `null`
+  // (the thing requirement 4 exists to catch) would otherwise be silently
+  // dropped by the JsValue marshalling boundary before ever reaching the
+  // check. See `checkContractDocument`'s doc comment in gitsheets-napi.
+  callCore(() => addon.checkContractDocument(name, text, format));
+
+  // Canonicalize through the SAME encoder vendored contracts (and records)
+  // are byte-authoritative through — the written file is canonical by
+  // construction (specs/behaviors/contracts.md "Canonical form").
+  const canonicalText = stringifyRecord(document);
+  const vendorPath = scopedPath(root, addon.contractPath(name));
+
+  // Adoption gate: with --sheet, validate EVERY existing record of each named
+  // sheet against the would-be effective schema (its currently-declared
+  // contracts + this candidate + its local schema). Any failure refuses the
+  // whole adopt — nothing is written (specs/behaviors/contracts.md
+  // "Adoption is gated on existing data").
+  if (argv.sheet && argv.sheet.length > 0) {
+    let anyFailed = false;
+    for (const sheetName of argv.sheet) {
+      const sheet = await repo.openSheet(sheetName, sheetOpenOpts(root));
+      const config = await sheet.readConfig();
+      const existingNames = await readImplements(repo.gitDir, ref, root, sheetName);
+      const contractSchemas = existingNames.map((n) => loadVendoredContract(repo.gitDir, ref, root, n));
+      contractSchemas.push(document as JSONSchema);
+      const effectiveSchema: JSONSchema = { allOf: [...contractSchemas, config.schema ?? {}] };
+
+      const records: RecordLike[] = [];
+      for await (const r of sheet.query()) records.push(r);
+      const failed = streamValidateBatch(
+        effectiveSchema,
+        records,
+        (r, i) => `${sheetName} ${recordPathOf(r) ?? `#${i}`}`,
+        'contracts adopt',
+      );
+      if (failed) anyFailed = true;
+    }
+    if (anyFailed) {
+      throw new ContractError(
+        'contract_unsatisfied',
+        `contracts adopt: ${name} refused — existing records of one or more named sheets do not ` +
+          'conform to the new effective schema; the tree was left untouched',
+      );
+    }
+  }
+
+  // All gates passed — vendor the document + record provenance atomically.
+  const sourcesPath = scopedPath(root, '.gitsheets/contracts/sources.toml');
+  const existingSourcesText = await readBlobText(repo.gitDir, ref, sourcesPath);
+  let sources: RecordLike = {};
+  if (existingSourcesText !== null) {
+    try {
+      sources = parseToml(existingSourcesText) as RecordLike;
+    } catch {
+      sources = {};
+    }
+  }
+  // sources.toml is non-load-bearing provenance (specs/behaviors/contracts.md
+  // "The sources sidecar") — a stdin ('-') adopt has no meaningful source to
+  // record, so it's simply omitted (an absent entry is documented as
+  // no-loss-of-function). Union merge: each contract name is its own table,
+  // so two branches adopting different contracts never conflict.
+  if (source !== '-') {
+    sources = { ...sources, [name]: { source, adopted: new Date() } };
+  }
+  const sourcesText = stringifyRecord(sources);
+
+  const txOpts = buildTxOpts(argv, `contracts adopt ${name}`);
+  await repo.transact(txOpts, async (tx) => {
+    tx.writeFile(vendorPath, canonicalText);
+    if (source !== '-') {
+      tx.writeFile(sourcesPath, sourcesText);
+    }
+  });
+
+  process.stdout.write(`adopted ${name} → ${vendorPath}\n`);
+  printImplementsHint(name);
+}
+
+// --- verify -----------------------------------------------------------------
+
+async function runContractsVerify(argv: VerifyArgs): Promise<void> {
+  const repo = await openRepo(argv.gitDir ? { gitDir: argv.gitDir } : {});
+  const ref = argv.ref ?? 'HEAD';
+  const root = argv.root ?? '.';
+
+  let sheetNames: string[];
+  if (argv.sheets && argv.sheets.length > 0) {
+    sheetNames = argv.sheets;
+  } else {
+    sheetNames = Object.keys(await repo.openSheets(sheetOpenOpts(root)));
+  }
+
+  let hardFailure = false;
+  let checkedAny = false;
+
+  for (const sheetName of sheetNames) {
+    const implementsNames = await readImplements(repo.gitDir, ref, root, sheetName);
+    if (implementsNames.length === 0) continue;
+    checkedAny = true;
+
+    const sheet = await repo.openSheet(sheetName, sheetOpenOpts(root));
+    const config = await sheet.readConfig();
+
+    // 1) every declared name resolves + document requirements + canonical +
+    // $id↔path — all enforced inside `load_contract` itself.
+    const contractSchemas: JSONSchema[] = [];
+    let loadFailed = false;
+    for (const contractName of implementsNames) {
+      try {
+        contractSchemas.push(loadVendoredContract(repo.gitDir, ref, root, contractName));
+      } catch (err) {
+        hardFailure = true;
+        loadFailed = true;
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`gitsheets: contracts verify: ${sheetName} implements ${contractName}: ${message}\n`);
+      }
+    }
+    if (loadFailed) continue;
+
+    // 2) every record validates against the effective schema.
+    const effectiveSchema: JSONSchema = { allOf: [...contractSchemas, config.schema ?? {}] };
+    const records: RecordLike[] = [];
+    for await (const r of sheet.query()) records.push(r);
+    const failed = streamValidateBatch(
+      effectiveSchema,
+      records,
+      (r, i) => `${sheetName} ${recordPathOf(r) ?? `#${i}`}`,
+      'contracts verify',
+    );
+    if (failed) hardFailure = true;
+
+    // 3) advisory: a closed local schema can silently reject conforming
+    // contract data under allOf composition — warn, never fail.
+    if (config.schema && schemaHasClosedAdditionalProperties(config.schema)) {
+      process.stderr.write(
+        `gitsheets: contracts verify: warning — ${sheetName}'s local [gitsheet.schema] sets ` +
+          'additionalProperties: false, which can reject contract-conforming records under allOf composition\n',
+      );
+    }
+  }
+
+  if (hardFailure) {
+    throw new ContractError(
+      'contract_unsatisfied',
+      'contracts verify: one or more sheets failed contract verification',
+    );
+  }
+  process.stdout.write(
+    checkedAny ? 'contracts verify: ok\n' : 'contracts verify: no sheets declare any contracts\n',
+  );
+}
+
+// --- test -----------------------------------------------------------------------
+
+async function runContractsTest(argv: TestArgs): Promise<void> {
+  const repo = await openRepo(argv.gitDir ? { gitDir: argv.gitDir } : {});
+  const ref = argv.ref ?? 'HEAD';
+  const root = argv.root ?? '.';
+
+  const sheet = await repo.openSheet(argv.sheet, sheetOpenOpts(root));
+  const targetSchema = await resolveAgainstSchema(repo.gitDir, ref, root, argv.against);
+
+  const records: RecordLike[] = [];
+  for await (const r of sheet.query()) records.push(r);
+
+  if (records.length === 0) {
+    process.stdout.write(`contracts test: ${argv.sheet} has no records — trivially conforms\n`);
+    return;
+  }
+
+  const issuesPerRecord = callCore(() => addon.validateBatch(targetSchema, records)) as ValidationIssue[][];
+  let failed = false;
+  issuesPerRecord.forEach((issues, i) => {
+    const label = recordPathOf(records[i]!) ?? `#${i}`;
+    if (issues.length === 0) {
+      process.stdout.write(`ok ${label}\n`);
+      return;
+    }
+    failed = true;
+    for (const issue of issues) {
+      process.stderr.write(
+        `gitsheets: contracts test: ${label}: ${issue.path.join('.') || '<root>'}: ${issue.message}\n`,
+      );
+    }
+  });
+
+  if (failed) {
+    throw new ContractError(
+      'contract_unsatisfied',
+      `contracts test: ${argv.sheet} does not conform to ${argv.against}`,
+    );
+  }
+}
+
+// --- sync -----------------------------------------------------------------------
+
+async function runContractsSync(argv: SyncArgs): Promise<void> {
+  const repo = await openRepo(argv.gitDir ? { gitDir: argv.gitDir } : {});
+  const ref = argv.ref ?? 'HEAD';
+  const root = argv.root ?? '.';
+
+  const sourcesPath = scopedPath(root, '.gitsheets/contracts/sources.toml');
+  const sourcesText = await readBlobText(repo.gitDir, ref, sourcesPath);
+  const sources: RecordLike = sourcesText !== null ? (parseToml(sourcesText) as RecordLike) : {};
+
+  const names = argv.names && argv.names.length > 0 ? argv.names : Object.keys(sources);
+
+  for (const name of names) {
+    const entry = sources[name] as RecordLike | undefined;
+    const source = entry && typeof entry['source'] === 'string' ? (entry['source'] as string) : undefined;
+    if (!source) {
+      process.stdout.write(`unsyncable ${name} (no recorded source)\n`);
+      continue;
+    }
+
+    const vendorPath = scopedPath(root, addon.contractPath(name));
+    const vendoredText = await readBlobText(repo.gitDir, ref, vendorPath);
+    if (vendoredText === null) {
+      process.stdout.write(`missing ${name}: recorded source but no vendored document at ${vendorPath}\n`);
+      continue;
+    }
+
+    let fetched: { text: string; format: DocFormat };
+    try {
+      fetched = await readSource(source);
+    } catch (err) {
+      process.stdout.write(
+        `error ${name}: could not re-fetch ${source}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      continue;
+    }
+    const upstreamCanonical = stringifyRecord(parseDocument(fetched.text, fetched.format));
+
+    // Never rewrites the vendored copy — published versions are immutable
+    // (specs/behaviors/contracts.md "sync"); drift is reported, not pulled.
+    if (upstreamCanonical === vendoredText) {
+      process.stdout.write(`match ${name}\n`);
+    } else {
+      process.stdout.write(`drift ${name}: upstream ${source} differs from the vendored bytes (vendored copy not modified)\n`);
+    }
+  }
+}
+
+// --- export ---------------------------------------------------------------------
+
+async function runContractsExport(argv: ExportArgs): Promise<void> {
+  const repo = await openRepo(argv.gitDir ? { gitDir: argv.gitDir } : {});
+  const ref = argv.ref ?? 'HEAD';
+  const root = argv.root ?? '.';
+
+  const schema = loadVendoredContract(repo.gitDir, ref, root, argv.name);
+  process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
+}
+
+// --- prune ----------------------------------------------------------------------
+
+/** Every vendored contract NAME under `<root>/.gitsheets/contracts/` at `ref` (the `sources.toml` sidecar is excluded — it never has a `/`, contract names always do). */
+async function listVendoredContracts(gitDir: string, ref: string, root: string): Promise<string[]> {
+  const base = scopedPath(root, '.gitsheets/contracts');
+  let stdout: string;
+  try {
+    ({ stdout } = await exec('git', ['ls-tree', '-r', '--name-only', ref, '--', base], { cwd: gitDir }));
+  } catch {
+    return [];
+  }
+  const names: string[] = [];
+  for (const line of stdout.split('\n')) {
+    const p = line.trim();
+    if (!p || !p.startsWith(`${base}/`)) continue;
+    const rel = p.slice(base.length + 1);
+    if (!rel.endsWith('.toml')) continue;
+    const name = rel.slice(0, -'.toml'.length);
+    if (!name.includes('/')) continue; // top-level (sources.toml) — never a contract name
+    names.push(name);
+  }
+  return names;
+}
+
+async function promptYesNo(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(question);
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
+async function runContractsPrune(argv: PruneArgs): Promise<void> {
+  const repo = await openRepo(argv.gitDir ? { gitDir: argv.gitDir } : {});
+  const ref = argv.ref ?? 'HEAD';
+  const root = argv.root ?? '.';
+
+  const allSheets = await repo.openSheets(sheetOpenOpts(root));
+  const declared = new Set<string>();
+  for (const sheetName of Object.keys(allSheets)) {
+    for (const name of await readImplements(repo.gitDir, ref, root, sheetName)) {
+      declared.add(name);
+    }
+  }
+
+  const vendored = await listVendoredContracts(repo.gitDir, ref, root);
+  const orphans = vendored.filter((name) => !declared.has(name));
+
+  if (orphans.length === 0) {
+    process.stdout.write('contracts prune: nothing to prune\n');
+    return;
+  }
+
+  for (const name of orphans) {
+    process.stdout.write(`${argv.dryRun ? 'would remove' : 'remove'} ${name}\n`);
+  }
+  if (argv.dryRun) return;
+
+  if (!argv.yes) {
+    const confirmed = await promptYesNo(
+      `Remove ${orphans.length} vendored contract document(s) not declared by any sheet? [y/N] `,
+    );
+    if (!confirmed) {
+      process.stdout.write('contracts prune: aborted\n');
+      return;
+    }
+  }
+
+  const txOpts = buildTxOpts(argv, `contracts prune (${orphans.length})`);
+  await repo.transact(txOpts, async (tx) => {
+    for (const name of orphans) {
+      tx.deleteFile(scopedPath(root, addon.contractPath(name)));
+    }
+  });
+  process.stdout.write(`removed ${orphans.length} vendored contract document(s)\n`);
+}
+
+// --- yargs wiring -----------------------------------------------------------------
+
+export function registerContractsCommands(y: Argv): Argv {
+  return y
+    .command<AdoptArgs>(
+      'adopt <source>',
+      'Fetch/read a contract document (local path, https:// URL, or - for stdin; JSON or TOML), vendor it, and record provenance',
+      (yy) =>
+        yy
+          .positional('source', { type: 'string', demandOption: true })
+          .option('sheet', {
+            type: 'string',
+            array: true,
+            describe:
+              'Validate every existing record of this sheet against the would-be effective schema; refuse adoption on any failure. Repeatable.',
+          }),
+      runContractsAdopt,
+    )
+    .command<VerifyArgs>(
+      'verify [sheets...]',
+      'Offline conformance gate: every declared contract resolves + is valid + canonical, and every record conforms (default: all declaring sheets)',
+      (yy) => yy.positional('sheets', { type: 'string', array: true }),
+      runContractsVerify,
+    )
+    .command<TestArgs>(
+      'test <sheet>',
+      "Consumer-side structural check: validate <sheet>'s records against an arbitrary document (a file, or a vendored contract name) — rung 2",
+      (yy) =>
+        yy
+          .positional('sheet', { type: 'string', demandOption: true })
+          .option('against', {
+            type: 'string',
+            demandOption: true,
+            describe: 'A file path or the name of a vendored contract',
+          }),
+      runContractsTest,
+    )
+    .command<SyncArgs>(
+      'sync [names...]',
+      "Re-fetch each contract's recorded source and report drift against the vendored bytes (never rewrites)",
+      (yy) => yy.positional('names', { type: 'string', array: true }),
+      runContractsSync,
+    )
+    .command<ExportArgs>(
+      'export <name>',
+      'Emit a vendored contract as interchange JSON on stdout',
+      (yy) => yy.positional('name', { type: 'string', demandOption: true }),
+      runContractsExport,
+    )
+    .command<PruneArgs>(
+      'prune',
+      'List (and with confirmation, remove) vendored documents no sheet declares',
+      (yy) =>
+        yy
+          .option('dry-run', { type: 'boolean', default: false, describe: 'List only; nothing is removed' })
+          .option('yes', { type: 'boolean', default: false, describe: 'Skip the removal confirmation prompt' }),
+      runContractsPrune,
+    )
+    .demandCommand(1, 'Specify a contracts subcommand: adopt, verify, test, sync, export, prune');
+}

--- a/packages/gitsheets/src/cli/index.ts
+++ b/packages/gitsheets/src/cli/index.ts
@@ -10,6 +10,7 @@ import { hideBin } from 'yargs/helpers';
 
 import {
   ConfigError,
+  ContractError,
   GitsheetsError,
   IndexError,
   NotFoundError,
@@ -31,18 +32,10 @@ import {
   type InputFormat,
   type OutputFormat,
 } from './formats.js';
+import { registerContractsCommands } from './contracts.js';
+import { buildTxOpts, type GlobalArgs } from './shared.js';
 
-interface GlobalArgs {
-  gitDir?: string;
-  root?: string;
-  prefix?: string;
-  ref?: string;
-  commitTo?: string;
-  message?: string;
-  authorName?: string;
-  authorEmail?: string;
-  trailer?: Record<string, string>;
-}
+export type { GlobalArgs } from './shared.js';
 
 interface UpsertArgs extends GlobalArgs {
   sheet: string;
@@ -106,6 +99,7 @@ function exitCodeForError(err: unknown): number {
   if (err instanceof ConfigError) return 64;
   if (err instanceof RefError) return 65;
   if (err instanceof NotFoundError) return 66;
+  if (err instanceof ContractError) return 67;
   if (err instanceof TransactionError) return 69;
   if (err instanceof IndexError) return 70;
   if (err instanceof GitsheetsError) return 1;
@@ -120,6 +114,13 @@ function reportError(err: unknown): void {
     if (err instanceof ValidationError && err.issues.length > 0) {
       for (const i of err.issues) {
         out.write(`  issue:  ${i.path.join('.') || '<root>'}: ${i.message} (${i.source})\n`);
+      }
+    }
+    if (err instanceof ContractError && err.issues && err.issues.length > 0) {
+      for (const i of err.issues) {
+        out.write(
+          `  issue:  ${i.path.join('.') || '<root>'}: ${i.message}${i.contract ? ` [${i.contract}]` : ''}\n`,
+        );
       }
     }
     if (err.cause !== undefined) {
@@ -177,31 +178,6 @@ async function loadRepoAndSheet(
   if (argv.prefix) sheetOpts.prefix = argv.prefix;
   const sheet = await repo.openSheet(argv.sheet, sheetOpts);
   return { repo, sheet };
-}
-
-function buildTxOpts(argv: GlobalArgs, defaultMessage: string): {
-  message: string;
-  author?: { name: string; email: string };
-  trailers?: Record<string, string>;
-  parent?: string;
-  branch?: string;
-} {
-  const opts: {
-    message: string;
-    author?: { name: string; email: string };
-    trailers?: Record<string, string>;
-    parent?: string;
-    branch?: string;
-  } = { message: argv.message ?? defaultMessage };
-  if (argv.authorName && argv.authorEmail) {
-    opts.author = { name: argv.authorName, email: argv.authorEmail };
-  }
-  if (argv.trailer && Object.keys(argv.trailer).length > 0) {
-    opts.trailers = argv.trailer;
-  }
-  if (argv.ref) opts.parent = argv.ref;
-  if (argv.commitTo) opts.branch = argv.commitTo;
-  return opts;
 }
 
 // --- Commands ---
@@ -1064,6 +1040,11 @@ export async function main(args: string[] = hideBin(process.argv)): Promise<numb
       "Convert a pre-v1.0 [gitsheet.fields] config to a v1.0 [gitsheet.schema] config",
       (y) => y.positional('sheet', { type: 'string', demandOption: true }),
       runMigrateConfig,
+    )
+    .command(
+      'contracts',
+      'Manage schema contracts: adopt, verify, test, sync, export, prune (see specs/behaviors/contracts.md)',
+      (y) => registerContractsCommands(y),
     )
     .fail((msg, err) => {
       if (err) {

--- a/packages/gitsheets/src/cli/shared.ts
+++ b/packages/gitsheets/src/cli/shared.ts
@@ -1,0 +1,39 @@
+// Shared CLI types + helpers used across command modules (`index.ts`,
+// `contracts.ts`). Split out to avoid a circular import between them — both
+// need `GlobalArgs`/`buildTxOpts`, and `index.ts` imports command-group
+// registration functions (e.g. `registerContractsCommands`) from the modules
+// that need these.
+
+export interface GlobalArgs {
+  gitDir?: string;
+  root?: string;
+  prefix?: string;
+  ref?: string;
+  commitTo?: string;
+  message?: string;
+  authorName?: string;
+  authorEmail?: string;
+  trailer?: Record<string, string>;
+}
+
+export interface TxOpts {
+  message: string;
+  author?: { name: string; email: string };
+  trailers?: Record<string, string>;
+  parent?: string;
+  branch?: string;
+}
+
+/** Build `repo.transact` options from the global CLI flags shared by every mutating command. */
+export function buildTxOpts(argv: GlobalArgs, defaultMessage: string): TxOpts {
+  const opts: TxOpts = { message: argv.message ?? defaultMessage };
+  if (argv.authorName && argv.authorEmail) {
+    opts.author = { name: argv.authorName, email: argv.authorEmail };
+  }
+  if (argv.trailer && Object.keys(argv.trailer).length > 0) {
+    opts.trailers = argv.trailer;
+  }
+  if (argv.ref) opts.parent = argv.ref;
+  if (argv.commitTo) opts.branch = argv.commitTo;
+  return opts;
+}

--- a/packages/gitsheets/src/transaction.ts
+++ b/packages/gitsheets/src/transaction.ts
@@ -204,6 +204,22 @@ export class Transaction {
   }
 
   /**
+   * @internal — Delete a raw file at `path` (repo-root-relative) in this
+   * transaction's tree — `writeFile`'s inverse. Returns whether a blob existed
+   * at `path` before the delete. Used by `contracts prune`. Marks the
+   * transaction mutated only when something was actually removed.
+   */
+  deleteFile(path: string): boolean {
+    if (this.#closed) {
+      throw new TransactionError(
+        'transaction_closed',
+        'transaction is already closed — obtain a fresh Transaction via repo.transact',
+      );
+    }
+    return callCore(() => this.#coreTx.deleteFile(path));
+  }
+
+  /**
    * Finalize the transaction. Returns the commit hash + tree hash, or nulls if
    * no mutations occurred. Throws TransactionError(parent_moved) on optimistic
    * concurrency conflict. After finalize the transaction is closed.

--- a/plans/contracts-cli.md
+++ b/plans/contracts-cli.md
@@ -1,5 +1,6 @@
 ---
-status: planned
+status: done
+pr: 268
 depends: [contracts-core]
 specs:
   - specs/behaviors/contracts.md
@@ -80,18 +81,18 @@ surface ([`contracts-consumer-verify`](contracts-consumer-verify.md));
 
 ## Validation
 
-- [ ] `adopt` of the same document from JSON-over-HTTPS and a local TOML file
+- [x] `adopt` of the same document from JSON-over-HTTPS and a local TOML file
       produces byte-identical vendored files and records both sources
-- [ ] `adopt --sheet` against a sheet with a non-conforming existing record
+- [x] `adopt --sheet` against a sheet with a non-conforming existing record
       refuses, streams the per-record issues, and leaves the tree untouched
-- [ ] `verify` passes on a conforming fixture repo, fails (exit 67) on each
+- [x] `verify` passes on a conforming fixture repo, fails (exit 67) on each
       seeded defect class, and warns on a closed local schema without failing
-- [ ] `contracts test` passes against a contract-unaware sheet whose records
+- [x] `contracts test` passes against a contract-unaware sheet whose records
       conform, and reports per-record issues against one whose records don't
-- [ ] `sync` reports drift when the upstream fixture changes and never
+- [x] `sync` reports drift when the upstream fixture changes and never
       modifies the vendored file
-- [ ] `export <name> | contracts adopt -` round-trips to identical bytes
-- [ ] `prune --dry-run` lists exactly the undeclared vendored documents
+- [x] `export <name> | contracts adopt -` round-trips to identical bytes
+- [x] `prune --dry-run` lists exactly the undeclared vendored documents
 
 ## Risks / unknowns
 
@@ -108,8 +109,60 @@ surface ([`contracts-consumer-verify`](contracts-consumer-verify.md));
 
 ## Notes
 
-(populated at closeout)
+- Built two new thin `gitsheets-core`/`gitsheets-napi` surfaces rather than
+  re-implementing their logic host-side, per the plan's "reuse, not reinvent"
+  building blocks: `contract::check_contract_document` (a new pub wrapper
+  around the existing private `check_document_requirements` +
+  `reject_unknown_keywords`, for a not-yet-vendored candidate) and a
+  `contractLoad` napi binding surfacing `load_contract` end-to-end
+  (byte-canonical + document-requirement + `$id`↔path, exactly what `verify`
+  needs). Also added `CoreTransaction.deleteFile` (napi + JS) — `writeFile`'s
+  inverse, needed for `prune` — via `MutableTree::delete_child_deep`.
+- `checkContractDocument`'s napi signature is `Either<String, JsValue> +
+  format` (mirroring `canonicalContractHash`), not a plain `JsValue`: a
+  JSON-text input is parsed via `serde_json::from_str` directly, preserving a
+  literal `null`. Routing through the `JsValue`/core-`Value` marshalling
+  boundary would silently drop null-valued keys (the documented type-fidelity
+  rule), making the "no null-bearing keywords" document requirement
+  unreachable for exactly the JSON-sourced input it exists to catch. Caught by
+  reasoning through the marshalling contract, not by a failing test — worth
+  flagging as a general hazard for any future napi surface that needs to see
+  a real JSON `null`.
+- The effective-schema `allOf` array (contracts + local schema) is assembled
+  host-side in TS, not in the core — it's the one documented, mechanical
+  formula (specs/behaviors/contracts.md "Composition and enforcement") that
+  doesn't need a dedicated core entry point, since it's just an array literal
+  handed to the already-exposed `validateBatch`.
+- `prune` gained a `--yes` flag (not in the original spec text) to skip the
+  removal confirmation prompt non-interactively/in scripts and tests — the
+  spec says "needs confirmation" without dictating the mechanism, so this
+  isn't a spec amendment, just a filled-in gap.
+- The plan's Risks note ("document the resolution (union) in the file's
+  header comment" for `sources.toml`) isn't honored as a literal file
+  comment: the canonical TOML encoder strips comments on every rewrite, same
+  as every other config file this CLI rewrites (`init`/`infer`/
+  `migrate-config`). Documented as a source comment in `contracts.ts` instead.
+- Test coverage: `packages/gitsheets/src/cli/cli-contracts.test.ts` (17
+  tests) covers every Validation bullet above. The HTTPS leg of `adopt`/`sync`
+  is exercised with `fetch` mocked (`vi.stubGlobal`) rather than a real
+  network call, per this plan's Risks note allowing a "unit seam" fallback —
+  `readSource`'s URL branch (timeout, non-2xx handling) is exercised through
+  the full CLI path, just with the network substituted.
 
 ## Follow-ups
 
-(populated at closeout)
+- **`gitsheets-axi` parity** (deliberately out of scope here, per Risks):
+  agents will want `contracts verify`/`test` surfaced through the axi
+  interface. Needs its own plan.
+- **`sources.toml` merge-conflict resolution is undocumented in-repo** beyond
+  a source comment — if this becomes a real pain point, consider a
+  `--merge-sources` flag or a dedicated `contracts sources` subcommand rather
+  than relying on git's default table-level merge behavior.
+- No dedicated `rust/gitsheets-napi/test/contracts.mjs` boundary tests were
+  added for the four new napi functions (`validateContractName`,
+  `contractPath`, `checkContractDocument`, `contractLoad`) or
+  `CoreTransaction.deleteFile` — they're exercised indirectly through the
+  full CLI test suite (which passed, including the `check_contract_document`
+  null-preservation behavior via the JSON-adopt tests) and through
+  `gitsheets-core`'s own unit tests, but a future pass could add direct
+  boundary coverage matching the existing `contracts.mjs` style.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "serde_json",
  "toml",
 ]
 

--- a/rust/gitsheets-core/src/contract.rs
+++ b/rust/gitsheets-core/src/contract.rs
@@ -294,6 +294,26 @@ fn check_no_null_bearing_keywords(name: &str, json: &Json) -> Result<()> {
     })
 }
 
+/// Enforce the [document requirements](../../../specs/behaviors/contracts.md#contract-document-requirements)
+/// against a NOT-yet-vendored candidate document — `contracts-cli adopt`'s
+/// pre-vendor gate. Exactly the checks [`load_contract`] runs on an
+/// already-vendored document (self-contained, open, TOML-data-model-only,
+/// `$id`↔name, Draft-07 strict compile), minus the canonical-bytes-reencode
+/// check: `adopt` CANONICALIZES the candidate itself before vendoring it, so
+/// there is no pre-existing "vendored bytes" to compare against yet — the
+/// written file is canonical by construction (see
+/// `specs/behaviors/contracts.md` "Canonical form").
+pub fn check_contract_document(name: &str, json: &Json) -> Result<()> {
+    check_document_requirements(name, json)?;
+    // Draft-07, strictly compiled: unknown keywords fail compilation, the same
+    // as `[gitsheet.schema]` and `load_contract`.
+    validation::reject_unknown_keywords(json).map_err(|e| Error::ContractInvalid {
+        message: format!("contract {name:?}: {}", e.message()),
+        contract: name.to_string(),
+    })?;
+    Ok(())
+}
+
 // ── composition ────────────────────────────────────────────────────────────────
 
 /// Build a sheet's effective compiled JSON Schema, per
@@ -854,6 +874,35 @@ mod tests {
         });
         let err = validation::reject_unknown_keywords(&doc).unwrap_err();
         assert_eq!(err.code(), "config_invalid");
+    }
+
+    #[test]
+    fn check_contract_document_passes_a_conforming_candidate() {
+        let name = "example.com/c/v1";
+        check_contract_document(name, &valid_doc(name)).unwrap();
+    }
+
+    #[test]
+    fn check_contract_document_rejects_unknown_keywords_like_load_contract() {
+        let name = "example.com/c/v1";
+        let mut doc = valid_doc(name);
+        doc.as_object_mut()
+            .unwrap()
+            .insert("frobnicate".into(), Json::Bool(true));
+        let err = check_contract_document(name, &doc).unwrap_err();
+        assert_eq!(err.code(), "contract_invalid");
+    }
+
+    #[test]
+    fn check_contract_document_rejects_a_closed_candidate() {
+        let name = "example.com/c/v1";
+        let mut doc = valid_doc(name);
+        doc.as_object_mut()
+            .unwrap()
+            .insert("additionalProperties".into(), Json::Bool(false));
+        let err = check_contract_document(name, &doc).unwrap_err();
+        assert_eq!(err.code(), "contract_invalid");
+        assert!(err.message().contains("additionalProperties"));
     }
 
     // ── loading from a committed tree ──────────────────────────────────────────

--- a/rust/gitsheets-core/src/validation.rs
+++ b/rust/gitsheets-core/src/validation.rs
@@ -201,7 +201,14 @@ fn keyword_from_schema_path(schema_path: &str) -> Option<String> {
 /// datetime field passes here but the host would see an object. Datetime-typed
 /// schema fields are uncommon (the spec's example schemas are string/number);
 /// the parity fixtures stay JSON-representable and this case is enumerated.
-pub(crate) fn value_to_json(value: &Value) -> Json {
+///
+/// Widened to `pub` (from `pub(crate)`) for `contracts-cli`
+/// (`gitsheets-napi::check_contract_document`): the napi binding marshals a
+/// candidate document from JS as the core [`Value`] (the same `JsValue`
+/// newtype `validate_batch` already uses) and needs this exact conversion
+/// before running [`crate::contract::check_contract_document`] — reusing the
+/// one JSON-shape-of-record-truth rather than a second JS-side conversion.
+pub fn value_to_json(value: &Value) -> Json {
     match value {
         Value::String(s) => Json::String(s.clone()),
         Value::Integer(i) => Json::Number((*i).into()),

--- a/rust/gitsheets-napi/Cargo.toml
+++ b/rust/gitsheets-napi/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.8"
 # date components). The JS `Date` surface is a host concern, so this lives in
 # the binding, not the core.
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+serde_json = "1"
 
 [build-dependencies]
 napi-build = "2"

--- a/rust/gitsheets-napi/index.d.ts
+++ b/rust/gitsheets-napi/index.d.ts
@@ -75,6 +75,52 @@ export declare function validateBatch(schema: JsValue, records: Array<JsValue>):
  */
 export declare function canonicalContractHash(input: string | JsValue, format?: string | undefined | null): string
 /**
+ * Validate a contract name (`specs/behaviors/contracts.md` "Contract names
+ * and the derived path") — the same check a sheet's `implements` entries run
+ * through at sheet-open. `contracts adopt` runs it on the name derived from a
+ * candidate document's `$id` before vendoring. Throws
+ * `ConfigError(config_invalid)` naming the violated rule.
+ */
+export declare function validateContractName(name: string): void
+/**
+ * The derived vendored path for a contract name — mechanical, no manifest:
+ * `.gitsheets/contracts/<name>.toml`. The minimal JS surface over
+ * [`gitsheets_core::contract_path`].
+ */
+export declare function contractPath(name: string): string
+/**
+ * Enforce the contract document requirements
+ * (`specs/behaviors/contracts.md` "Contract document requirements") against a
+ * NOT-yet-vendored candidate document — `contracts adopt`'s pre-vendor gate.
+ *
+ * `input` is either already-parsed data (a JS object) or a string, in which
+ * case `format` says how to parse it — mirrors `canonicalContractHash`'s
+ * shape exactly, for the same reason: a **JSON-text** input is parsed with
+ * `serde_json::from_str` directly (preserving a literal JSON `null`),
+ * deliberately NOT via the `JsValue`/core-`Value` marshalling boundary,
+ * which silently *drops* null-valued keys per the type-fidelity rules at the
+ * top of this file. Requirement 4 (no null-bearing keywords — `default:
+ * null`, `const: null`, a null in `enum`) can only ever be violated by a
+ * JSON-sourced document (TOML has no null literal at all), so routing
+ * through the null-dropping path would make that check silently unreachable
+ * for exactly the input shape it exists to catch. A TOML-text or
+ * already-parsed-data input has no such hazard (nothing they carry can be a
+ * TOML/core `Value` null in the first place), so those still go through the
+ * shared `value_to_json` conversion.
+ * Throws `ContractError(contract_invalid)` naming the violated rule.
+ */
+export declare function checkContractDocument(name: string, input: string | JsValue, format?: string | undefined | null): void
+/**
+ * Load a vendored contract document `name` from the committed tree at
+ * `treeRef` (scoped under `openRoot`), returning it as JSON text on success.
+ * The minimal JS surface over [`gitsheets_core::contract::load_contract`] —
+ * runs the exact compile-time check (byte-canonical, document requirements,
+ * `$id`↔path) `Sheet::open` composition relies on, so `contracts verify` /
+ * `contracts adopt --sheet` get the identical guarantee. Throws
+ * `ContractError('contract_missing' | 'contract_invalid')` on failure.
+ */
+export declare function contractLoad(gitDir: string, treeRef: string, openRoot: string, name: string): string
+/**
  * The result of a successful [`verify_sheet_contract`] call — the wire shape
  * for `sheet.contractVerification` minus `tree` (the JS binding attaches that
  * from the read snapshot it already resolved to open the sheet).
@@ -430,6 +476,14 @@ export declare class CoreTransaction {
    * else. `path` is repo-root-relative. Returns the written blob hash.
    */
   writeFile(path: string, content: string): string
+  /**
+   * Delete a raw file at `path` (repo-root-relative) in this transaction's
+   * private tree *(mutating)* — `write_file`'s inverse. Returns whether a
+   * blob existed at `path` before the delete. Used by `contracts prune` to
+   * remove undeclared vendored contract documents; deep (slash-separated)
+   * paths are supported directly via `MutableTree::delete_child_deep`.
+   */
+  deleteFile(path: string): boolean
   /**
    * The blob-hash map of a record's attachments (`name → hash`, sorted by
    * name), or `null` when the record has no attachment directory. Read-only.

--- a/rust/gitsheets-napi/index.js
+++ b/rust/gitsheets-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, canonicalContractHash, verifySheetContract, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, writeBlob, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
+const { roundtrip, parseRecords, serializeRecords, renderPathsBatch, validateBatch, canonicalContractHash, validateContractName, contractPath, checkContractDocument, contractLoad, verifySheetContract, runComparator, collatorSort, CompiledDefinition, recordRead, recordWrite, recordDelete, recordList, writeBlob, substrateStats, substrateReset, recordQuery, recordQueryCandidates, templateFieldNames, recordIndexUnique, recordIndexMulti, createPatch, applyMergePatch, diffRecords, simulateCoreError, CoreTransaction, coreDiscoverSheets, coreCheckValidators, markdownSerialize, markdownNormalizeBody, markdownParse, markdownParseHeaderOnly, markdownExtractH1, markdownRewriteH1 } = nativeBinding
 
 module.exports.roundtrip = roundtrip
 module.exports.parseRecords = parseRecords
@@ -318,6 +318,10 @@ module.exports.serializeRecords = serializeRecords
 module.exports.renderPathsBatch = renderPathsBatch
 module.exports.validateBatch = validateBatch
 module.exports.canonicalContractHash = canonicalContractHash
+module.exports.validateContractName = validateContractName
+module.exports.contractPath = contractPath
+module.exports.checkContractDocument = checkContractDocument
+module.exports.contractLoad = contractLoad
 module.exports.verifySheetContract = verifySheetContract
 module.exports.runComparator = runComparator
 module.exports.collatorSort = collatorSort

--- a/rust/gitsheets-napi/src/lib.rs
+++ b/rust/gitsheets-napi/src/lib.rs
@@ -431,6 +431,115 @@ pub fn canonical_contract_hash(
     };
     gitsheets_core::canonical_contract_hash(core_input).map_err(|err| raise_core_error(&env, &err))
 }
+// ── contracts-cli surface (specs/api/cli.md "git sheet contracts") ──────────────
+//
+// The CLI's `adopt`/`verify`/`test` commands compose these four thin wrappers
+// over `gitsheets-core::contract` — reusing its name validation, derived-path
+// formula, document-requirement walk, and vendored-tree loader rather than
+// re-implementing any of them host-side. Effective-schema composition itself
+// (`allOf: [<contracts>, <local schema>]`) is the documented, mechanical
+// formula from `specs/behaviors/contracts.md` "Composition and enforcement" —
+// the CLI assembles that array in TS and validates it through the existing
+// `validate_batch`, so no further core/napi surface is needed for it.
+
+/// Validate a contract name (`specs/behaviors/contracts.md` "Contract names
+/// and the derived path") — the same check a sheet's `implements` entries run
+/// through at sheet-open. `contracts adopt` runs it on the name derived from a
+/// candidate document's `$id` before vendoring. Throws
+/// `ConfigError(config_invalid)` naming the violated rule.
+#[napi]
+pub fn validate_contract_name(env: Env, name: String) -> Result<()> {
+    gitsheets_core::validate_contract_name(&name).map_err(|err| raise_core_error(&env, &err))
+}
+
+/// The derived vendored path for a contract name — mechanical, no manifest:
+/// `.gitsheets/contracts/<name>.toml`. The minimal JS surface over
+/// [`gitsheets_core::contract_path`].
+#[napi]
+pub fn contract_path(name: String) -> String {
+    gitsheets_core::contract_path(&name)
+}
+
+/// Enforce the contract document requirements
+/// (`specs/behaviors/contracts.md` "Contract document requirements") against a
+/// NOT-yet-vendored candidate document — `contracts adopt`'s pre-vendor gate.
+///
+/// `input` is either already-parsed data (a JS object) or a string, in which
+/// case `format` says how to parse it — mirrors `canonicalContractHash`'s
+/// shape exactly, for the same reason: a **JSON-text** input is parsed with
+/// `serde_json::from_str` directly (preserving a literal JSON `null`),
+/// deliberately NOT via the `JsValue`/core-`Value` marshalling boundary,
+/// which silently *drops* null-valued keys per the type-fidelity rules at the
+/// top of this file. Requirement 4 (no null-bearing keywords — `default:
+/// null`, `const: null`, a null in `enum`) can only ever be violated by a
+/// JSON-sourced document (TOML has no null literal at all), so routing
+/// through the null-dropping path would make that check silently unreachable
+/// for exactly the input shape it exists to catch. A TOML-text or
+/// already-parsed-data input has no such hazard (nothing they carry can be a
+/// TOML/core `Value` null in the first place), so those still go through the
+/// shared `value_to_json` conversion.
+/// Throws `ContractError(contract_invalid)` naming the violated rule.
+#[napi]
+pub fn check_contract_document(
+    env: Env,
+    name: String,
+    input: Either<String, JsValue>,
+    format: Option<String>,
+) -> Result<()> {
+    let json: serde_json::Value = match input {
+        Either::B(value) => gitsheets_core::validation::value_to_json(&value.0),
+        Either::A(text) => match format.as_deref() {
+            Some("json") => serde_json::from_str(&text).map_err(|e| {
+                napi::Error::new(
+                    Status::InvalidArg,
+                    format!("checkContractDocument: JSON parse failed: {e}"),
+                )
+            })?,
+            Some("toml") => {
+                let value = gitsheets_core::parse(&text).map_err(|err| raise_core_error(&env, &err))?;
+                gitsheets_core::validation::value_to_json(&value)
+            }
+            Some(other) => {
+                return Err(napi::Error::new(
+                    Status::InvalidArg,
+                    format!("checkContractDocument: unknown format {other:?} — expected 'json' or 'toml'"),
+                ))
+            }
+            None => {
+                return Err(napi::Error::new(
+                    Status::InvalidArg,
+                    "checkContractDocument: pass { format: 'json' | 'toml' } when input is a string",
+                ))
+            }
+        },
+    };
+    gitsheets_core::contract::check_contract_document(&name, &json)
+        .map_err(|err| raise_core_error(&env, &err))
+}
+
+/// Load a vendored contract document `name` from the committed tree at
+/// `treeRef` (scoped under `openRoot`), returning it as JSON text on success.
+/// The minimal JS surface over [`gitsheets_core::contract::load_contract`] —
+/// runs the exact compile-time check (byte-canonical, document requirements,
+/// `$id`↔path) `Sheet::open` composition relies on, so `contracts verify` /
+/// `contracts adopt --sheet` get the identical guarantee. Throws
+/// `ContractError('contract_missing' | 'contract_invalid')` on failure.
+#[napi]
+pub fn contract_load(
+    env: Env,
+    git_dir: String,
+    tree_ref: String,
+    open_root: String,
+    name: String,
+) -> Result<String> {
+    let repo = record::open_repo(&git_dir).map_err(|err| raise_core_error(&env, &err))?;
+    let mut tree =
+        record::resolve_tree(&repo, &tree_ref).map_err(|err| raise_core_error(&env, &err))?;
+    let json = gitsheets_core::contract::load_contract(&repo, &mut tree, &open_root, &name)
+        .map_err(|err| raise_core_error(&env, &err))?;
+    Ok(json.to_string())
+}
+
 
 /// The result of a successful [`verify_sheet_contract`] call — the wire shape
 /// for `sheet.contractVerification` minus `tree` (the JS binding attaches that
@@ -1660,6 +1769,35 @@ impl CoreTransaction {
         tx.mark_mutated();
         Ok(hash)
     }
+    /// Delete a raw file at `path` (repo-root-relative) in this transaction's
+    /// private tree *(mutating)* — `write_file`'s inverse. Returns whether a
+    /// blob existed at `path` before the delete. Used by `contracts prune` to
+    /// remove undeclared vendored contract documents; deep (slash-separated)
+    /// paths are supported directly via `MutableTree::delete_child_deep`.
+    #[napi]
+    pub fn delete_file(&mut self, env: Env, path: String) -> Result<bool> {
+        let Self { inner, .. } = self;
+        let tx = inner.as_mut().ok_or_else(|| {
+            Error::new(Status::GenericFailure, "transaction is already finalized")
+        })?;
+        let existed = {
+            let (repo, tree) = tx.split();
+            match tree.delete_child_deep(repo, &path) {
+                Ok(existed) => existed,
+                Err(e) => {
+                    let core_err = gitsheets_core::Error::CommitFailed {
+                        message: format!("delete_file {path:?} failed: {e}"),
+                    };
+                    return Err(raise_core_error(&env, &core_err));
+                }
+            }
+        };
+        if existed {
+            tx.mark_mutated();
+        }
+        Ok(existed)
+    }
+
 
     /// The blob-hash map of a record's attachments (`name → hash`, sorted by
     /// name), or `null` when the record has no attachment directory. Read-only.


### PR DESCRIPTION
## Summary

Implements the `git sheet contracts <subcommand>` command group per [specs/api/cli.md](specs/api/cli.md) and [specs/behaviors/contracts.md](specs/behaviors/contracts.md), completing the plan in [plans/contracts-cli.md](plans/contracts-cli.md). Rides `contracts-core`'s (PR #265) loader/validation primitives.

- **`adopt <source> [--sheet <name>]...`** — reads a local file, `https://` URL (one-shot, 15s timeout), or `-` (stdin); JSON or TOML. Derives the name from `$id`, validates it, checks document requirements, canonicalizes, vendors at the derived path, records provenance in `.gitsheets/contracts/sources.toml`. `--sheet` gates on validating every existing record of the named sheet(s) against the would-be effective schema, refusing (streaming per-record issues to stderr) if any fails — nothing is written.
- **`verify [<sheet>]...`** — the offline CI gate: every declared contract resolves + is valid + canonical + `$id`↔path-consistent, every record validates against the effective schema; warns (not fails) on a closed local schema.
- **`test <sheet> --against <file-or-name>`** — rung-2 structural check against an arbitrary document, not the effective schema. Works on sheets that declare nothing.
- **`sync [<name>]...`** — re-fetches recorded sources, reports match/drift/unsyncable/missing; never rewrites vendored files.
- **`export <name>`** — vendored contract as interchange JSON on stdout.
- **`prune [--dry-run] [--yes]`** — lists/removes vendored documents no sheet declares.
- `ContractError` wired to CLI exit 67 (was missing from `exitCodeForError`).

## Review guide

- `packages/gitsheets/src/cli/contracts.ts` — the whole command group. Every command is a thin orchestration layer over core primitives; the one host-side "logic" is assembling the effective-schema `allOf` array — a documented, mechanical formula from the spec, validated through the existing `validateBatch`.
- `rust/gitsheets-core/src/contract.rs` — new `check_contract_document` (pub wrapper around the existing private `check_document_requirements` + `reject_unknown_keywords`, for a not-yet-vendored candidate).
- `rust/gitsheets-napi/src/lib.rs` — four new thin napi wrappers (`validateContractName`, `contractPath`, `checkContractDocument`, `contractLoad`) plus `CoreTransaction.deleteFile` (the `writeFile` inverse, for `prune`).
- `packages/gitsheets/src/cli/shared.ts` — `GlobalArgs`/`buildTxOpts` extracted here (previously private to `cli/index.ts`) to avoid a circular import between `index.ts` and `contracts.ts`.

### Design decision worth flagging

`checkContractDocument`'s napi signature takes `Either<String, JsValue> + format` (mirroring `canonicalContractHash`) rather than a plain `JsValue`. A JSON-text input is parsed directly via `serde_json::from_str`, preserving a literal `null` — routing through the `JsValue` marshalling boundary would silently *drop* null-valued keys (the documented type-fidelity rule), making the "no null-bearing keywords" document requirement unreachable for exactly the JSON-sourced input it exists to catch.

### Minor spec-adjacent additions (not contradicting the spec, just filling gaps it left open)

- `prune` gained a `--yes` flag to skip the removal confirmation prompt non-interactively — the spec says "needs confirmation" without dictating the mechanism.
- `sources.toml`'s header-comment note in the plan ("document the resolution (union) in the file's header comment") isn't literally honored as a file comment, because the canonical TOML encoder (correctly) strips comments on every rewrite — same as every other config file this CLI rewrites (`init`/`infer`/`migrate-config`). Documented as a source comment instead.

## Test plan

- [x] `cargo test --workspace` — 225 core + 4 corpus-parity tests pass
- [x] `rust/gitsheets-napi`'s `npm test` (node --test boundary suite) — 119 pass
- [x] `npm run type-check` (root, all workspaces) — clean
- [x] `npm run build` (root) — clean
- [x] `npm test` (root, all workspaces) — gitsheets 42 files/381 tests, gitsheets-axi 14 files/118 tests, gitsheets-napi 119 tests — all pass
- [x] New `packages/gitsheets/src/cli/cli-contracts.test.ts` (17 tests) covers every `plans/contracts-cli.md` Validation bullet: adopt byte-identity across JSON-local/TOML-local/HTTPS(mocked)-JSON, `--sheet` refusal leaving the tree untouched, `verify` pass + `contract_missing` + non-canonical-vendored (`contract_invalid`) + a record violation + the closed-local-schema warning, `test` pass/fail against a contract-unaware sheet, `sync` drift detection without rewriting, `export | adopt -` byte-identical round-trip, `prune --dry-run`/`--yes`.
- HTTPS is exercised with `fetch` mocked (`vi.stubGlobal`), not a real network call — per the plan's Risks note allowing a "unit seam" when real HTTPS is untestable locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1