### PR TITLE
feat(axi): contracts list, verify, test — agent-facing conformance commands

### DIFF
--- a/packages/gitsheets-axi/README.md
+++ b/packages/gitsheets-axi/README.md
@@ -19,7 +19,7 @@ Requires Node.js ≥ 20 and a `gitsheets`-managed git repository. Lockstep-versi
 ## When to use this vs. `gitsheets`
 
 | Scenario | Use |
-|---|---|
+| --- | --- |
 | Agent reading or mutating records via shell | `gitsheets-axi` |
 | Writing TypeScript that imports the library | [`gitsheets`](https://www.npmjs.com/package/gitsheets) |
 | Authoring `.gitsheets/<name>.toml` configs | Either (configs are shared) |
@@ -43,11 +43,35 @@ gitsheets-axi init <sheet> [--path <template>] [--schema <file>] [--force]
 gitsheets-axi infer <sheet>
 gitsheets-axi migrate-config <sheet>
 gitsheets-axi attachment <list|get|set|delete> <sheet> <path> [<name>]
+gitsheets-axi contracts [list]
+gitsheets-axi contracts verify [<sheet>...]
+gitsheets-axi contracts test <sheet> --against <file-or-name>
 gitsheets-axi push [--remote r] [--branch b]
 gitsheets-axi setup hooks
 ```
 
 Run any command with `--help` for its flags + examples. Every command runs `--help` against itself, not the top-level manual.
+
+## Schema contracts
+
+`contracts` is read-only — a sheet's own vendoring, adoption, and sync stay
+human-CLI-only (`git sheet contracts adopt|sync|prune`); adoption is a
+reviewed, committed act, not an agent loop step.
+
+- `contracts list` — every vendored contract (name, canonical hash, declaring
+  sheets) plus every sheet's own `implements` declaration.
+- `contracts verify [<sheet>...]` — the offline producer gate: for each
+  sheet that declares `implements`, checks every named contract resolves and
+  every existing record conforms to it (plus the sheet's own schema).
+  Outcome per sheet is `ok` / `warning` (a closed local schema that could
+  reject conforming contract data) / `failed` / `skipped` (no declared
+  contracts). Exits non-zero with `CONTRACT_UNSATISFIED` on any failure.
+- `contracts test <sheet> --against <file-or-name>` — rung-2 (structural)
+  consumer verification: does every record of `<sheet>` conform to an
+  arbitrary schema document (a file, or a vendored contract name)? Works on
+  any sheet, whether or not it declares that contract — pure duck typing.
+
+See [`specs/behaviors/contracts.md`](https://github.com/JarvusInnovations/gitsheets/blob/develop/specs/behaviors/contracts.md) for the full model.
 
 ## Idempotency contract
 
@@ -106,7 +130,7 @@ code: VALIDATION_FAILED
 help[1]: Run `gitsheets-axi sheets view users` to see the schema
 ```
 
-Stable codes: `VALIDATION_FAILED`, `NOT_FOUND`, `CONFIG_INVALID`, `NOT_CANONICAL`, `INDEX_CONFLICT`, `NOT_A_REPOSITORY`, `INVALID_JSON`, `PATH_TEMPLATE_ERROR`, `REF_ERROR`, `TRANSACTION_ERROR`, `CONFIG_EXISTS`, `NO_RECORDS`, `WRITE_ERROR`, `NON_FAST_FORWARD`, `PUSH_FAILED`.
+Stable codes: `VALIDATION_FAILED`, `NOT_FOUND`, `CONFIG_INVALID`, `NOT_CANONICAL`, `INDEX_CONFLICT`, `NOT_A_REPOSITORY`, `INVALID_JSON`, `PATH_TEMPLATE_ERROR`, `REF_ERROR`, `TRANSACTION_ERROR`, `CONFIG_EXISTS`, `NO_RECORDS`, `WRITE_ERROR`, `NON_FAST_FORWARD`, `PUSH_FAILED`, `CONTRACT_UNSATISFIED`, `CONTRACT_MISSING`, `CONTRACT_INVALID`.
 
 Exit codes: `0` for success (incl. no-ops), `2` for validation/usage errors, `1` for everything else.
 

--- a/packages/gitsheets-axi/src/cli.ts
+++ b/packages/gitsheets-axi/src/cli.ts
@@ -21,6 +21,7 @@ import { initCommand, INIT_HELP } from './commands/init.js';
 import { inferCommand, INFER_HELP } from './commands/infer.js';
 import { migrateConfigCommand, MIGRATE_CONFIG_HELP } from './commands/migrate-config.js';
 import { attachmentCommand, ATTACHMENT_HELP } from './commands/attachment.js';
+import { contractsCommand, CONTRACTS_HELP } from './commands/contracts.js';
 import { pushCommand, PUSH_HELP } from './commands/push.js';
 import { setupCommand, SETUP_HELP } from './commands/setup.js';
 
@@ -31,12 +32,12 @@ const DESCRIPTION =
 const VERSION = readPackageVersion();
 
 export const TOP_HELP = `usage: gitsheets-axi [command] [args] [flags]
-commands[19]:
+commands[20]:
   (none)=home, sheets, query, count,
   distinct, read, upsert, patch, rename,
   delete, check, diff, normalize,
   init, infer, migrate-config,
-  attachment, push, setup
+  attachment, contracts, push, setup
 flags[2]:
   --help, -v/-V/--version
 examples:
@@ -50,6 +51,7 @@ examples:
   gitsheets-axi check users users/jane.toml --fix
   gitsheets-axi diff posts HEAD~10
   gitsheets-axi attachment list users jane
+  gitsheets-axi contracts verify
   gitsheets-axi setup hooks
 `;
 
@@ -70,6 +72,7 @@ const COMMAND_HELP: Record<string, string> = {
   infer: INFER_HELP,
   'migrate-config': MIGRATE_CONFIG_HELP,
   attachment: ATTACHMENT_HELP,
+  contracts: CONTRACTS_HELP,
   push: PUSH_HELP,
   setup: SETUP_HELP,
 };
@@ -93,6 +96,7 @@ const COMMANDS: Record<string, CommandFn> = {
   infer: inferCommand,
   'migrate-config': migrateConfigCommand,
   attachment: attachmentCommand,
+  contracts: contractsCommand,
   push: pushCommand,
   setup: setupCommand,
 };

--- a/packages/gitsheets-axi/src/commands/contracts.ts
+++ b/packages/gitsheets-axi/src/commands/contracts.ts
@@ -1,0 +1,453 @@
+// `contracts list|verify|test` — agent-facing surface for
+// specs/behaviors/contracts.md's producer verify gate + consumer
+// verification ladder. Read-only by design: `adopt`/`sync`/`prune` stay
+// human-CLI-only (adoption is a reviewed, committed act — see
+// plans/contracts-axi.md).
+//
+// Every command here is built from the PUBLIC `gitsheets` package surface —
+// `Repository.readBlobStream`/`parseConfigToml` (via ../util/contracts.js),
+// `canonicalContractHash`, `validateRecord`, `openSheet({ contract })` — the
+// same exports the rest of gitsheets-axi already consumes. None of this
+// imports from `gitsheets`'s internal `cli/contracts.ts` (not part of the
+// package's public export map). Actual JSON-Schema validation is always
+// delegated to the public `validateRecord`/`openSheet({contract})` — nothing
+// here re-implements schema checking; the only host-side assembly is the
+// documented, mechanical `implements` → per-contract `validateRecord` call
+// (equivalent to the spec's `allOf` composition — a conjunction of
+// independent schemas is satisfied iff every branch is, so validating each
+// declared contract plus the local schema separately is exactly the same
+// gate, without hand-building an `allOf` array).
+
+import { isAbsolute, join, relative } from 'node:path';
+import { readFile, stat } from 'node:fs/promises';
+
+import { AxiError } from 'axi-sdk-js';
+import {
+  canonicalContractHash,
+  parseToml,
+  ValidationError,
+  RECORD_PATH_KEY,
+  validateRecord,
+  type JSONSchema,
+  type Repository,
+} from 'gitsheets';
+
+import type { GitsheetsContext } from '../context.js';
+import { translateError } from '../errors.js';
+import { renderObject } from '../output/render.js';
+import { countRecords } from '../output/sheet-schema.js';
+import { openSheetForCommand } from '../util/open-sheet.js';
+import {
+  checkVendoredContractIdentity,
+  hasClosedAdditionalProperties,
+  joinNamesOr,
+  listVendoredContractNames,
+  readSheetImplements,
+  readVendoredContractText,
+} from '../util/contracts.js';
+
+export const CONTRACTS_HELP = `usage: gitsheets-axi contracts <subcommand> [args] [flags]
+subcommands[3]:
+  list                              Vendored contracts + each sheet's implements (default)
+  verify [<sheet>...]               Offline producer gate: declared contracts resolve + every record conforms
+  test <sheet> --against <f-or-n>   Consumer-side rung-2 check against any file or vendored contract name
+flags[1]:
+  --against <f-or-n>   test only: a JSON/TOML schema file path, or a vendored contract name
+examples:
+  gitsheets-axi contracts
+  gitsheets-axi contracts list
+  gitsheets-axi contracts verify
+  gitsheets-axi contracts verify meals users
+  gitsheets-axi contracts test posts --against gitsheets.io/posts/v1
+  gitsheets-axi contracts test posts --against ./posts-contract.json
+behavior:
+  list: every vendored contract under .gitsheets/contracts/ (name, canonical
+  hash, declaring sheets) plus every sheet's own \`implements\` declaration.
+  verify: the offline producer gate (specs/behaviors/contracts.md) — for each
+  sheet that declares \`implements\`, resolves every named contract and
+  validates every existing record against it (plus the sheet's own
+  [gitsheet.schema]). Per-sheet outcome: ok / warning (a closed local schema
+  that could reject conforming contract data) / failed / skipped (no
+  declared contracts). Default (no sheets given): every sheet in the repo.
+  test: rung-2 (structural) consumer verification — validates every record
+  of <sheet> against the given document, whether or not the sheet declares
+  that contract (or any contract at all). Pure duck typing.
+exit codes:
+  0    verify/test: every checked sheet/record is ok/warning/skipped/conforming
+  1    CONTRACT_UNSATISFIED — one or more sheets/records failed
+notes:
+  Read-only. Adopting, syncing, or pruning vendored contracts is a reviewed,
+  committed act — use the human \`git sheet contracts\` CLI for those.
+`;
+
+export async function contractsCommand(
+  args: string[],
+  ctx: GitsheetsContext,
+): Promise<string> {
+  if (args.length === 0) return contractsList(ctx);
+
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case 'list':
+      return contractsList(ctx);
+    case 'verify':
+      return contractsVerify(rest, ctx);
+    case 'test':
+      return contractsTest(rest, ctx);
+    case '--help':
+      return CONTRACTS_HELP;
+    default:
+      throw new AxiError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
+        'Subcommands: list, verify, test',
+      ]);
+  }
+}
+
+// --- list --------------------------------------------------------------------
+
+async function contractsList(ctx: GitsheetsContext): Promise<string> {
+  const repo = await ctx.repo();
+  const treeRef = await repo.currentReadTree();
+
+  let sheets: Awaited<ReturnType<typeof repo.openSheets>>;
+  try {
+    sheets = await repo.openSheets();
+  } catch (error) {
+    throw translateError(error);
+  }
+  const sheetNames = Object.keys(sheets).sort();
+
+  const implementsBySheet = new Map<string, string[]>();
+  for (const name of sheetNames) {
+    implementsBySheet.set(name, await readSheetImplements(repo, treeRef, name));
+  }
+
+  const vendoredNames = await listVendoredContractNames(repo, treeRef);
+  const contractRows: Array<Record<string, unknown>> = [];
+  for (const name of vendoredNames) {
+    let hash = '(unreadable)';
+    try {
+      const text = await readVendoredContractText(repo, treeRef, name);
+      hash = canonicalContractHash(text, { format: 'toml' });
+    } catch {
+      // leave as '(unreadable)' — surfaced via the row itself, not a hard failure
+    }
+    const declaredBy = sheetNames.filter((s) => implementsBySheet.get(s)!.includes(name));
+    contractRows.push({ name, hash, declared_by: joinNamesOr(declaredBy) });
+  }
+
+  const sheetRows = sheetNames.map((name) => ({
+    sheet: name,
+    implements: joinNamesOr(implementsBySheet.get(name) ?? []),
+  }));
+
+  const output: Record<string, unknown> = {
+    contracts:
+      contractRows.length > 0
+        ? contractRows
+        : 'no vendored contracts in this repository',
+    sheets:
+      sheetRows.length > 0 ? sheetRows : 'no sheets configured in this repository',
+  };
+
+  const help: string[] = [];
+  if (contractRows.length === 0 && sheetRows.length === 0) {
+    help.push(
+      'No sheets or contracts yet — see .gitsheets/<name>.toml (sheet config) and the `git sheet contracts adopt` human CLI command',
+    );
+  } else {
+    if (contractRows.length > 0) {
+      help.push('Run `gitsheets-axi contracts verify` to check every declaring sheet conforms');
+    }
+    if (sheetRows.length > 0) {
+      help.push(
+        'Run `gitsheets-axi contracts test <sheet> --against <file-or-name>` to check any sheet, contract-aware or not',
+      );
+    }
+  }
+  output['help'] = help;
+
+  return renderObject(output);
+}
+
+// --- verify ------------------------------------------------------------------
+
+type VerifyOutcome = 'ok' | 'warning' | 'failed' | 'skipped';
+
+interface IssueRow {
+  sheet: string;
+  contract: string;
+  record: string;
+  path: string;
+  message: string;
+}
+
+function issueLine(issue: IssueRow): string {
+  const contract = issue.contract ? ` [${issue.contract}]` : '';
+  return `${issue.sheet} ${issue.record} ${issue.path}: ${issue.message}${contract}`;
+}
+
+async function contractsVerify(args: string[], ctx: GitsheetsContext): Promise<string> {
+  const positional = args.filter((a) => !a.startsWith('-'));
+
+  const repo = await ctx.repo();
+  const treeRef = await repo.currentReadTree();
+
+  let sheetNames: string[];
+  if (positional.length > 0) {
+    sheetNames = positional;
+  } else {
+    let sheets: Awaited<ReturnType<typeof repo.openSheets>>;
+    try {
+      sheets = await repo.openSheets();
+    } catch (error) {
+      throw translateError(error);
+    }
+    sheetNames = Object.keys(sheets).sort();
+  }
+
+  const results: Array<{ sheet: string; outcome: VerifyOutcome; contracts: string; issues: number }> = [];
+  const issues: IssueRow[] = [];
+
+  for (const sheetName of sheetNames) {
+    const sheet = await openSheetForCommand(repo, sheetName);
+    const config = await sheet.readConfig();
+    const implementsNames = await readSheetImplements(repo, treeRef, sheetName);
+
+    if (implementsNames.length === 0) {
+      results.push({ sheet: sheetName, outcome: 'skipped', contracts: '(none)', issues: 0 });
+      continue;
+    }
+
+    const contractSchemas: Array<{ name: string; schema: JSONSchema }> = [];
+    let loadFailed = false;
+    for (const name of implementsNames) {
+      let text: string;
+      try {
+        text = await readVendoredContractText(repo, treeRef, name);
+      } catch (error) {
+        loadFailed = true;
+        issues.push({
+          sheet: sheetName,
+          contract: name,
+          record: '(declaration)',
+          path: 'implements',
+          message: translateError(error).message,
+        });
+        continue;
+      }
+
+      const problems = checkVendoredContractIdentity(name, text);
+      if (problems.length > 0) {
+        loadFailed = true;
+        for (const problem of problems) {
+          issues.push({ sheet: sheetName, contract: name, record: '(declaration)', path: 'implements', message: problem });
+        }
+        continue;
+      }
+
+      contractSchemas.push({ name, schema: parseToml(text) as JSONSchema });
+    }
+
+    if (loadFailed) {
+      results.push({
+        sheet: sheetName,
+        outcome: 'failed',
+        contracts: joinNamesOr(implementsNames),
+        issues: issues.filter((i) => i.sheet === sheetName).length,
+      });
+      continue;
+    }
+
+    let sheetIssueCount = 0;
+    for await (const record of sheet.query()) {
+      const recordPath = String((record as Record<symbol, unknown>)[RECORD_PATH_KEY] ?? '(unknown)');
+      const plain = { ...record } as Record<string, unknown>;
+
+      for (const { name, schema } of contractSchemas) {
+        try {
+          await validateRecord({ record: plain, schema, schemaSourcePath: `.gitsheets/contracts/${name}.toml` });
+        } catch (error) {
+          if (!(error instanceof ValidationError)) throw translateError(error);
+          for (const issue of error.issues) {
+            issues.push({
+              sheet: sheetName,
+              contract: name,
+              record: recordPath,
+              path: issue.path.length > 0 ? issue.path.join('.') : '(root)',
+              message: issue.message,
+            });
+            sheetIssueCount++;
+          }
+        }
+      }
+
+      if (config.schema) {
+        try {
+          await validateRecord({ record: plain, schema: config.schema, schemaSourcePath: `.gitsheets/${sheetName}.toml` });
+        } catch (error) {
+          if (!(error instanceof ValidationError)) throw translateError(error);
+          for (const issue of error.issues) {
+            issues.push({
+              sheet: sheetName,
+              contract: '',
+              record: recordPath,
+              path: issue.path.length > 0 ? issue.path.join('.') : '(root)',
+              message: issue.message,
+            });
+            sheetIssueCount++;
+          }
+        }
+      }
+    }
+
+    const closedLocalSchema = config.schema ? hasClosedAdditionalProperties(config.schema) : false;
+    if (closedLocalSchema) {
+      issues.push({
+        sheet: sheetName,
+        contract: '',
+        record: '(config)',
+        path: 'gitsheet.schema.additionalProperties',
+        message:
+          'local schema sets additionalProperties: false, which can reject contract-conforming records under allOf composition',
+      });
+    }
+
+    const outcome: VerifyOutcome =
+      sheetIssueCount > 0 ? 'failed' : closedLocalSchema ? 'warning' : 'ok';
+    results.push({ sheet: sheetName, outcome, contracts: joinNamesOr(implementsNames), issues: sheetIssueCount });
+  }
+
+  const failing = results.filter((r) => r.outcome === 'failed');
+  if (failing.length > 0) {
+    const failingIssues = issues.filter((i) => failing.some((r) => r.sheet === i.sheet));
+    const first = failingIssues[0];
+    const lines = failingIssues.slice(1).map(issueLine);
+    lines.push(
+      `Run \`gitsheets-axi contracts verify ${failing.map((r) => r.sheet).join(' ')}\` to isolate, or \`gitsheets-axi contracts list\` for a repo-wide view`,
+    );
+    throw new AxiError(
+      `${failing.length} of ${results.length} sheet(s) failed contract verification` +
+        (first ? `: ${issueLine(first)}` : ''),
+      'CONTRACT_UNSATISFIED',
+      lines,
+    );
+  }
+
+  const warnings = issues.filter((i) => i.path === 'gitsheet.schema.additionalProperties');
+  const output: Record<string, unknown> = {
+    sheets: results.map((r) => ({ sheet: r.sheet, outcome: r.outcome, contracts: r.contracts, issues: r.issues })),
+  };
+  if (warnings.length > 0) {
+    output['warnings'] = warnings.map(issueLine);
+  }
+  const help: string[] = [];
+  if (results.every((r) => r.outcome === 'skipped')) {
+    help.push('No checked sheet declares any contracts — see `gitsheets-axi contracts list`');
+  } else {
+    help.push('Run `gitsheets-axi contracts list` to see the vendored contracts + declaring sheets');
+  }
+  output['help'] = help;
+
+  return renderObject(output);
+}
+
+// --- test --------------------------------------------------------------------
+
+type SchemaFormat = 'json' | 'toml';
+
+function sniffFormat(path: string, text: string): SchemaFormat {
+  if (path.endsWith('.json')) return 'json';
+  if (path.endsWith('.toml')) return 'toml';
+  return text.trimStart().startsWith('{') ? 'json' : 'toml';
+}
+
+async function resolveAgainst(
+  repo: Repository,
+  treeRef: string,
+  against: string,
+): Promise<{ text: string; format: SchemaFormat; description: string }> {
+  const absPath = isAbsolute(against) ? against : join(process.cwd(), against);
+  let isFile = false;
+  try {
+    isFile = (await stat(absPath)).isFile();
+  } catch {
+    isFile = false;
+  }
+  if (isFile) {
+    const text = await readFile(absPath, 'utf-8');
+    return {
+      text,
+      format: sniffFormat(against, text),
+      description: relative(process.cwd(), absPath) || against,
+    };
+  }
+  try {
+    const text = await readVendoredContractText(repo, treeRef, against);
+    return { text, format: 'toml', description: against };
+  } catch (error) {
+    throw translateError(error);
+  }
+}
+
+function parseTestFlags(args: string[]): { sheet: string; against: string } {
+  let sheet: string | undefined;
+  let against: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    if (arg === '--against') {
+      const next = args[i + 1];
+      if (!next) throw new AxiError('--against expects a file path or contract name', 'VALIDATION_ERROR');
+      against = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new AxiError(`Unknown flag: ${arg}`, 'VALIDATION_ERROR', [
+        'Run `gitsheets-axi contracts test --help`',
+      ]);
+    }
+    if (sheet === undefined) sheet = arg;
+  }
+  if (!sheet) {
+    throw new AxiError('contracts test requires <sheet>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi contracts test posts --against gitsheets.io/posts/v1',
+    ]);
+  }
+  if (!against) {
+    throw new AxiError('contracts test requires --against <file-or-name>', 'VALIDATION_ERROR', [
+      'Example: gitsheets-axi contracts test posts --against ./posts-contract.json',
+    ]);
+  }
+  return { sheet, against };
+}
+
+async function contractsTest(args: string[], ctx: GitsheetsContext): Promise<string> {
+  const { sheet: sheetName, against } = parseTestFlags(args);
+  const repo = await ctx.repo();
+  const treeRef = await repo.currentReadTree();
+
+  const resolved = await resolveAgainst(repo, treeRef, against);
+
+  const sheet = await openSheetForCommand(repo, sheetName, {
+    contract: { schema: resolved.text, format: resolved.format, mode: 'structural' },
+  });
+
+  const recordCount = await countRecords(sheet);
+  const report = sheet.contractVerification;
+
+  return renderObject({
+    result: 'conforms',
+    sheet: sheetName,
+    against: resolved.description,
+    rung: report?.rung ?? 'structural',
+    records_checked: recordCount,
+    help: [
+      recordCount === 0
+        ? `${sheetName} has no records — trivially conforms`
+        : `${sheetName}'s ${recordCount} record(s) conform to ${resolved.description}`,
+    ],
+  });
+}

