### PR TITLE
feat(py): consumer-side contract verification — verify_sheet_contract

### DIFF
--- a/plans/contracts-python-parity.md
+++ b/plans/contracts-python-parity.md
@@ -1,10 +1,11 @@
 ---
-status: planned
+status: done
 depends: []
 specs:
   - specs/api/python-binding.md
   - specs/behaviors/contracts.md
 issues: []
+pr: 277
 ---
 
 # Plan: contracts parity for the Python binding
@@ -55,15 +56,15 @@ deliberately batch-first per `specs/api/python-binding.md`); drift callbacks
 
 ## Validation
 
-- [ ] `verify_sheet_contract` passes rung 1 against a declaring fixture sheet
+- [x] `verify_sheet_contract` passes rung 1 against a declaring fixture sheet
       and reports `rung: 'declared'` without reading records
-- [ ] Rung-1 miss falls through to a rung-2 structural pass; `declared` mode
+- [x] Rung-1 miss falls through to a rung-2 structural pass; `declared` mode
       raises immediately; `structural` mode verifies a contract-unaware sheet
-- [ ] A non-conforming sheet raises `ContractError` (`contract_unsatisfied`)
+- [x] A non-conforming sheet raises `ContractError` (`contract_unsatisfied`)
       whose issues name record path, field, and contract
-- [ ] Cross-binding parity: Node and Python produce equivalent conformance
+- [x] Cross-binding parity: Node and Python produce equivalent conformance
       reports for the same fixtures
-- [ ] Full existing suites pass unchanged (`cargo test`, pytest, napi, JS)
+- [x] Full existing suites pass unchanged (`cargo test`, pytest, napi, JS)
 
 ## Risks / unknowns
 
@@ -77,8 +78,36 @@ deliberately batch-first per `specs/api/python-binding.md`); drift callbacks
 
 ## Notes
 
