### PR TITLE
docs(readmes): contracts coverage + registry cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ One handler, one commit, committed only on success. `openStore` layers typed
 sheets on top with Standard Schema validators (Zod, Valibot, ArkType), and a
 successful transaction auto-refreshes reads. See
 [the docs](https://jarvusinnovations.github.io/gitsheets/) for the API guide.
+Published as [`gitsheets`](https://www.npmjs.com/package/gitsheets) on npm; the
+agent-facing [`gitsheets-axi`](https://www.npmjs.com/package/gitsheets-axi)
+ships separately.
 
 ### The CLI
 
@@ -113,10 +116,26 @@ npx skills add JarvusInnovations/gitsheets -y --skill gitsheets
 
 ### Python
 
-A Python binding ([`rust/gitsheets-py`](rust/gitsheets-py), pyo3) runs on the
-same core — a write from Python and a write from Node produce byte-identical
-commits, proven by cross-binding tests in CI. It builds from the repo today;
-PyPI publication is on the roadmap.
+```console
+pip install gitsheets        # CPython >= 3.9; prebuilt abi3 wheels
+```
+
+The [PyPI package](https://pypi.org/project/gitsheets/) runs on the same Rust
+core — a write from Python and a write from Node produce byte-identical
+commits, proven by cross-binding tests in CI. Surface and scope:
+[`rust/gitsheets-py`](rust/gitsheets-py/README.md).
+
+## Sheets as checked interfaces
+
+A sheet can declare that it `implements` named, versioned schema contracts —
+JSON Schema documents vendored into the repo in canonical form and composed
+into validation on every write, so conformance is enforced by construction. A
+system consuming someone else's sheet verifies it mechanically at wiring time:
+by content identity (fast, and guaranteed for all future writes) or by
+validating the records themselves (works against any sheet ever written).
+Cross-system data sharing becomes a checked interface instead of a hopeful
+convention. See the
+[contracts guide](https://jarvusinnovations.github.io/gitsheets/contracts/).
 
 ## What it is not
 

--- a/packages/gitsheets/README.md
+++ b/packages/gitsheets/README.md
@@ -10,7 +10,9 @@ npm install gitsheets
 
 ESM-only. Targets Node.js ≥ 20 and Bun ≥ 1. CLI installs as `gitsheets` and `git-sheet`.
 
-The engine is a shared Rust core, shipped as a prebuilt native addon (`@gitsheets/core-napi`) for Linux (x64/arm64, glibc + musl), macOS (x64/arm64), and Windows (x64), so a plain install needs no Rust toolchain. The same core backs a Python binding, and a write from either language produces byte-identical commits.
+The engine is a shared Rust core, shipped as a prebuilt native addon (`@gitsheets/core-napi`) for Linux (x64/arm64, glibc + musl), macOS (x64/arm64), and Windows (x64), so a plain install needs no Rust toolchain. The same core backs a [Python binding on PyPI](https://pypi.org/project/gitsheets/), and a write from either language produces byte-identical commits.
+
+Sheets can declare that they `implements` named, versioned **schema contracts** — JSON Schema documents vendored into the repo in canonical form and composed into write-time validation, so conformance is enforced by construction. Consumers verify a sheet against a contract at wiring time with `openSheet(name, { contract })` (by content identity, or by validating the records themselves), and the CLI manages the lifecycle via `gitsheets contracts adopt|verify|test|sync|export|prune`. See the [contracts guide](https://jarvusinnovations.github.io/gitsheets/contracts/).
 
 > **Upgrading from v1?** The public API is unchanged, but v2 moves the engine to that Rust core. Two things change for existing repos: `gitsheets` now depends on the prebuilt addon above, and the canonical on-disk form shifted once (the change is value-preserving; for example, integer digit separators are dropped and markdown bodies are reformatted). Re-normalize an existing repo once; see the [v2.0.0 release notes](https://github.com/JarvusInnovations/gitsheets/releases) for the exact command.
 

--- a/rust/gitsheets-py/README.md
+++ b/rust/gitsheets-py/README.md
@@ -108,13 +108,44 @@ with gitsheets.transact(git_dir, "add jane", time_seconds, author=("Jane", "jane
 JSON-Schema validation declared in the sheet config runs in-core, identically
 to the Node binding.
 
+## Schema contracts
+
+The full [contracts](https://jarvusinnovations.github.io/gitsheets/contracts/)
+surface ships in this binding (0.2.0+), in its batch-first shape:
+
+- **Write-time enforcement** needs nothing Python-specific — a sheet declaring
+  `implements` rejects non-conforming writes through the shared core,
+  byte-identically to Node, with the violated contract named on each issue.
+- `canonical_contract_hash(document, format=None)` — a contract document's
+  identity: parsed data (a `dict`), or JSON/TOML text with an explicit
+  `format`. Two parties holding the same logical document compute the same
+  hash from either language.
+- `verify_sheet_contract(git_dir, tree_ref, sheet, document, ...)` — consumer-side
+  verification, the module-level equivalent of Node's
+  `openSheet(name, { contract })`:
+
+```python
+report = gitsheets.verify_sheet_contract(
+    git_dir, "HEAD", "meals", contract_doc, mode="verify",
+)
+# {'name': 'gitsheets.io/meals/v1', 'rung': 'declared', 'conforming': True,
+#  'issues': [], 'tree': '9c41...'}
+```
+
+Modes: `'verify'` (declared-identity fast path, falling back to structural
+record validation — the default), `'declared'` (fast path only, never reads
+records), `'structural'` (duck-typing any sheet, contract-aware or not).
+A failed verification raises `ContractError` (code `contract_unsatisfied`)
+carrying per-record issues.
+
 ## What 0.x is (and isn't)
 
 The 0.x releases are honestly scoped as a **transactional writer with
 parity-proven reads**: `transact`/`Transaction` (`open_sheet`, `upsert`,
 `delete`, `clear`, `will_change`), attachments
 (`set_attachment(s)`/`get_attachment(s)`/`delete_attachment(s)`), reads
-through opened sheets, and validation.
+through opened sheets, validation, and schema contracts (enforcement,
+identity, and consumer verification — above).
 
 Known gaps, tracked in
 [#240](https://github.com/JarvusInnovations/gitsheets/issues/240) and stated

--- a/rust/gitsheets-py/pyproject.toml
+++ b/rust/gitsheets-py/pyproject.toml
@@ -18,6 +18,8 @@ dynamic = ["version"]
 
 [project.urls]
 Repository = "https://github.com/JarvusInnovations/gitsheets"
+Documentation = "https://jarvusinnovations.github.io/gitsheets/"
+Changelog = "https://github.com/JarvusInnovations/gitsheets/releases"
 
 [project.optional-dependencies]
 # The consumer-validator hook is validator-agnostic (any callable / Pydantic


### PR DESCRIPTION
README follow-through after the contracts releases (v2.5.0/v2.6.0 npm, 0.2.0 PyPI):

- **Root README** — new "Sheets as checked interfaces" section linking the contracts guide; the Python section's stale "PyPI publication is on the roadmap" replaced with `pip install gitsheets` + PyPI link; npm package links added for `gitsheets` and `gitsheets-axi`.
- **npm package README** (`packages/gitsheets`) — contracts paragraph (implements/enforcement, `openSheet({contract})`, the CLI group) + PyPI cross-link.
- **PyPI README** (`rust/gitsheets-py`) — a Schema contracts section documenting the 0.2.0 surface with a `verify_sheet_contract` example, and the "What 0.x is" scope updated to include contracts.
- **pyproject `[project.urls]`** — Documentation + Changelog sidebar links (take effect on the next `py-v*` release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCxogamrSUZ7etFGsnoD1