### PR TITLE
docs: schema contracts guide + contract attribution on write-failure output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,10 +16,10 @@ import {
 
   // error classes
   GitsheetsError, ConfigError, ValidationError, TransactionError,
-  IndexError, RefError, PathTemplateError, NotFoundError,
+  IndexError, RefError, PathTemplateError, NotFoundError, ContractError,
 
   // utilities
-  mergePatch, validateRecord,
+  mergePatch, validateRecord, canonicalContractHash,
   parseToml, parseConfigToml, stringifyRecord,
   getFormat, hasFormat, registerFormat, resolveFormatConfig,
 
@@ -43,6 +43,8 @@ import type {
   PushDaemonOptions, PushDaemonStatus, PushFailureReason, BackoffConfig,
   JSONSchema, StandardSchemaV1, ValidationIssue, StandardSchemaResult,
   RecordLike, PathTemplateBlob, PathTemplateTree, PathTemplateQueryResult,
+  OpenSheetContractOptions, ContractVerificationMode, ConformanceReport,
+  ContractDocumentFormat, CanonicalContractHashOptions,
 } from 'gitsheets';
 ```
 
@@ -77,7 +79,7 @@ const store = await openStore(repo, {
 
 | Method | Purpose |
 | --- | --- |
-| `repo.openSheet<T>(name, opts?)` | Sheet handle; `opts.validator` (Standard Schema), `opts.root`, `opts.prefix` |
+| `repo.openSheet<T>(name, opts?)` | Sheet handle; `opts.validator` (Standard Schema), `opts.root`, `opts.prefix`, `opts.contract` (verify against a [contract](contracts.md) before returning — result on `sheet.contractVerification`) |
 | `repo.openSheets(opts?)` | All sheets keyed by name; `opts.root`, `opts.prefix` |
 | `repo.transact(opts, handler)` | Run a handler in a single-commit transaction |
 | `repo.withLock(fn)` | Run `fn` holding the write lock transact uses — coordinate non-transact git ops. Not reentrant (`lock_held`) |
@@ -237,6 +239,7 @@ Subclasses:
 | `RefError` | `ref_not_found`, `not_an_ancestor` |
 | `PathTemplateError` | `path_render_failed`, `path_invalid_chars` |
 | `NotFoundError` | `record_not_found` |
+| `ContractError` | `contract_missing`, `contract_invalid`, `contract_unsatisfied` (carries `contract` and, on `contract_unsatisfied`, the conformance report in `issues`) |
 
 Consumers switch on `instanceof` or `err.code` — never on `err.message`.
 
@@ -257,6 +260,10 @@ RFC 7396 JSON Merge Patch as a pure function. Useful when you want the patch sem
 ### `validateRecord({ record, schema, validator? })`
 
 Run the same validation pipeline `Sheet.upsert` uses without going through a Sheet. Useful for pre-flight (UI form submission, CSV ingest, audit passes against legacy records). Returns the possibly-transformed record on success, throws `ValidationError` on failure. See [`specs/behaviors/validation.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/validation.md).