-(populated at closeout)
+- The sheet-open plumbing risk was a non-issue: `record::open_repo`,
+  `record::resolve_tree`, and `sheet::Sheet as CoreSheet::open` were already
+  imported/used elsewhere in `rust/gitsheets-py/src/lib.rs` (e.g.
+  `record_query`), so `verify_sheet_contract` reuses them directly — no core
+  refactor needed.
+- The issue-marshalling risk was real: `raise_core_error`'s generic
+  `ValidationIssue → dict` loop was dropping the `record` key entirely (for
+  every typed exception, not just contracts). Fixed as part of this PR —
+  `ContractError.issues` now carries `record`/`contract` alongside the usual
+  `path`/`message`/`source`/`schema_path`/`code`, matching napi's
+  `JsValidationIssue` shape.
+- `config_path` defaults to `<root>/.gitsheets/<sheet>.toml` when omitted
+  (mirroring `Repository.openSheet`'s `joinTreePath(root, '.gitsheets',
+  '<name>.toml')` default on the Node/TS side), via the existing
+  `gitsheets_core::sheet::join_path` helper.
+- `declared`-mode failures carry no `.issues` attribute at all (not an empty
+  list) — `raise_core_error` only sets the attribute when issues are
+  non-empty, an existing convention shared with every other typed exception.
+  The test asserts `getattr(err, "issues", []) == []` rather than
+  `err.issues == []`.
+- Verified with: `cargo test --workspace` (230+ passing), `cargo clippy
+  --workspace --all-targets -- -D warnings` (clean), `gitsheets-napi`'s
+  `npm run build:debug && npm test` (123/123, `contracts.mjs` unchanged),
+  a release wheel built with `maturin build --release` + installed into a
+  `uv venv` + `pytest tests/ -v` with `GITSHEETS_NAPI_BINDING` set (49/49,
+  including the new cross-binding parity tests), and root `npm test`
+  (all workspaces, exit 0).
 
 ## Follow-ups
 
-(populated at closeout)
+None identified. The plan's scope (module function + `ContractError`
+marshalling + tests) is fully delivered; no CLI or spec follow-on work
+surfaced.

--- a/rust/gitsheets-py/python/gitsheets/__init__.py
+++ b/rust/gitsheets-py/python/gitsheets/__init__.py
@@ -46,6 +46,7 @@ serialize_records = _core.serialize_records
 render_paths_batch = _core.render_paths_batch
 validate_batch = _core.validate_batch
 canonical_contract_hash = _core.canonical_contract_hash
+verify_sheet_contract = _core.verify_sheet_contract
 run_comparator = _core.run_comparator
 record_read = _core.record_read
 record_write = _core.record_write
@@ -90,6 +91,7 @@ __all__ = [
     "render_paths_batch",
     "validate_batch",
     "canonical_contract_hash",
+    "verify_sheet_contract",
     "run_comparator",
     "record_read",
     "record_write",

--- a/rust/gitsheets-py/src/lib.rs
+++ b/rust/gitsheets-py/src/lib.rs
@@ -106,6 +106,7 @@ fn raise_core_error(py: Python<'_>, err: &gitsheets_core::Error) -> PyErr {
             let _ = d.set_item("schema_path", issue.schema_path.clone());
             let _ = d.set_item("code", issue.code.clone());
             let _ = d.set_item("contract", issue.contract.clone());
+            let _ = d.set_item("record", issue.record.clone());
             let _ = list.append(d);
         }
         let _ = value.setattr("issues", list);
@@ -480,6 +481,114 @@ fn canonical_contract_hash(
         gitsheets_core::ContractHashInput::Data(py_to_value(input)?)
     };
     gitsheets_core::canonical_contract_hash(core_input).map_err(|err| raise_core_error(py, &err))
+}
+
+/// Consumer-side contract verification — the two-rung ladder behind Node's
+/// `openSheet(name, { contract })`, in this binding's batch-first shape
+/// (specs/behaviors/contracts.md "Consumer verification",
+/// specs/api/python-binding.md "Contracts"). Opens `sheet` read-only against
+/// `tree_ref` (config read + effective-schema compile, same as any other
+/// read) — defaulting `config_path` to `<root>/.gitsheets/<sheet>.toml` when
+/// omitted, mirroring `Repository.openSheet`'s default — then verifies it
+/// against `document`: parsed data (a `dict`), or text with an explicit
+/// `format` (`'json'` | `'toml'`, no auto-detection — matching
+/// `canonical_contract_hash`). Returns the conformance report as a dict
+/// (`name`, `rung`, `conforming`, `issues`, `tree`). Modes: `'verify'` (rung
+/// 1, fall back to rung 2 — the default), `'declared'` (rung 1 only, never
+/// reads records), `'structural'` (rung 2 only — pure duck typing, ignores
+/// `implements`). A verification failure (both rungs missed, or the
+/// attempted rung missed in `declared`/`structural` mode) raises
+/// `ContractError('contract_unsatisfied')` with the per-record issues
+/// attached (`record`/`contract` keys alongside the usual
+/// `path`/`message`/`source` — the same shape `ValidationError.issues`
+/// carries).
+#[pyfunction]
+#[pyo3(signature = (git_dir, tree_ref, sheet, document, format=None, mode="verify", config_path=None, root=".", prefix=""))]
+#[allow(clippy::too_many_arguments)]
+fn verify_sheet_contract<'py>(
+    py: Python<'py>,
+    git_dir: String,
+    tree_ref: String,
+    sheet: String,
+    document: &Bound<'py, PyAny>,
+    format: Option<&str>,
+    mode: &str,
+    config_path: Option<String>,
+    root: &str,
+    prefix: &str,
+) -> PyResult<Bound<'py, PyDict>> {
+    let core_input = if let Ok(text) = document.extract::<String>() {
+        match format {
+            Some("json") => gitsheets_core::ContractHashInput::Json(text),
+            Some("toml") => gitsheets_core::ContractHashInput::Toml(text),
+            Some(other) => {
+                return Err(PyValueError::new_err(format!(
+                    "verify_sheet_contract: unknown format {other:?} — expected 'json' or 'toml'"
+                )))
+            }
+            None => {
+                return Err(PyValueError::new_err(
+                    "verify_sheet_contract: pass format='json'|'toml' when document is a str",
+                ))
+            }
+        }
+    } else {
+        gitsheets_core::ContractHashInput::Data(py_to_value(document)?)
+    };
+
+    let verify_mode = match mode {
+        "verify" => gitsheets_core::VerifyMode::Verify,
+        "declared" => gitsheets_core::VerifyMode::Declared,
+        "structural" => gitsheets_core::VerifyMode::Structural,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "verify_sheet_contract: unknown mode {other:?} — expected 'verify', 'declared', or 'structural'"
+            )))
+        }
+    };
+
+    // Default config_path mirrors `Repository.openSheet`'s
+    // `joinTreePath(root, '.gitsheets', \`${name}.toml\`)`.
+    let resolved_config_path = config_path.unwrap_or_else(|| {
+        gitsheets_core::sheet::join_path(&[root, ".gitsheets", &format!("{sheet}.toml")])
+    });
+
+    let repo = record::open_repo(&git_dir).map_err(|e| raise_core_error(py, &e))?;
+    let mut tree = record::resolve_tree(&repo, &tree_ref).map_err(|e| raise_core_error(py, &e))?;
+    let core_sheet = CoreSheet::open(&repo, &mut tree, &sheet, &resolved_config_path, root, prefix)
+        .map_err(|e| raise_core_error(py, &e))?;
+
+    match gitsheets_core::verify_sheet_contract(
+        &repo,
+        &mut tree,
+        root,
+        &core_sheet,
+        core_input,
+        verify_mode,
+    ) {
+        Ok(report) => {
+            let d = PyDict::new(py);
+            d.set_item("name", report.name)?;
+            d.set_item("rung", report.rung.as_str())?;
+            d.set_item("conforming", report.conforming)?;
+            let issues = PyList::empty(py);
+            for issue in report.issues {
+                let id = PyDict::new(py);
+                id.set_item("path", issue.path)?;
+                id.set_item("message", issue.message)?;
+                id.set_item("source", issue.source.as_str())?;
+                id.set_item("schema_path", issue.schema_path)?;
+                id.set_item("code", issue.code)?;
+                id.set_item("contract", issue.contract)?;
+                id.set_item("record", issue.record)?;
+                issues.append(id)?;
+            }
+            d.set_item("issues", issues)?;
+            d.set_item("tree", tree_ref)?;
+            Ok(d)
+        }
+        Err(err) => Err(raise_core_error(py, &err)),
+    }
 }
 
 /// Compile a raw-JS sort comparator (`rule`, the body of `(a, b) => { … }`) and
