### PR TITLE
chore(py): version 0.2.0 for the py-v0.2.0 release track

### DIFF
--- a/plans/contracts-axi.md
+++ b/plans/contracts-axi.md
@@ -4,7 +4,7 @@ depends: []
 specs:
   - specs/behaviors/contracts.md
 issues: []
-pr: https://github.com/JarvusInnovations/gitsheets/pull/278
+pr: 278
 ---
 
 # Plan: contract affordances for gitsheets-axi

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "gitsheets-py"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "gitsheets-core",

--- a/rust/gitsheets-py/Cargo.toml
+++ b/rust/gitsheets-py/Cargo.toml
@@ -5,7 +5,7 @@ description = "Python (pyo3) binding for gitsheets-core: marshals records betwee
 # maturin reads it (pyproject.toml declares `dynamic = ["version"]`), and a
 # `py-v*` release tag must match it exactly — python-publish.yml fails loudly
 # on mismatch. See specs/behaviors/distribution.md.
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Version bump ahead of tagging `py-v0.2.0` (the guard requires the committed version to match the tag). First Python release carrying the contracts surface: shared-core write-time enforcement, `canonical_contract_hash` + `ContractError` (#265), and `verify_sheet_contract` (#277). Rides along: `plans/contracts-axi.md` `pr:` field normalized to a number per the plan protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1