### PR TITLE
chore(napi): sync manifests to published @gitsheets/core-napi 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       "link": true
     },
     "node_modules/@gitsheets/core-napi-darwin-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-arm64/-/core-napi-darwin-arm64-0.3.0.tgz",
-      "integrity": "sha512-WIzPjJdHfLqqKoK3YpuN2tI7kDC6Wa7yo9fXl3k+2y8m+FxwwvjpLg0QraDcbKwbCnkHRqw0L5iw7d7IxEpilg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-arm64/-/core-napi-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-lXbPtRNovqla4Axj0zB89Q0gkQkoI4VHfgRTJVKXgK8GKcaNM7T0Y8J14lOTNugzP8KkLIbM0ea/Vep/kjeieQ==",
       "cpu": [
         "arm64"
       ],
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-darwin-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-x64/-/core-napi-darwin-x64-0.3.0.tgz",
-      "integrity": "sha512-smppb3w9Qwjvstuav/FdfFJdqzwswidvHryk7UdCO/HfOHXogl5b2EnKnHTjLdv7inU4RJatBQOGeB8tpbweGg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-darwin-x64/-/core-napi-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-vooQ4yxlMfpuSPhngz8B2rlvnljCSYte3irLkCQctqSGwBKOoIj1oHLOxvMqCEs0PI3ilkAZbIkgwsdv+58LGg==",
       "cpu": [
         "x64"
       ],
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-arm64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-arm64-gnu/-/core-napi-linux-arm64-gnu-0.3.0.tgz",
-      "integrity": "sha512-+PEY/scA6FKJpd5hJnmUrlQLG1q6dT4/8a8SuoUMIbUMdtY+enBG8kCHQ2Bdlu87lcC7CsZKmLHyIVFLz70bnw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-arm64-gnu/-/core-napi-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-GOk3EaM7kmxGvVdO0RG06t5Y5UJBq7bGQnauZN+dUJAPaPpA0Uidx21UGiEVtb0WBMaoSnyK0kGQ0QpwHDpy7A==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-x64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-gnu/-/core-napi-linux-x64-gnu-0.3.0.tgz",
-      "integrity": "sha512-bkUgFc/1jvLt1RT17/VatAILxG2yWHBuHLYYNe5ZRbo27nm5Jsy4DYjR2nOcet0pZcIgXAiN1cxT2cLGrq9D/A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-gnu/-/core-napi-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-Dy8Rav7pzJxgZX3kXztOEWq3p3W7fw8wY4EfzI6qScoQzpWy04wKFaPiz2zdmDP3KhKsBffr4NN2JgqpECMcgg==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-linux-x64-musl": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-musl/-/core-napi-linux-x64-musl-0.3.0.tgz",
-      "integrity": "sha512-DRlvLrvrrHl4ZbchX0vIP/hxwk70WR6/SZrqqL7r3Yjg3AnDTA7nsYwXLRGkfxcPt1BLTMFqcUffiz4FchoiMQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-linux-x64-musl/-/core-napi-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-MQierkKVNr+DLUd0W0yA6ISk+MdnkfGOWmBdLWzeMGYpDTZCj/pk6Zc1UvIDoT3sOsJSqKxEx6lJXyIz7CRXwg==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@gitsheets/core-napi-win32-x64-msvc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-win32-x64-msvc/-/core-napi-win32-x64-msvc-0.3.0.tgz",
-      "integrity": "sha512-jfXfWznQt7YQnBWpOCfV3mwJylJf8/H0AN/BeB56O4co598Xk7gXahWYZ8yAHXQgND2jibmpcMDzdJqCMdxeDA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gitsheets/core-napi-win32-x64-msvc/-/core-napi-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-UQXeY5irexeJxxV/bU2VHov5CZHlQjdkqI0YuyOF7XZ8tse8cUe93EsCeb5Mi1i6ffSuHMHoUcXwmdfQvvHyYQ==",
       "cpu": [
         "x64"
       ],
@@ -1804,7 +1804,7 @@
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gitsheets/core-napi": "^0.3.0",
+        "@gitsheets/core-napi": "^0.4.0",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "rfc6902": "^5.2.0",
@@ -1850,7 +1850,7 @@
     },
     "rust/gitsheets-napi": {
       "name": "@gitsheets/core-napi",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -1863,12 +1863,12 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@gitsheets/core-napi-darwin-arm64": "0.3.0",
-        "@gitsheets/core-napi-darwin-x64": "0.3.0",
-        "@gitsheets/core-napi-linux-arm64-gnu": "0.3.0",
-        "@gitsheets/core-napi-linux-x64-gnu": "0.3.0",
-        "@gitsheets/core-napi-linux-x64-musl": "0.3.0",
-        "@gitsheets/core-napi-win32-x64-msvc": "0.3.0"
+        "@gitsheets/core-napi-darwin-arm64": "0.4.0",
+        "@gitsheets/core-napi-darwin-x64": "0.4.0",
+        "@gitsheets/core-napi-linux-arm64-gnu": "0.4.0",
+        "@gitsheets/core-napi-linux-x64-gnu": "0.4.0",
+        "@gitsheets/core-napi-linux-x64-musl": "0.4.0",
+        "@gitsheets/core-napi-win32-x64-msvc": "0.4.0"
       }
     }
   }

--- a/packages/gitsheets/package.json
+++ b/packages/gitsheets/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "author": "Jarvus Innovations",
   "dependencies": {
-    "@gitsheets/core-napi": "^0.3.0",
+    "@gitsheets/core-napi": "^0.4.0",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "rfc6902": "^5.2.0",

--- a/rust/gitsheets-napi/package.json
+++ b/rust/gitsheets-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitsheets/core-napi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Node.js native binding for gitsheets-core — the FFI marshalling boundary.",
   "main": "binding.cjs",
   "types": "index.d.ts",
@@ -33,12 +33,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "@gitsheets/core-napi-darwin-arm64": "0.3.0",
-    "@gitsheets/core-napi-darwin-x64": "0.3.0",
-    "@gitsheets/core-napi-linux-arm64-gnu": "0.3.0",
-    "@gitsheets/core-napi-linux-x64-gnu": "0.3.0",
-    "@gitsheets/core-napi-linux-x64-musl": "0.3.0",
-    "@gitsheets/core-napi-win32-x64-msvc": "0.3.0"
+    "@gitsheets/core-napi-darwin-arm64": "0.4.0",
+    "@gitsheets/core-napi-darwin-x64": "0.4.0",
+    "@gitsheets/core-napi-linux-arm64-gnu": "0.4.0",
+    "@gitsheets/core-napi-linux-x64-gnu": "0.4.0",
+    "@gitsheets/core-napi-linux-x64-musl": "0.4.0",
+    "@gitsheets/core-napi-win32-x64-msvc": "0.4.0"
   },
   "scripts": {
     "artifacts": "napi artifacts",


### PR DESCRIPTION
Post-publish manifest sync for the `core-napi-v0.4.0` release (the contracts batch: new `canonicalContractHash`/`verifySheetContract`/contracts-CLI napi surface). Version + platform `optionalDependencies` in `rust/gitsheets-napi`, `^0.4.0` in `gitsheets`, lockfile refresh — so workspace tests resolve the published 0.4.0 binaries instead of stale 0.3.0, unblocking the v2.5.0 JS release per the repo's core-napi-first sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1