@@ -1434,6 +1543,7 @@ fn _gitsheets(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(render_paths_batch, m)?)?;
     m.add_function(wrap_pyfunction!(validate_batch, m)?)?;
     m.add_function(wrap_pyfunction!(canonical_contract_hash, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_sheet_contract, m)?)?;
     m.add_function(wrap_pyfunction!(run_comparator, m)?)?;
     m.add_function(wrap_pyfunction!(record_read, m)?)?;
     m.add_function(wrap_pyfunction!(record_write, m)?)?;

--- a/rust/gitsheets-py/tests/_node_writer.mjs
+++ b/rust/gitsheets-py/tests/_node_writer.mjs
@@ -6,6 +6,11 @@
 //   commit <gitDir>                   → { commitHash, treeHash, refName }
 //   comparator <rule> <aJson> <bJson> → { result }
 //   contract-hash <kind> <input>      → { hash } — kind: data|json|toml
+//   verify-contract <gitDir> <docJson> [mode]
+//     → { ok: true, report } | { ok: false, code, contract, issues }
+//     Verifies the 'people' sheet (config at .gitsheets/people.toml, root '.',
+//     no prefix) at HEAD — the same shared fixture the Python side builds via
+//     test_cross_binding.py, so the two bindings' reports can be diffed.
 //
 // The binding.cjs path comes from $GITSHEETS_NAPI_BINDING. Fixtures are authored
 // here as native JS values (the whole point: the same logical data, expressed in