+
+### `canonicalContractHash(input, options?)`
+
+The [contract](contracts.md) identity primitive: canonicalize a contract document — parsed data, or JSON/TOML text with `{ format }` — through the canonical TOML encoder and return the SHA-256 hex of the resulting bytes. Two parties holding the same logical document compute the same hash regardless of serialization.
 
 ### TOML round-tripping
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,6 +212,21 @@ Migration table (matches [`specs/behaviors/validation.md`](https://github.com/Ja
 | `sort: ...` | `[gitsheet.fields.<name>.sort]` (unchanged) |
 | `trueValues: [...]`, `falseValues: [...]` | Warning to stderr — move to CSV-ingest helper |
 
+### `gitsheets contracts <subcommand>`
+
+Manage [schema contracts](contracts.md) — vendored, immutable JSON Schema documents that sheets declare via `implements` and that compose into write-time validation. All writes land under `.gitsheets/contracts/`; sheet configs are never rewritten by tooling.
+
+```bash
+gitsheets contracts adopt <source> [--sheet <name>]...     # vendor a document (file, https:// URL, or - for stdin)
+gitsheets contracts verify [<sheet>]...                    # offline CI gate: documents + records all conform
+gitsheets contracts test <sheet> --against <file-or-name>  # structural check against any sheet (duck typing)
+gitsheets contracts sync [<name>]...                       # re-fetch recorded sources, report drift — never rewrites
+gitsheets contracts export <name>                          # vendored contract as interchange JSON on stdout
+gitsheets contracts prune [--dry-run] [--yes]              # remove vendored documents no sheet declares
+```
+
+`adopt --sheet` validates every existing record of the named sheet(s) against the would-be effective schema and refuses (tree untouched) until the data conforms. `verify` additionally warns when a declaring sheet's local schema sets `additionalProperties: false` (which can reject contract-conforming records under `allOf` composition). See the [contracts guide](contracts.md) for the full workflow.
+
 ## Exit codes
 
 | Code | Meaning |
@@ -223,6 +238,7 @@ Migration table (matches [`specs/behaviors/validation.md`](https://github.com/Ja
 | 64 | `ConfigError` |
 | 65 | `RefError` |
 | 66 | `NotFoundError` |
+| 67 | `ContractError` |
 | 69 | `TransactionError` |
 | 70 | `IndexError` |
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -186,6 +186,19 @@ The Standard Schema layer can **transform** the record (lower-casing, defaulting
 
 See [validation](validation.md) for the full pipeline.
 
+## Contract
+
+A named, versioned, **immutable** JSON Schema document a sheet declares it `implements`. The document is vendored into the repo (canonical TOML under `.gitsheets/contracts/`) and composed into the sheet's write-time validation via `allOf` — so every record the sheet ever commits conforms, by construction. A consumer holding the same document verifies the sheet mechanically: by content identity (fast; guarantees future writes too) or by validating the records themselves (works against any sheet; guarantees the present). The unit of cross-system sheet interoperability.
+
+```toml
+[gitsheet]
+root = 'meals'
+path = '${{ slug }}'
+implements = ['gitsheets.io/meals/v1']
+```
+
+See the [contracts guide](contracts.md).
+
 ## Content-typed sheets (markdown / mdx)
 
 A sheet's `[gitsheet.format]` block can switch its on-disk storage from

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,211 @@
+# Contracts
+
+A **contract** is a named, versioned, immutable JSON Schema document that a sheet
+can declare it **implements**. Declaring one composes it into the sheet's
+write-time validation — every record the sheet ever commits conforms, enforced
+where writes already happen. A consumer wiring itself to that sheet from another
+system can then *verify* conformance mechanically instead of hoping.
+
+Use contracts when one system consumes a sheet owned by another — a shared
+toolkit reading a domain sheet out of an application repo, two services meeting
+over a data repo, a published dataset with a stable shape. Without a contract,
+the consumer's expectations live implicitly in its code and drift surfaces as a
+confusing runtime failure in the system that *didn't* change. With one, drift is
+a commit-time failure in the producer and a precise wiring-time refusal in the
+consumer.
+
+## Declaring: the producer side
+
+A contract document is plain JSON Schema (Draft-07, the same dialect as
+`[gitsheet.schema]`) with a required `$id`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gitsheets.io/meals/v1",
+  "title": "Meal",
+  "type": "object",
+  "required": ["slug", "name", "nutrition"],
+  "properties": {
+    "slug": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "name": { "type": "string", "minLength": 1 },
+    "nutrition": {
+      "type": "object",
+      "description": "Ballpark per serving.",
+      "required": ["calories"],
+      "properties": {
+        "calories": { "type": "number", "description": "kcal" },
+        "protein_g": { "type": "number" }
+      }
+    }
+  }
+}
+```
+
+The `$id` minus its scheme is the **contract name** (`gitsheets.io/meals/v1`).
+It's an identifier, not a URL anything ever fetches — it only has to be
+host-qualified and stable.
+
+Adopt it into the repo:
+
+```console
+$ gitsheets contracts adopt ./meals-v1.schema.json
+adopted gitsheets.io/meals/v1 → .gitsheets/contracts/gitsheets.io/meals/v1.toml
+add to the declaring sheet's config (tooling never edits sheet configs):
+  implements = ['gitsheets.io/meals/v1']
+```
+
+`adopt` accepts a local file, an `https://` URL (fetched once, at adopt time —
+nothing ever fetches at runtime), or `-` for stdin, in JSON or TOML. It
+re-encodes the document through the canonical TOML encoder and **vendors** it at
+a path derived from its name. The vendored file is both the lock state and the
+enforced artifact: what validation compiles is exactly what identity hashes, so
+there is no recorded checksum that can drift from reality — the bytes *are* the
+pin.
+
+Then declare it — a one-line edit that stays yours (tooling never rewrites sheet
+configs):
+
+```toml
+# .gitsheets/meal-bank.toml
+[gitsheet]
+root = 'meals'
+path = '${{ slug }}'
+implements = ['gitsheets.io/meals/v1']
+
+[gitsheet.schema]                 # local extensions, composed with the contract
+type = 'object'
+required = ['tier']
+
+[gitsheet.schema.properties.tier]
+type = 'string'
+enum = ['anchor', 'rotation', 'occasional']
+```
+
+From here the sheet's effective schema is `allOf(contract, local schema)`: every
+write must satisfy both, and a violation says which contract it broke:
+
+```text
+gitsheets: ValidationError: record failed JSON Schema validation
+  code:   validation_failed
+  issue:  nutrition: "calories" is a required property (json-schema) [gitsheets.io/meals/v1]
+```
+
+The sheet keeps evolving freely beyond the contract — extra fields, stricter
+local rules — with zero coordination. Contracts are required to stay **open**
+(no `additionalProperties: false`) precisely so extension always works.
+
+Adopting into a sheet that already has records is gated on those records:
+`gitsheets contracts adopt <source> --sheet meal-bank` validates every existing
+record against the new effective schema and refuses (leaving the tree untouched)
+until the data conforms — adopting a contract is a claim that cannot lie.
+
+Add the offline gate to CI:
+
+```console
+$ gitsheets contracts verify
+contracts verify: ok
+```
+
+It checks every declaring sheet: names resolve to vendored documents, documents
+are byte-canonical with matching `$id`s, records validate, and it warns if a
+local schema sets `additionalProperties: false` (which can reject
+contract-conforming records under composition).
+
+## Verifying: the consumer side
+
+A consumer holds its own copy of the contract document and verifies at wiring
+time, through a two-rung ladder:
+
+```typescript
+import { openRepo, ContractError } from 'gitsheets';
+import mealsV1 from './contracts/meals-v1.schema.json';
+
+const repo = await openRepo({ gitDir: '/srv/hari/.git' });
+const meals = await repo.openSheet('meal-bank', {
+  contract: { schema: mealsV1 },   // mode: 'verify' is the default
+});
+
+meals.contractVerification;
+// { name: 'gitsheets.io/meals/v1', rung: 'declared', tree: '9c41…', conforming: true, issues: [] }
+```
+
+- **Rung 1 — declared identity.** The sheet declares the contract's name *and*
+  the vendored document is byte-identical (canonical-hash-equal) to the
+  consumer's copy. Pass ⇒ verified for the present **and the future** — the
+  producer's write-time enforcement guarantees every record that will ever
+  land — with zero records read.
+- **Rung 2 — structural.** On a rung-1 miss (no declaration, or a different
+  version), every record is validated against the consumer's document directly.
+  Pass ⇒ verified for the current tree. This is duck typing: it works against
+  any sheet ever written, contract-aware or not.
+
+Failure of the attempted rung(s) throws `ContractError('contract_unsatisfied')`
+carrying a per-record, per-field conformance report — a diff-quality refusal at
+wiring time, never a surprise mid-read.
+
+Three modes: `'verify'` (rung 1 then rung 2 — default), `'declared'` (rung 1
+only, never scans records), `'structural'` (rung 2 only). An optional `onDrift`
+callback gets an advisory signal if a structurally-verified sheet's producer
+later commits non-conforming data — reads are never blocked by drift; refusal
+belongs at wiring time only.
+
+The identity primitive is also exported directly:
+
+```typescript
+import { canonicalContractHash } from 'gitsheets';
+
+canonicalContractHash(mealsV1);                    // parsed data
+canonicalContractHash(text, { format: 'json' });   // or text — same hash either way
+```
+
+Two parties holding the same logical document get the same hash regardless of
+serialization, because everything funnels through the canonical TOML encoder —
+byte-equality and data-equality are the same question. (It's also the git blob
+OID question: the vendored file's hash *is* its identity.)
+
+From the command line, the structural check works against any sheet:
+
+```console
+$ gitsheets contracts test meal-bank --against ./contracts/meals-v1.schema.json
+ok overnight-oat-jar
+```
+
+## Evolving a contract
+
+Published versions are immutable — `…/v1` never changes; a changed document is a
+new name. Evolution patterns:
+
+- **Additive** (`…/v1.1` adds optional fields): the producer declares **both** —
+  `implements = ['gitsheets.io/meals/v1', 'gitsheets.io/meals/v1.1']`. Old
+  consumers keep matching v1 on rung 1, upgraded consumers match v1.1, both
+  fast-path, indefinitely. Carrying both costs nearly nothing.
+- **Breaking** (`…/v2` renames or restructures): prefer a bridge — design v2 so
+  records can satisfy v1 and v2 simultaneously during the transition (rename by
+  addition), then drop v1 and the legacy fields together later. A hard cutover
+  also fails *well*: old consumers get a precise conformance report at their
+  next boot, not a mid-request surprise.
+- A consumer needing more than a contract gives is a new contract version, not a
+  side channel — the ask arrives at the producer as a PR whose CI can't go
+  green until the data satisfies it.
+
+## Housekeeping
+
+```console
+$ gitsheets contracts sync            # re-fetch recorded sources, report drift — never rewrites
+match gitsheets.io/meals/v1
+$ gitsheets contracts export gitsheets.io/meals/v1   # interchange JSON to stdout
+$ gitsheets contracts prune --dry-run # list vendored documents no sheet declares
+```
+
+Provenance (where a contract was adopted from) lives in
+`.gitsheets/contracts/sources.toml` — tool-managed, non-load-bearing; validation
+and identity depend only on the vendored bytes.
+
+## Reference
+
+- CLI: [`gitsheets contracts`](cli.md#git-sheet-contracts-subcommand)
+- API: [`openSheet(name, { contract })`](api.md), `canonicalContractHash`,
+  `ContractError`
+- Authoritative behavior:
+  [`specs/behaviors/contracts.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/contracts.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Guides:
       - Path templates: path-templates.md
       - Validation: validation.md
+      - Contracts: contracts.md
       - CLI: cli.md
       - API reference: api.md
       - gitsheets-axi (agent CLI): axi.md

--- a/packages/gitsheets/src/cli/index.ts
+++ b/packages/gitsheets/src/cli/index.ts
@@ -113,7 +113,10 @@ function reportError(err: unknown): void {
     out.write(`  code:   ${err.code}\n`);
     if (err instanceof ValidationError && err.issues.length > 0) {
       for (const i of err.issues) {
-        out.write(`  issue:  ${i.path.join('.') || '<root>'}: ${i.message} (${i.source})\n`);
+        out.write(
+          `  issue:  ${i.path.join('.') || '<root>'}: ${i.message} (${i.source})` +
+            `${i.contract ? ` [${i.contract}]` : ''}\n`,
+        );
       }
     }
     if (err instanceof ContractError && err.issues && err.issues.length > 0) {


### PR DESCRIPTION
## What

Consumer-facing documentation for the schema-contracts feature that just landed (PRs #265/#267/#268) — the docs site had zero coverage.

- **New `docs/contracts.md`** — the full tour: contract documents and naming, `adopt` + `implements` (producer side), composed write-time enforcement, the two-rung consumer verification ladder (`openSheet({ contract })`), `canonicalContractHash`, evolution patterns (additive multi-implements, breaking-change bridges), and housekeeping (`sync`/`export`/`prune`). **Every command output is pasted from a live run** against the built CLI in a scratch repo, not invented.
- Touch-ups: `docs/cli.md` (`gitsheets contracts` command group + exit code 67), `docs/api.md` (module surface, `openSheet` contract option, `ContractError` row, `canonicalContractHash` utility), `docs/concepts.md` (Contract entry), `mkdocs.yml` nav.

## Plus one small fix the live run surfaced

`fix(cli)`: the write-failure printer dropped the contract attribution the core provides — an upsert rejected by a contract looked identical to one rejected by the local schema, contradicting the spec's "a failing write says which obligation it violated." Issue lines now append `[<contract-name>]` when present (the `ContractError` printer already did this; `ValidationError`'s didn't).

Verified: `npm test -w gitsheets` 388/388, type-check clean, live CLI run confirms the tag renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1