### PR TITLE
specs+plans: contract parity for Python binding + gitsheets-axi

### DIFF
--- a/plans/contracts-axi.md
+++ b/plans/contracts-axi.md
@@ -1,0 +1,82 @@
+---
+status: planned
+depends: []
+specs:
+  - specs/behaviors/contracts.md
+issues: []
+---
+
+# Plan: contract affordances for gitsheets-axi
+
+## Scope
+
+Surface the contract verification workflow through the agent-facing
+`gitsheets-axi` CLI so agents can gate on and diagnose conformance without the
+human CLI: `contracts verify`, `contracts test`, and `contracts list` — TOON
+output, stable outcome codes, idempotent read-only semantics per the AXI
+conventions the package already follows. The recorded follow-up from
+[`contracts-cli`](contracts-cli.md).
+
+Out of scope: mutating commands (`adopt`/`sync`/`prune` stay human-CLI-only for
+now — adoption is a reviewed, committed act, not an agent loop step; revisit on
+demand); any new core/napi surface (everything needed shipped in #265/#267/#268).
+
+## Implements
+
+- `specs/behaviors/contracts.md` — Consumer verification (`test` = rung 2) and
+  the producer verify gate, exposed agent-side. Note: `gitsheets-axi` has no
+  dedicated spec file (its conventions live in the AXI guidance + its README);
+  this plan implements the *behaviors* spec and documents the command surface
+  in the package README, matching how the rest of the axi surface is specified.
+
+## Approach
+
+1. Follow the existing `gitsheets-axi` command architecture (find the command
+   registry in `packages/gitsheets-axi/src/`, match its option parsing, TOON
+   emission, and error-code mapping exactly).
+2. `contracts list` — the discovery view: each vendored contract (name, hash,
+   declaring sheets) plus each sheet's `implements`; empty-state guidance line.
+3. `contracts verify [<sheet>...]` — the offline producer gate, reusing the
+   `gitsheets` package's exported machinery (never reimplement validation):
+   TOON rows per sheet/contract with `outcome: ok|failed|warning`, per-record
+   issues as structured rows (path, field, message, contract), stable exit
+   behavior and a `CONTRACT_UNSATISFIED`-style outcome code consistent with
+   the package's existing code vocabulary.
+4. `contracts test <sheet> --against <file-or-name>` — rung-2 structural check,
+   same output discipline; works against sheets declaring nothing.
+5. Tests: the package's existing test style (`packages/gitsheets-axi/test/`)
+   over fixture repos — verify ok / verify failure detail / test duck-typing /
+   list; snapshot or assert the TOON shapes agents will parse.
+6. README: document the three commands in the package README's command
+   reference, in its existing format.
+
+## Validation
+
+- [ ] `contracts list` renders vendored contracts + declaring sheets in TOON,
+      with a helpful empty state
+- [ ] `contracts verify` passes on a conforming fixture and reports structured
+      per-record issues (path, field, contract) on a seeded defect, with a
+      stable outcome code
+- [ ] `contracts test --against` verifies a contract-unaware sheet and reports
+      per-record conformance
+- [ ] Output is agent-parseable TOON consistent with the package's existing
+      commands (spot-checked against a real run)
+- [ ] Full `gitsheets-axi` suite passes; no changes outside the package +
+      README
+
+## Risks / unknowns
+
+- **Code-vocabulary fit** — the package has an established outcome-code set
+  (`VALIDATION_FAILED`, `CONFIG_INVALID`, …); new codes must extend it
+  consistently, not fork a parallel convention. Read the existing table first.
+- **TOON shape for nested issues** — per-record, per-field issues need a flat,
+  parseable row shape; follow whatever the package already does for
+  `check`-style validation output.
+
+## Notes
+
+(populated at closeout)
+
+## Follow-ups
+
+(populated at closeout)

--- a/plans/contracts-python-parity.md
+++ b/plans/contracts-python-parity.md
@@ -1,0 +1,84 @@
+---
+status: planned
+depends: []
+specs:
+  - specs/api/python-binding.md
+  - specs/behaviors/contracts.md
+issues: []
+---
+
+# Plan: contracts parity for the Python binding
+
+## Scope
+
+Bring the Python binding's contract surface to parity with Node, in the
+binding's own batch-first shape: `verify_sheet_contract` (the module-level
+consumer-verification function), a documented `canonical_contract_hash` (already
+shipped in #265 but absent from the spec until now), and `ContractError` with
+all three stable codes surfaced through the pyo3 exception taxonomy. Write-time
+enforcement needs nothing — it rides the shared core.
+
+Out of scope: any OO `open_sheet(contract=...)` surface (the binding is
+deliberately batch-first per `specs/api/python-binding.md`); drift callbacks
+(no live-rebind model exists on this surface); the axi work
+([`contracts-axi`](contracts-axi.md)).
+
+## Implements
+
+- `specs/api/python-binding.md` — the new **Contracts** subsection of
+  "Supported surface (0.x)" (this plan's spec change, landed with it)
+- `specs/behaviors/contracts.md` — Consumer verification, as exposed through
+  the batch FFI
+
+## Approach
+
+1. pyo3: `verify_sheet_contract(...)` wrapping the existing core
+   `gitsheets_core::verify_sheet_contract` (built in #267) — mirror the napi
+   wrapper's shape (`rust/gitsheets-napi/src/lib.rs::verify_sheet_contract`):
+   open the sheet read-only at `(git_dir, tree_ref)`, resolve the document
+   input (dict / JSON text / TOML text with explicit `format`, exactly like
+   the existing `canonical_contract_hash` py wrapper), run the ladder, return
+   the report as a dict (`name`, `rung`, `conforming`, `issues`, `tree`);
+   `contract_unsatisfied` raises `ContractError` with `issues` attached.
+2. Confirm `ContractError` marshalling covers all three codes (the class
+   landed in #265; `contract_unsatisfied` must carry per-record issues the
+   same way `ValidationError` carries its issues).
+3. Pure-Python wrapper in `python/gitsheets/__init__.py` following the
+   existing module-function conventions (docstrings, keyword defaults).
+4. Tests (`rust/gitsheets-py/tests/`): mirror the napi contract-verification
+   suite — rung-1 pass against a declaring fixture; rung-1 miss → rung-2 pass;
+   rung-2 failure report (record paths + contract + field issues);
+   `declared` fail-fast; `structural` duck-typing a contract-unaware sheet.
+   Extend the cross-binding parity suite: Node and Python must return the same
+   report (name/rung/conforming, same issue set) for the same fixture, and
+   identical `canonical_contract_hash` values (already covered — keep green).
+
+## Validation
+
+- [ ] `verify_sheet_contract` passes rung 1 against a declaring fixture sheet
+      and reports `rung: 'declared'` without reading records
+- [ ] Rung-1 miss falls through to a rung-2 structural pass; `declared` mode
+      raises immediately; `structural` mode verifies a contract-unaware sheet
+- [ ] A non-conforming sheet raises `ContractError` (`contract_unsatisfied`)
+      whose issues name record path, field, and contract
+- [ ] Cross-binding parity: Node and Python produce equivalent conformance
+      reports for the same fixtures
+- [ ] Full existing suites pass unchanged (`cargo test`, pytest, napi, JS)
+
+## Risks / unknowns
+
+- **Sheet-open plumbing in the py crate** — the napi wrapper leans on shared
+  `record::open_repo`/`resolve_tree`/`CoreSheet::open` helpers; confirm the py
+  crate has (or can reuse) equivalents without duplicating logic. If a helper
+  needs to move core-side for sharing, keep it a pure refactor.
+- **Issue marshalling shape** — Python issues today come through as dicts on
+  `ValidationError`; keep `ContractError.issues` the same shape (including the
+  new `record`/`contract` keys) rather than inventing a class.
+
+## Notes
+
+(populated at closeout)
+
+## Follow-ups
+
+(populated at closeout)

--- a/specs/api/python-binding.md
+++ b/specs/api/python-binding.md
@@ -16,6 +16,13 @@ The 0.x releases are honestly scoped as a **transactional writer with parity-pro
 
 **Reads** — module-level batch functions over a git dir + tree, taking `(git_dir, tree_ref, base, ...)` and returning records directly: `record_read`, `record_list`, `record_query`, `record_query_candidates`, alongside lower-level primitives (`parse_records`, `serialize_records`, `render_paths_batch`, `validate_batch`, `write_blob`, `create_patch`/`apply_merge_patch`/`diff_records`, `core_discover_sheets`, `record_index_unique`/`record_index_multi`). This is a batch-first FFI boundary — intentionally not the object-oriented `openRepo`/`Store`/`Sheet` API the Node/TS docs describe. Consumers coming from the JS surface should expect the writer + batch-read shape, which the bundled README states up front.
 
+**Contracts** ([behaviors/contracts.md](../behaviors/contracts.md)) — the same three surfaces the Node binding carries, in the batch-first shape:
+
+- Write-time enforcement of `implements` rides the shared core — nothing Python-specific; a contract-violating `upsert` raises the Python `ValidationError` with contract-attributed issues, byte-identically to Node.
+- `canonical_contract_hash(document, format=None)` — the identity primitive: parsed data (a `dict`), or JSON/TOML text with an explicit `format` (`'json'` | `'toml'`, no auto-detection — matching the Node surface). A JSON-text input preserves literal `null`s so the null-bearing-keyword requirement stays checkable.
+- `verify_sheet_contract(git_dir, tree_ref, sheet, document, format=None, mode='verify', config_path=None, root='.', prefix='')` — consumer-side verification, the module-level equivalent of Node's `openSheet(name, { contract })`: runs the two-rung ladder ([behaviors/contracts.md § Consumer verification](../behaviors/contracts.md#consumer-verification)) against the sheet at the given tree and returns the conformance report (`{name, rung, conforming, issues}` plus the verified tree hash). Failure raises `ContractError` with code `contract_unsatisfied` carrying the per-record issues. Modes `'verify'` | `'declared'` | `'structural'`, same semantics as Node. There is no drift callback — the batch surface has no live-rebind model to hook; consumers re-verify by calling again against a new tree.
+- `ContractError` in the exception taxonomy with the stable codes `contract_missing` / `contract_invalid` / `contract_unsatisfied`.
+
 ## Known gaps (documented, tracked, not blockers for 0.x)
 
 Per [#240](https://github.com/JarvusInnovations/gitsheets/issues/240): no freshness model (`refresh`/auto-refresh after commit) and no streaming blob reads. No push daemon. These reach parity as #240 lands; the 0.x README states them plainly.


### PR DESCRIPTION
Follow-through on the two follow-ups recorded at the contracts DAG's closeout:

- **`specs/api/python-binding.md`** gains a Contracts subsection in the binding's own batch-first shape — notably `verify_sheet_contract(...)` as the module-level equivalent of Node's `openSheet({ contract })` (no OO surface, no drift callback — the batch FFI has no live-rebind model), and documents `canonical_contract_hash`, which shipped in #265 but never made it into the spec's surface list (drift, now fixed).
- **`plans/contracts-python-parity.md`** — pyo3 wrapper over the existing core ladder (#267), ContractError with issues, cross-binding report parity tests.
- **`plans/contracts-axi.md`** — `contracts verify` / `test` / `list` through the agent CLI (TOON, stable outcome codes); mutating commands deliberately stay human-CLI-only.

Both plans are independent (empty `depends:`) — they touch disjoint packages and can drain in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1