@@ -116,6 +121,26 @@ if (op === 'record-write') {
   const input = kind === 'data' ? JSON.parse(args[1]) : args[1];
   const format = kind === 'data' ? undefined : kind;
   out({ hash: binding.canonicalContractHash(input, format) });
+} else if (op === 'verify-contract') {
+  const gitDir = args[0];
+  const doc = JSON.parse(args[1]);
+  const mode = args[2]; // 'verify' | 'declared' | 'structural' | undefined
+  try {
+    const report = binding.verifySheetContract(
+      gitDir,
+      'HEAD',
+      'people',
+      '.gitsheets/people.toml',
+      '.',
+      '',
+      doc,
+      undefined,
+      mode,
+    );
+    out({ ok: true, report });
+  } catch (err) {
+    out({ ok: false, code: err.code, contract: err.contract, issues: err.issues ?? [] });
+  }
 } else {
   process.stderr.write(`unknown op: ${op}\n`);
   process.exit(2);

--- a/rust/gitsheets-py/tests/test_contracts.py
+++ b/rust/gitsheets-py/tests/test_contracts.py
@@ -10,6 +10,7 @@ contract on a failing write and lets a conforming write through;
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -144,3 +145,147 @@ def test_canonical_contract_hash_agrees_across_data_json_and_toml():
 def test_canonical_contract_hash_requires_a_format_for_string_input():
     with pytest.raises(ValueError, match="format"):
         gitsheets.canonical_contract_hash("a = 1\n")
+
+
+# ── verify_sheet_contract: the two-rung consumer verification ladder ────────
+#
+# Mirrors rust/gitsheets-napi/test/contracts.mjs's `verifySheetContract` suite
+# — same fixtures, same five cases (rung-1 zero-record-read pass, rung-1 miss
+# falling through to a rung-2 pass, a rung-2 failure's per-record issues,
+# `declared` mode's fail-fast, `structural` mode's duck typing).
+
+NO_IMPLEMENTS = "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n"
+
+
+@contextlib.contextmanager
+def _setup_repo(sheet_config: str, contract_toml: str | None = None, contract_name: str = CONTRACT_NAME):
+    """A repo with `.gitsheets/people.toml` (`sheet_config`) committed on
+    `main`. When `contract_toml` is given, also vendors it at
+    `contract_name`'s derived path in the same commit. Yields
+    `(repo_dir, git_dir)`; cleans up the tempdir on exit."""
+    d = tempfile.mkdtemp(prefix="gitsheets-py-contracts-")
+    try:
+        _git(["init", "-q", "-b", "main", d])
+        _git(["config", "user.name", "Seed"], cwd=d)
+        _git(["config", "user.email", "seed@x.org"], cwd=d)
+        os.makedirs(os.path.join(d, ".gitsheets"), exist_ok=True)
+        with open(os.path.join(d, ".gitsheets", "people.toml"), "w") as fh:
+            fh.write(sheet_config)
+        _git(["add", ".gitsheets/people.toml"], cwd=d)
+        if contract_toml is not None:
+            path = os.path.join(d, ".gitsheets", "contracts", f"{contract_name}.toml")
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as fh:
+                fh.write(contract_toml)
+            _git(["add", ".gitsheets/contracts"], cwd=d)
+        _git(["commit", "-q", "-m", "init"], cwd=d)
+        yield d, os.path.join(d, ".git")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _write_record(repo_dir: str, root: str, slug: str, fields: dict) -> None:
+    rd = os.path.join(repo_dir, root)
+    os.makedirs(rd, exist_ok=True)
+    with open(os.path.join(rd, f"{slug}.toml"), "w") as fh:
+        fh.write(gitsheets.serialize_records([{"slug": slug, **fields}])[0])
+
+
+def _write_garbage(repo_dir: str, root: str, slug: str) -> None:
+    rd = os.path.join(repo_dir, root)
+    os.makedirs(rd, exist_ok=True)
+    with open(os.path.join(rd, f"{slug}.toml"), "w") as fh:
+        fh.write("not [ valid toml")
+
+
+def _consumer_doc(name: str, required: list) -> dict:
+    return {
+        "$id": f"https://{name}",
+        "type": "object",
+        "required": required,
+        "properties": {field: {"type": "string"} for field in required},
+    }
+
+
+def test_verify_rung1_passes_with_zero_record_reads():
+    with _setup_repo(SHEET_WITH_IMPLEMENTS, CONFORMING_CONTRACT) as (d, git_dir):
+        # A garbage record that would blow up `Sheet.list` if rung 1 ever fell
+        # through to reading records — proves the zero-record-read claim.
+        _write_garbage(d, "people", "garbage")
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "garbage"], cwd=d)
+
+        doc = _consumer_doc(CONTRACT_NAME, ["email"])
+        report = gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc)
+        assert report["name"] == CONTRACT_NAME
+        assert report["rung"] == "declared"
+        assert report["conforming"] is True
+        assert report["issues"] == []
+
+
+def test_verify_rung1_miss_on_newer_producer_version_falls_through_to_rung2_pass():
+    name_v1_1 = "example.com/people/v1.1"
+    sheet_config = (
+        "[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n"
+        f"implements = ['{name_v1_1}']\n"
+    )
+    contract_v1_1 = _canonical_toml(_consumer_doc(name_v1_1, ["email"]))
+    with _setup_repo(sheet_config, contract_v1_1, contract_name=name_v1_1) as (d, git_dir):
+        _write_record(d, "people", "jane", {"email": "jane@x.org"})
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "add jane"], cwd=d)
+
+        # The consumer still holds v1 — a rung-1 miss (name not declared) that
+        # falls through to a rung-2 pass (the data satisfies v1 too).
+        doc_v1 = _consumer_doc(CONTRACT_NAME, ["email"])
+        report = gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc_v1)
+        assert report["rung"] == "structural"
+        assert report["conforming"] is True
+
+
+def test_verify_rung2_failure_reports_record_and_field_issues():
+    with _setup_repo(NO_IMPLEMENTS) as (d, git_dir):  # contract-unaware
+        _write_record(d, "people", "jane", {"email": "jane@x.org"})
+        _write_record(d, "people", "bob", {})  # missing email
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "add people"], cwd=d)
+
+        doc = _consumer_doc(CONTRACT_NAME, ["email"])
+        with pytest.raises(gitsheets.ContractError) as ei:
+            gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc)
+        err = ei.value
+        assert err.code == "contract_unsatisfied"
+        assert err.contract == CONTRACT_NAME
+        issue = next(i for i in err.issues if i["record"] == "bob")
+        assert issue["contract"] == CONTRACT_NAME
+        assert issue["code"] == "required"
+        assert not any(i["record"] == "jane" for i in err.issues)
+
+
+def test_verify_declared_mode_fails_fast_without_reading_records():
+    with _setup_repo(NO_IMPLEMENTS) as (d, git_dir):  # not declared
+        _write_garbage(d, "people", "garbage")
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "garbage"], cwd=d)
+
+        doc = _consumer_doc(CONTRACT_NAME, ["email"])
+        with pytest.raises(gitsheets.ContractError) as ei:
+            gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc, mode="declared")
+        err = ei.value
+        assert err.code == "contract_unsatisfied"
+        # Declared mode never scans records, so there are no per-record
+        # issues — `raise_core_error` only sets `.issues` when non-empty (the
+        # same convention every other typed exception follows).
+        assert getattr(err, "issues", []) == []
+
+
+def test_verify_structural_mode_duck_types_a_contract_unaware_sheet():
+    with _setup_repo(NO_IMPLEMENTS) as (d, git_dir):  # no implements at all
+        _write_record(d, "people", "jane", {"email": "jane@x.org"})
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "add jane"], cwd=d)
+
+        doc = _consumer_doc(CONTRACT_NAME, ["email"])
+        report = gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc, mode="structural")
+        assert report["rung"] == "structural"
+        assert report["conforming"] is True