--- a/packages/gitsheets-axi/src/errors.ts
+++ b/packages/gitsheets-axi/src/errors.ts
@@ -1,6 +1,7 @@
 import { AxiError } from 'axi-sdk-js';
 import {
   ConfigError,
+  ContractError,
   GitsheetsError,
   IndexError,
   NotFoundError,
@@ -35,6 +36,21 @@ export function translateError(error: unknown): AxiError {
 
   if (error instanceof NotFoundError) {
     return new AxiError(error.message, 'NOT_FOUND', []);
+  }
+
+  if (error instanceof ContractError) {
+    // error.code is 'contract_missing' | 'contract_invalid' | 'contract_unsatisfied'
+    // — the CONTRACT_* code vocabulary `contracts verify`/`test` document.
+    // `issues` (present on contract_unsatisfied) carry the same
+    // path/message/contract/record shape ValidationError.issues do; fold the
+    // first into the message and the rest into hints, same as below.
+    const issues = formatContractIssues(error.issues);
+    const hasIssues = error.issues !== undefined && error.issues.length > 0;
+    return new AxiError(
+      hasIssues ? `${error.message}: ${issues[0]}` : error.message,
+      error.code.toUpperCase(),
+      hasIssues ? issues.slice(1) : [],
+    );
   }
 
   if (error instanceof ConfigError) {
@@ -79,5 +95,18 @@ function formatValidationIssues(
   return issues.map((issue) => {
     const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
     return `${path}: ${issue.message}`;
+  });
+}
+
+/** Like {@link formatValidationIssues}, plus the `record`/`contract` tags a conformance report's issues carry. */
+function formatContractIssues(
+  issues: readonly ValidationIssue[] | undefined,
+): string[] {
+  if (!issues || issues.length === 0) return ['(no issue details)'];
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    const record = issue.record ? `${issue.record} ` : '';
+    const contract = issue.contract ? ` [${issue.contract}]` : '';
+    return `${record}${path}: ${issue.message}${contract}`;
   });
 }

--- a/packages/gitsheets-axi/src/util/contracts.ts
+++ b/packages/gitsheets-axi/src/util/contracts.ts
@@ -1,0 +1,184 @@
+// Shared helpers for the `contracts` command group (list/verify/test). Every
+// primitive here is built from the SAME public `gitsheets` surface the rest
+// of gitsheets-axi already consumes (`Repository.readBlobStream`,
+// `parseConfigToml`/`parseToml`) — none of this reaches into
+// `gitsheets`'s internal `cli/contracts.ts` (not part of the package's public
+// export map; see `packages/gitsheets/package.json`'s `exports`). The actual
+// JSON-Schema validation is always delegated to the public `validateRecord`
+// (see commands/contracts.ts) — nothing here re-implements schema checking.
+//
+// See specs/behaviors/contracts.md for the vocabulary (vendored contract,
+// `implements`, the derived path formula) this module mechanically applies.
+
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { promisify } from 'node:util';
+
+import { canonicalContractHash, parseConfigToml, parseToml, type Repository } from 'gitsheets';
+
+const exec = promisify(execFile);
+
+/** Root of the vendored contract store, relative to the repo root. */
+export const CONTRACTS_ROOT = '.gitsheets/contracts';
+
+/**
+ * The derived vendored path for a contract name — a mechanical formula
+ * (specs/behaviors/contracts.md "Contract names and the derived path"), not a
+ * core lookup: `.gitsheets/contracts/<name>.toml`.
+ */
+export function contractPathFor(name: string): string {
+  return `${CONTRACTS_ROOT}/${name}.toml`;
+}
+
+/** Drain a Node Readable (as returned by `Repository.readBlobStream`) to a UTF-8 string. */
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+/** Read a vendored contract's raw canonical-TOML text by name. Throws NotFoundError if unvendored. */
+export async function readVendoredContractText(
+  repo: Repository,
+  treeRef: string,
+  name: string,
+): Promise<string> {
+  return streamToString(await repo.readBlobStream(treeRef, contractPathFor(name)));
+}
+
+/**
+ * Every vendored contract name under `.gitsheets/contracts/` at `treeRef`.
+ * The `sources.toml` sidecar is excluded — contract names always contain a
+ * `/` (host-qualified), so a top-level file can never collide with one (see
+ * specs/behaviors/contracts.md "Contract names and the derived path").
+ *
+ * No public `Repository` API lists tree contents, so this shells out to
+ * `git ls-tree` against `repo.gitDir` — the same plumbing
+ * `Repository.readBlobStream` itself uses internally for blob reads.
+ */
+export async function listVendoredContractNames(
+  repo: Repository,
+  treeRef: string,
+): Promise<string[]> {
+  let stdout: string;
+  try {
+    ({ stdout } = await exec(
+      'git',
+      ['ls-tree', '-r', '--name-only', treeRef, '--', CONTRACTS_ROOT],
+      { cwd: repo.gitDir },
+    ));
+  } catch {
+    return [];
+  }
+  const names: string[] = [];
+  for (const line of stdout.split('\n')) {
+    const p = line.trim();
+    if (!p || !p.startsWith(`${CONTRACTS_ROOT}/`) || !p.endsWith('.toml')) continue;
+    const rel = p.slice(CONTRACTS_ROOT.length + 1, -'.toml'.length);
+    if (!rel.includes('/')) continue; // top-level file (sources.toml) — never a contract name
+    names.push(rel);
+  }
+  return names.sort();
+}
+
+/**
+ * The `implements` array declared by `.gitsheets/<sheet>.toml` at `treeRef`
+ * ([] if the config is absent/unparseable/has no such key) — parsed with the
+ * same public `parseConfigToml` the library's own config loader uses
+ * (`Sheet`'s `SheetConfig` just doesn't surface this one field).
+ */
+export async function readSheetImplements(
+  repo: Repository,
+  treeRef: string,
+  sheetName: string,
+): Promise<string[]> {
+  const configPath = `.gitsheets/${sheetName}.toml`;
+  let text: string;
+  try {
+    text = await streamToString(await repo.readBlobStream(treeRef, configPath));
+  } catch {
+    return [];
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseConfigToml(text, configPath) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+  const gitsheet = parsed['gitsheet'] as Record<string, unknown> | undefined;
+  const raw = gitsheet?.['implements'];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((x): x is string => typeof x === 'string');
+}
+
+/**
+ * Best-effort check that an already-vendored contract's raw bytes still
+ * satisfy the two cheapest "document requirements" (specs/behaviors/
+ * contracts.md "Contract document requirements" #1 canonical form, #5 `$id`
+ * matches the derived path) — a non-empty result is a `contract_invalid`-
+ * grade problem. Returns the violation messages (empty = no problem found).
+ *
+ * This is deliberately NOT the core's full `load_contract`/
+ * `check_contract_document` gate — the other three requirements
+ * (self-contained/no external `$ref`, open-for-extension/no closed
+ * `additionalProperties`, no null-bearing keywords) are enforced by the core
+ * at sheet-open for a *write* path (`Sheet::open` → `compile_effective_schema`
+ * → `load_contract`), which no read-only public API reaches independent of an
+ * actual write. Built from the same public `canonicalContractHash` identity
+ * primitive `contracts list` uses — no JSON-Schema validation is
+ * re-implemented here, only a byte-identity + string comparison.
+ */
+export function checkVendoredContractIdentity(name: string, text: string): string[] {
+  const problems: string[] = [];
+
+  const rawHash = createHash('sha256').update(text, 'utf-8').digest('hex');
+  let canonicalHash: string;
+  try {
+    canonicalHash = canonicalContractHash(text, { format: 'toml' });
+  } catch (error) {
+    return [`failed to canonicalize: ${error instanceof Error ? error.message : String(error)}`];
+  }
+  if (rawHash !== canonicalHash) {
+    problems.push('vendored bytes are not canonical TOML — re-encoding produces different bytes');
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseToml(text) as Record<string, unknown>;
+  } catch (error) {
+    problems.push(`failed to parse: ${error instanceof Error ? error.message : String(error)}`);
+    return problems;
+  }
+  const expectedId = `https://${name}`;
+  if (parsed['$id'] !== expectedId) {
+    problems.push(
+      `$id ${JSON.stringify(parsed['$id'] ?? null)} does not match the derived path (expected ${JSON.stringify(expectedId)})`,
+    );
+  }
+
+  return problems;
+}
+
+/**
+ * Advisory-only structural check (specs/behaviors/contracts.md "Composition
+ * and enforcement" — the closed-local-schema footgun): does `schema` (or any
+ * nested subschema) set `additionalProperties: false`? Pure data-shape
+ * recursion, not JSON-Schema validation — safe to compute locally.
+ */
+export function hasClosedAdditionalProperties(schema: unknown): boolean {
+  if (Array.isArray(schema)) return schema.some(hasClosedAdditionalProperties);
+  if (schema !== null && typeof schema === 'object') {
+    for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+      if (key === 'additionalProperties' && value === false) return true;
+      if (hasClosedAdditionalProperties(value)) return true;
+    }
+  }
+  return false;
+}
+
+/** Join a list of names for a TOON cell, with a fallback for the empty case. */
+export function joinNamesOr(names: readonly string[], fallback = '(none)'): string {
+  return names.length > 0 ? names.join('|') : fallback;
+}

--- a/packages/gitsheets-axi/src/util/open-sheet.ts
+++ b/packages/gitsheets-axi/src/util/open-sheet.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { AxiError } from 'axi-sdk-js';
-import { ConfigError, type Repository, type Sheet } from 'gitsheets';
+import { ConfigError, type OpenSheetContractOptions, type Repository, type Sheet } from 'gitsheets';
 
 import { translateError } from '../errors.js';
 
@@ -13,11 +13,16 @@ import { translateError } from '../errors.js';
  * committed git tree, not the working tree, so a freshly-authored config must
  * be committed before any record command can see it. This is a common first-run
  * trap — author the config, run upsert, get an opaque "not found".
+ *
+ * `opts.contract` passes through to `openSheet`'s consumer-side contract
+ * verification (`contracts test` uses this) — a `ContractError` it throws
+ * still lands in `translateError` below, which maps it (and any conformance
+ * issues it carries) to a `CONTRACT_*` AxiError.
  */
 export async function openSheetForCommand(
   repo: Repository,
   name: string,
-  opts: { prefix?: string } = {},
+  opts: { prefix?: string; contract?: OpenSheetContractOptions } = {},
 ): Promise<Sheet> {
   try {
     return await repo.openSheet(name, opts);

--- a/packages/gitsheets-axi/test/contracts.test.ts
+++ b/packages/gitsheets-axi/test/contracts.test.ts
@@ -1,0 +1,284 @@
+// `contracts list|verify|test` — the agent-facing surface for
+// specs/behaviors/contracts.md's producer verify gate + consumer
+// verification ladder. Fixture style mirrors packages/gitsheets/src/cli/
+// cli-contracts.test.ts (the human CLI's own contracts test suite).
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { stringifyRecord } from 'gitsheets';
+
+import { testRepo, type TestRepoHandle } from './test-repo.js';
+import { runCli } from './run-cli.js';
+
+const handles: TestRepoHandle[] = [];
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop();
+    if (h) await h.cleanup();
+  }
+});
+
+const CONTRACT_NAME = 'test.local/meals/v1';
+const CONTRACT_DOC = {
+  $id: `https://${CONTRACT_NAME}`,
+  type: 'object',
+  required: ['name'],
+  properties: { name: { type: 'string', minLength: 1 } },
+};
+
+function canonicalContractText(): string {
+  return stringifyRecord(CONTRACT_DOC as Record<string, unknown>);
+}
+
+const MEALS_CONFIG = `[gitsheet]
+root = 'meals'
+path = '\${{ slug }}'
+implements = ['${CONTRACT_NAME}']
+`;
+
+const MEALS_CONFIG_CLOSED = `[gitsheet]
+root = 'meals'
+path = '\${{ slug }}'
+implements = ['${CONTRACT_NAME}']
+
+[gitsheet.schema]
+type = 'object'
+additionalProperties = false
+
+[gitsheet.schema.properties.name]
+type = 'string'
+
+[gitsheet.schema.properties.slug]
+type = 'string'
+`;
+
+const MEALS_CONFIG_NO_CONTRACT = `[gitsheet]
+root = 'meals'
+path = '\${{ slug }}'
+`;
+
+async function vendorContract(fixture: TestRepoHandle): Promise<void> {
+  await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals'), { recursive: true });
+  await writeFile(
+    join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals', 'v1.toml'),
+    canonicalContractText(),
+  );
+}
+
+/** A repo with a `meals` sheet declaring CONTRACT_NAME, the contract vendored, and one conforming record. */
+async function seedConformingRepo(): Promise<TestRepoHandle> {
+  const fixture = await testRepo({ withInitialCommit: true });
+  handles.push(fixture);
+  await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+  await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+  await vendorContract(fixture);
+  await fixture.git('add', '.gitsheets');
+  await fixture.git('commit', '-m', 'seed meals sheet + contract');
+
+  const { exitCode } = await runCli(
+    ['upsert', 'meals', '--data', '{"slug":"soup","name":"Soup"}'],
+    fixture.path,
+  );
+  expect(exitCode).toBe(0);
+  await fixture.git('reset', '--hard', 'HEAD');
+  return fixture;
+}
+
+describe('contracts list', () => {
+  it('lists vendored contracts + declaring sheets + every sheet\'s implements', async () => {
+    const fixture = await seedConformingRepo();
+    const { stdout, exitCode } = await runCli(['contracts', 'list'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(CONTRACT_NAME);
+    expect(stdout).toContain('meals');
+    expect(stdout).toMatch(/hash/);
+  });
+
+  it('bare `contracts` (no subcommand) defaults to list', async () => {
+    const fixture = await seedConformingRepo();
+    const { stdout, exitCode } = await runCli(['contracts'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(CONTRACT_NAME);
+  });
+
+  it('reports a helpful empty state with no sheets and no contracts', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    const { stdout, exitCode } = await runCli(['contracts', 'list'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('no vendored contracts');
+    expect(stdout).toContain('no sheets configured');
+  });
+});
+
+describe('contracts verify', () => {
+  it('passes on a conforming fixture repo', async () => {
+    const fixture = await seedConformingRepo();
+    const { stdout, exitCode } = await runCli(['contracts', 'verify'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('meals');
+    expect(stdout).toContain('ok');
+  });
+
+  it('reports CONTRACT_UNSATISFIED with per-record issue detail on a seeded defect', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+    await vendorContract(fixture);
+    // `upsert` would refuse a record missing `name` (contracts are enforced
+    // at write time, by construction — see specs/behaviors/contracts.md
+    // "Composition and enforcement"). To exercise `verify`'s actual use case
+    // (drift: existing records predating a contract, or written outside the
+    // write path), commit a non-conforming record directly, bypassing the
+    // library entirely.
+    await mkdir(join(fixture.path, 'meals'), { recursive: true });
+    await writeFile(join(fixture.path, 'meals', 'soup.toml'), `slug = "soup"\n`);
+    await fixture.git('add', '.gitsheets', 'meals');
+    await fixture.git('commit', '-m', 'seed meals sheet + contract + a pre-existing non-conforming record');
+
+    const { stdout, exitCode } = await runCli(['contracts', 'verify'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('error:');
+    expect(stdout).toContain('CONTRACT_UNSATISFIED');
+    expect(stdout).toContain('soup');
+    expect(stdout).toContain(CONTRACT_NAME);
+    expect(stdout).toMatch(/name/);
+  });
+
+  it('reports skipped for sheets that declare no contracts', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'meals sheet, no contract');
+
+    const { stdout, exitCode } = await runCli(['contracts', 'verify'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('skipped');
+  });
+
+  it('warns (not fails) when a conforming sheet\'s local schema closes additionalProperties', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_CLOSED);
+    await vendorContract(fixture);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'seed meals sheet + contract, closed local schema');
+
+    const up = await runCli(['upsert', 'meals', '--data', '{"slug":"soup","name":"Soup"}'], fixture.path);
+    expect(up.exitCode).toBe(0);
+    await fixture.git('reset', '--hard', 'HEAD');
+
+    const { stdout, exitCode } = await runCli(['contracts', 'verify'], fixture.path);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('warning');
+    expect(stdout).toContain('additionalProperties');
+  });
+
+  it('fails with CONTRACT_UNSATISFIED when a declared contract has no vendored document', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'declares a contract with nothing vendored');
+
+    const { stdout, exitCode } = await runCli(['contracts', 'verify'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('CONTRACT_UNSATISFIED');
+    expect(stdout).toContain(CONTRACT_NAME);
+  });
+
+  it('fails with CONTRACT_UNSATISFIED when the vendored document is not canonical TOML', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG);
+    // Hand-authored TOML: valid data, but NOT the canonical (deep-key-sorted)
+    // encoding — re-encoding it produces different bytes.
+    await mkdir(join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals'), { recursive: true });
+    await writeFile(
+      join(fixture.path, '.gitsheets', 'contracts', 'test.local', 'meals', 'v1.toml'),
+      `type = "object"\nrequired = ["name"]\n"$id" = "https://${CONTRACT_NAME}"\n\n[properties.name]\ntype = "string"\n`,
+    );
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'vendors a non-canonical contract document');
+
+    const { stdout, exitCode } = await runCli(['contracts', 'verify'], fixture.path);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('CONTRACT_UNSATISFIED');
+    expect(stdout).toContain('not canonical');
+  });
+});
+
+describe('contracts test', () => {
+  it('duck-types a contract-unaware sheet against a vendored contract name', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    // Sheet declares NOTHING — pure duck typing.
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await vendorContract(fixture);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'meals sheet, contract vendored but not declared');
+
+    const up = await runCli(['upsert', 'meals', '--data', '{"slug":"soup","name":"Soup"}'], fixture.path);
+    expect(up.exitCode).toBe(0);
+    await fixture.git('reset', '--hard', 'HEAD');
+
+    const { stdout, exitCode } = await runCli(
+      ['contracts', 'test', 'meals', '--against', CONTRACT_NAME],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('conforms');
+    expect(stdout).toContain('records_checked: 1');
+  });
+
+  it('duck-types against an arbitrary local file, and fails with per-record detail on non-conformance', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'meals sheet, no contract');
+
+    // Record lacks `name`, which the ad-hoc file-based contract requires.
+    const up = await runCli(['upsert', 'meals', '--data', '{"slug":"soup"}'], fixture.path);
+    expect(up.exitCode).toBe(0);
+    await fixture.git('reset', '--hard', 'HEAD');
+
+    const docPath = join(fixture.path, 'meals-contract.json');
+    await writeFile(docPath, JSON.stringify(CONTRACT_DOC));
+
+    const { stdout, exitCode } = await runCli(
+      ['contracts', 'test', 'meals', '--against', docPath],
+      fixture.path,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('CONTRACT_UNSATISFIED');
+    expect(stdout).toContain('soup');
+  });
+
+  it('reports trivial conformance for a sheet with no records', async () => {
+    const fixture = await testRepo({ withInitialCommit: true });
+    handles.push(fixture);
+    await mkdir(join(fixture.path, '.gitsheets'), { recursive: true });
+    await writeFile(join(fixture.path, '.gitsheets', 'meals.toml'), MEALS_CONFIG_NO_CONTRACT);
+    await vendorContract(fixture);
+    await fixture.git('add', '.gitsheets');
+    await fixture.git('commit', '-m', 'meals sheet, no records');
+
+    const { stdout, exitCode } = await runCli(
+      ['contracts', 'test', 'meals', '--against', CONTRACT_NAME],
+      fixture.path,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('trivially conforms');
+  });
+});

--- a/packages/gitsheets-axi/test/run-cli.ts
+++ b/packages/gitsheets-axi/test/run-cli.ts
@@ -27,6 +27,7 @@ import {
   MIGRATE_CONFIG_HELP,
 } from '../src/commands/migrate-config.js';
 import { attachmentCommand, ATTACHMENT_HELP } from '../src/commands/attachment.js';
+import { contractsCommand, CONTRACTS_HELP } from '../src/commands/contracts.js';
 import { pushCommand, PUSH_HELP } from '../src/commands/push.js';
 import { setupCommand, SETUP_HELP } from '../src/commands/setup.js';
 
@@ -47,6 +48,7 @@ const COMMAND_HELP: Record<string, string> = {
   infer: INFER_HELP,
   'migrate-config': MIGRATE_CONFIG_HELP,
   attachment: ATTACHMENT_HELP,
+  contracts: CONTRACTS_HELP,
   push: PUSH_HELP,
   setup: SETUP_HELP,
 };
@@ -68,6 +70,7 @@ const COMMANDS = {
   infer: inferCommand,
   'migrate-config': migrateConfigCommand,
   attachment: attachmentCommand,
+  contracts: contractsCommand,
   push: pushCommand,
   setup: setupCommand,
 } as Record<

--- a/plans/contracts-axi.md
+++ b/plans/contracts-axi.md
@@ -1,9 +1,10 @@
 ---
-status: planned
+status: done
 depends: []
 specs:
   - specs/behaviors/contracts.md
 issues: []
+pr: https://github.com/JarvusInnovations/gitsheets/pull/278
 ---
 
 # Plan: contract affordances for gitsheets-axi
@@ -52,16 +53,16 @@ demand); any new core/napi surface (everything needed shipped in #265/#267/#268)
 
 ## Validation
 
-- [ ] `contracts list` renders vendored contracts + declaring sheets in TOON,
+- [x] `contracts list` renders vendored contracts + declaring sheets in TOON,
       with a helpful empty state
-- [ ] `contracts verify` passes on a conforming fixture and reports structured
+- [x] `contracts verify` passes on a conforming fixture and reports structured
       per-record issues (path, field, contract) on a seeded defect, with a
       stable outcome code
-- [ ] `contracts test --against` verifies a contract-unaware sheet and reports
+- [x] `contracts test --against` verifies a contract-unaware sheet and reports
       per-record conformance
-- [ ] Output is agent-parseable TOON consistent with the package's existing
+- [x] Output is agent-parseable TOON consistent with the package's existing
       commands (spot-checked against a real run)
-- [ ] Full `gitsheets-axi` suite passes; no changes outside the package +
+- [x] Full `gitsheets-axi` suite passes; no changes outside the package +
       README
 
 ## Risks / unknowns
@@ -75,8 +76,54 @@ demand); any new core/napi surface (everything needed shipped in #265/#267/#268)
 
 ## Notes
 
-(populated at closeout)
+Built entirely on `gitsheets`'s **public** export surface — `Repository.
+readBlobStream`, `parseConfigToml`/`parseToml`, `canonicalContractHash`,
+`validateRecord`, `openSheet({ contract })` — never the human CLI's internal
+`packages/gitsheets/src/cli/contracts.ts` (confirmed not part of the
+package's export map: `package.json`'s `exports` only publishes
+`dist/index.js`). `contracts test` is almost entirely `openSheet(sheet,
+{ contract: { schema, format, mode: 'structural' } })` — the exact rung-2
+primitive the spec describes, reused as-is with no additional logic needed.
+
+`contracts verify` validates each declared contract independently via
+`validateRecord`, plus the sheet's local schema separately, rather than
+hand-assembling `{ allOf: [...contracts, local] }` and validating once — a
+conjunction of independent JSON-Schema branches is satisfied iff every
+branch is (no `$defs` sharing/keyword interaction across the contract vs.
+local-schema branches here), so this reproduces the spec's composition
+semantics exactly without reimplementing validation or hand-rolling schema
+composition. Per-sheet outcome vocabulary settled on `ok` / `warning`
+(closed local schema under `allOf`) / `failed` / `skipped` (no declared
+contracts), matching the plan's three-way ask plus an explicit skip state.
+
+**Gap found + partially closed:** the human CLI's `contracts verify` checks
+a declared contract's full "document requirements" (self-contained, open-
+for-extension, no null-bearing keywords, canonical bytes, `$id`-matches-path)
+via the core's `load_contract`/`check_contract_document`, reached through the
+package's *internal* `addon` object. No such check is reachable read-only
+through the public surface — `Sheet::open`'s `compile_effective_schema` (the
+only call site) only runs on the **write** path. Closed the two cheapest,
+safely-replicable checks locally (canonical-TOML-bytes via
+`canonicalContractHash`, `$id`-matches-derived-path via string comparison —
+neither is JSON-Schema validation) so a corrupted/hand-edited vendored file
+is still caught by `contracts verify` (regression test: "fails … when the
+vendored document is not canonical TOML"). The remaining three checks
+(self-contained/no external `$ref`, open-for-extension, no null) are not
+independently re-verified; a malformed vendored document on those axes still
+surfaces correctly at the sheet's next `upsert` (enforcement stays where
+enforcement already happens), so this is a narrower pre-hoc diagnostic gap,
+not a hole in enforcement.
 
 ## Follow-ups
 
-(populated at closeout)
+- **Full contract document-requirements check for `contracts verify`** would
+  need new `gitsheets` public surface (e.g. an exported `checkContractDocument`/
+  `loadContract`-equivalent) to reach the core's self-contained /
+  open-for-extension / no-null-keyword checks read-only. Explicitly out of
+  scope for this plan ("any new core/napi surface" was declared out of
+  scope) — revisit if `contracts verify` needs to catch these without an
+  intervening write.
+- **`--prefix` on `contracts verify`/`test`** (tenant sub-tree scoping,
+  matching `query`/`check`/`attachment`) wasn't added — not requested by the
+  plan and contracts vendor at the repo/root level, not per-tenant. Revisit
+  on demand.


### PR DESCRIPTION
## Summary

Surfaces `specs/behaviors/contracts.md`'s producer verify gate and consumer verification ladder through `gitsheets-axi`, per `plans/contracts-axi.md`:

- **`contracts list`** — every vendored contract (name, canonical hash, declaring sheets) plus every sheet's own `implements` declaration. Helpful empty state when there are no sheets/contracts.
- **`contracts verify [<sheet>...]`** — the offline producer gate: for each sheet declaring `implements`, resolves every named contract and validates every existing record against it plus the sheet's own `[gitsheet.schema]`. Per-sheet outcome: `ok` / `warning` (closed local schema that could reject conforming contract data) / `failed` / `skipped` (no declared contracts). Exits non-zero with `CONTRACT_UNSATISFIED` and structured per-issue detail (sheet, record, path, message, contract) on any failure.
- **`contracts test <sheet> --against <file-or-name>`** — rung-2 (structural) consumer verification: does every record of `<sheet>` conform to an arbitrary schema document (a file, or a vendored contract name)? Works on any sheet, contract-aware or not — pure duck typing.

Read-only by design — `adopt`/`sync`/`prune` stay human-CLI-only (adoption is a reviewed, committed act, not an agent loop step), matching the plan's explicit scope.

## Review guide

- **`packages/gitsheets-axi/src/commands/contracts.ts`** — the three subcommands, dispatched from one `contracts` command (matches the `sheets`/`attachment` multi-subcommand pattern already in the package).
- **`packages/gitsheets-axi/src/util/contracts.ts`** — shared primitives, all built from `gitsheets`'s **public** export surface (`Repository.readBlobStream`, `parseConfigToml`/`parseToml`, `canonicalContractHash`) rather than the human CLI's internal `cli/contracts.ts` (not part of the package's export map — see `packages/gitsheets/package.json`'s `exports`, only `dist/index.js` is published).
- **Key design decision — no hand-built `allOf`:** `contracts verify` validates each declared contract independently via the public `validateRecord`, plus the sheet's local schema separately, instead of assembling `{ allOf: [...contracts, local] }` and validating once. A conjunction of independent JSON-Schema branches is satisfied iff every branch is (no shared `$defs`/keyword interaction across branches here), so this reproduces the spec's composition semantics exactly, without reimplementing validation or hand-rolling schema composition.
- **`contracts test`** is built almost entirely on the public `openSheet(sheet, { contract: { schema, format, mode: 'structural' } })` — the exact rung-2 consumer-verification primitive the spec describes, reused as-is.
- **`errors.ts`** — added a `ContractError` branch to `translateError` (folds `.issues`/`.contract`/`.record` into the message + `help[]` hints, mirroring the existing `ValidationError` handling) so `CONTRACT_UNSATISFIED`/`CONTRACT_MISSING`/`CONTRACT_INVALID` fit the package's existing outcome-code vocabulary.
- **`util/open-sheet.ts`** — extended `openSheetForCommand`'s options with an optional `contract` passthrough so `contracts test` gets the same "config not committed" hint as every other command.

### Known gap (flagged, not silently swallowed)

`contracts verify`'s "does this declared contract resolve validly" check does a **best-effort** re-verification (canonical-TOML-bytes + `$id`-matches-derived-path, via the public `canonicalContractHash`) rather than the core's full "document requirements" gate (self-contained/no external `$ref`, open-for-extension/no closed `additionalProperties`, no null-bearing keywords). Those three checks live in the Rust core's `load_contract`/`check_contract_document`, invoked at sheet-open **on the write path** (`Sheet::open` → `compile_effective_schema`) — no public, read-only API reaches them independent of an actual write. Closing this fully would need new `gitsheets` package (or napi) surface, which the plan declares out of scope ("any new core/napi surface — everything needed shipped in #265/#267/#268"). A malformed vendored document still surfaces correctly the moment any sheet declaring it is actually written to (`upsert`), matching the spec's "enforcement happens where enforcement already happens" principle — this is a narrower pre-hoc check, not a hole in enforcement. Recorded as a follow-up in the plan closeout.

## Test evidence

```
npm run build        # gitsheets + gitsheets-axi — clean
npm run type-check   # gitsheets + gitsheets-axi — clean
npm test             # gitsheets: 388 passed · gitsheets-axi: 130 passed (12 new) · core-napi: 123 passed
```

New tests in `packages/gitsheets-axi/test/contracts.test.ts` (fixture-repo style, matching the package's existing test conventions):
- `list`: populated repo, bare `contracts` defaults to list, empty-state
- `verify`: passes on a conforming fixture; `CONTRACT_UNSATISFIED` with per-record detail on a seeded pre-existing non-conforming record (bypassing the write path, since `upsert` itself would refuse it — contracts are enforced by construction); `skipped` for sheets with no `implements`; `warning` (not `failed`) for a closed local schema; `CONTRACT_UNSATISFIED` when a declared contract has no vendored document; `CONTRACT_UNSATISFIED` when the vendored document isn't canonical TOML
- `test`: duck-types a contract-unaware sheet against a vendored contract name; fails with per-record detail against an arbitrary local file; reports trivial conformance for a sheet with zero records

Also manually smoke-tested the built CLI end to end against a scratch repo (list/verify/test/upsert), confirming the TOON shapes render as expected and the non-canonical-vendor-document failure path works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1