--- a/rust/gitsheets-py/tests/test_cross_binding.py
+++ b/rust/gitsheets-py/tests/test_cross_binding.py
@@ -256,3 +256,85 @@ def test_canonical_contract_hash_identical_across_bindings():
     assert node_data == node_json == node_toml
 
     assert py_data == node_data, "contract identity diverged across bindings"
+
+
+def _init_people_repo(d: str) -> None:
+    """A minimal repo with `.gitsheets/people.toml` (no `implements`) committed
+    on `main` — the shared fixture both bindings verify against."""
+    _git(["init", "-q", "-b", "main", d])
+    _git(["config", "user.name", "Seed"], cwd=d)
+    _git(["config", "user.email", "seed@x.org"], cwd=d)
+    os.makedirs(os.path.join(d, ".gitsheets"))
+    with open(os.path.join(d, ".gitsheets", "people.toml"), "w") as fh:
+        fh.write("[gitsheet]\npath = '${{ slug }}'\nroot = 'people'\n")
+    _git(["add", ".gitsheets/people.toml"], cwd=d)
+
+
+def test_verify_sheet_contract_structural_pass_report_identical_across_bindings():
+    """A rung-2 (structural) conformance report — name/rung/conforming and an
+    empty issue set — agrees across Python and Node for the same fixture
+    (specs/behaviors/contracts.md 'Consumer verification')."""
+    d = tempfile.mkdtemp(prefix="gs-verify-")
+    try:
+        _init_people_repo(d)
+        os.makedirs(os.path.join(d, "people"))
+        with open(os.path.join(d, "people", "jane.toml"), "w") as fh:
+            fh.write(gitsheets.serialize_records([{"slug": "jane", "email": "jane@x.org"}])[0])
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "init"], cwd=d)
+
+        git_dir = os.path.join(d, ".git")
+        doc = {
+            "$id": "https://example.com/people/v1",
+            "type": "object",
+            "required": ["email"],
+            "properties": {"email": {"type": "string"}},
+        }
+        py_report = gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc, mode="structural")
+        node = _run_node("verify-contract", git_dir, json.dumps(doc), "structural")
+
+        assert node["ok"] is True
+        assert py_report["name"] == node["report"]["name"]
+        assert py_report["rung"] == node["report"]["rung"]
+        assert py_report["conforming"] == node["report"]["conforming"]
+        assert py_report["issues"] == node["report"]["issues"] == []
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_verify_sheet_contract_failure_issue_set_identical_across_bindings():
+    """A rung-2 failure's `ContractError` — code, contract name, and the
+    per-record issue set (record/code/contract) — agrees across Python and
+    Node for the same non-conforming fixture."""
+    d = tempfile.mkdtemp(prefix="gs-verify-")
+    try:
+        _init_people_repo(d)
+        os.makedirs(os.path.join(d, "people"))
+        for slug, fields in [("jane", {"email": "jane@x.org"}), ("bob", {})]:
+            with open(os.path.join(d, "people", f"{slug}.toml"), "w") as fh:
+                fh.write(gitsheets.serialize_records([{"slug": slug, **fields}])[0])
+        _git(["add", "people"], cwd=d)
+        _git(["commit", "-q", "-m", "init"], cwd=d)
+
+        git_dir = os.path.join(d, ".git")
+        doc = {
+            "$id": "https://example.com/people/v1",
+            "type": "object",
+            "required": ["email"],
+            "properties": {"email": {"type": "string"}},
+        }
+        with pytest.raises(gitsheets.ContractError) as ei:
+            gitsheets.verify_sheet_contract(git_dir, "HEAD", "people", doc)
+        py_err = ei.value
+
+        node = _run_node("verify-contract", git_dir, json.dumps(doc))
+
+        assert node["ok"] is False
+        assert py_err.code == node["code"] == "contract_unsatisfied"
+        assert py_err.contract == node["contract"] == "example.com/people/v1"
+
+        py_issue_set = {(i["record"], i["code"], i["contract"]) for i in py_err.issues}
+        node_issue_set = {(i["record"], i["code"], i["contract"]) for i in node["issues"]}
+        assert py_issue_set == node_issue_set == {("bob", "required", "example.com/people/v1")}
+    finally:
+        shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
## Summary

Brings the Python binding's contract surface to parity with Node, per
`specs/api/python-binding.md`'s **Contracts** subsection and
`specs/behaviors/contracts.md`'s "Consumer verification" ladder — the
batch-first `verify_sheet_contract` module function (the plan's
`contracts-python-parity`).

- `verify_sheet_contract(git_dir, tree_ref, sheet, document, format=None, mode='verify', config_path=None, root='.', prefix='')` —
  a pyo3 wrapper over `gitsheets_core::verify_sheet_contract`, mirroring the
  napi wrapper's shape: opens the sheet read-only at `(git_dir, tree_ref)`,
  resolves the document input exactly like the existing
  `canonical_contract_hash` (parsed `dict`, JSON text, or TOML text with an
  explicit `format` — no auto-detection), runs the two-rung ladder, and
  returns the conformance report as a dict: `{name, rung, conforming,
  issues, tree}`.
- `config_path` defaults to `<root>/.gitsheets/<sheet>.toml` when omitted,
  mirroring `Repository.openSheet`'s default on the Node side
  (`joinTreePath(root, '.gitsheets', '<name>.toml')`).
- A verification failure raises `ContractError('contract_unsatisfied')`
  with the conformance report's issues attached.
- **Fix**: `raise_core_error`'s generic issue marshalling was dropping the
  `record` key (the field a rung-2 conformance report uses to name which
  record failed) — every typed exception's `.issues` was missing it, not
  just contracts'. Added it so `ContractError.issues` carries the same
  shape `ValidationError.issues` does, per the plan's called-out risk.

Confirmed all three `ContractError` codes marshal correctly:
`contract_missing` / `contract_invalid` (pre-existing tests, unchanged) and
`contract_unsatisfied` (new tests below).

## Review guide

- `rust/gitsheets-py/src/lib.rs` — the new `verify_sheet_contract`
  pyfunction (registered in the `_gitsheets` pymodule) plus the one-line
  `raise_core_error` fix.
- `rust/gitsheets-py/python/gitsheets/__init__.py` — re-exports
  `verify_sheet_contract` alongside the other batch-first functions.
- `rust/gitsheets-py/tests/test_contracts.py` — five new tests mirroring
  `rust/gitsheets-napi/test/contracts.mjs`'s `verifySheetContract` suite:
  rung-1 zero-record-read pass, rung-1 miss falling through to a rung-2
  pass, rung-2 failure's per-record/per-field issues, `declared` mode's
  fail-fast, `structural` mode's duck-typing of a contract-unaware sheet.
- `rust/gitsheets-py/tests/_node_writer.mjs` +
  `rust/gitsheets-py/tests/test_cross_binding.py` — a new `verify-contract`
  op and two parity tests proving Python and Node produce equivalent
  conformance reports (name/rung/conforming + the same issue set) for
  shared fixtures.

No CLI-facing changes, no core changes — this is a binding-only addition,
scoped entirely to `rust/gitsheets-py` per the plan (the sibling
`contracts-axi` work lives in `packages/gitsheets-axi` and isn't touched
here).

## Deviations from the plan

None. No spec ambiguity encountered — `specs/api/python-binding.md`'s
Contracts subsection (landed with this plan) specified the exact function
signature and return shape, matched as written.

## Test plan

- [x] `cargo test --workspace` — 230 core/sheet/contract tests +
      corpus-parity + napi/py unit tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `rust/gitsheets-napi`: `npm run build:debug && npm test` — 123/123
      passing (contracts.mjs unchanged, proving the napi surface this PR
      mirrors is untouched)
- [x] `rust/gitsheets-py`: built a release wheel with `maturin build
      --release`, installed it into a `uv venv`, ran
      `GITSHEETS_NAPI_BINDING=../gitsheets-napi/binding.cjs pytest tests/
      -v` — 49/49 passing, including the 5 new `verify_sheet_contract`
      tests and the 2 new cross-binding parity tests
- [x] root `npm test` (all workspaces) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1